### PR TITLE
CI(vm): remove the wasm32 testing target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         special_features: ["", "lambdaworks-felt"]
-        target: [ test, test-no_std, test-wasm ]
+        target: [ test, test-no_std ]
         # TODO: features
     name: Run tests
     runs-on: ubuntu-22.04
@@ -217,7 +217,7 @@ jobs:
     - name: Install testing tools
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-nextest,cargo-llvm-cov,wasm-pack
+        tool: cargo-nextest,cargo-llvm-cov
     - name: Run
       run: |
         # FIXME: we need to update the Makefile to do this correctly
@@ -228,14 +228,9 @@ jobs:
         'test-no_std')
           cargo llvm-cov nextest --lcov --output-path lcov-${{ matrix.target }}.info --workspace --no-default-features --features "${{ matrix.special_features }}"
           ;;
-        'test-wasm')
-          # NOTE: release mode is needed to avoid "too many locals" error
-          wasm-pack test --release --node vm --no-default-features --features "${{ matrix.special_features }}"
-          ;;
         esac
 
     - name: Save coverage
-      if: matrix.target != 'test-wasm'
       uses: actions/cache/save@v3
       with:
         path: lcov-${{ matrix.target }}.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* remove the wasm32 testing target
+
 #### [0.8.1] - 2023-6-29
 
 * chore: change mentions of *cairo-rs-py* to *cairo-vm-py* [#1296](https://github.com/lambdaclass/cairo-vm/pull/1296)
@@ -41,7 +43,6 @@
   * Remove argument `run_resources: &mut RunResources` from `CairoRunner::run_until_pc` & `CairoRunner::run_from_entrypoint`
 
 * build: remove unused implicit features from cairo-vm [#1266](https://github.com/lambdaclass/cairo-vm/pull/1266)
-
 
 #### [0.6.1] - 2023-6-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,6 @@ dependencies = [
  "sha3",
  "starknet-crypto",
  "thiserror-no-std",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -810,16 +809,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2342,12 +2331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,18 +2842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,30 +2869,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
-dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ bitvec = { version = "1", default-features = false, features = ["alloc"] }
 cairo-lang-starknet = { version = "2.0.0-rc6", default-features = false }
 cairo-lang-casm = { version = "2.0.0-rc6", default-features = false }
 
-# TODO: check these dependencies for wasm compatibility
 ark-ff = { version = "0.4.0-alpha.7", default-features = false }
 ark-std = { version = "0.3.0", default-features = false }
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ cargo-deps:
 	cargo install --version 1.14.0 hyperfine
 	cargo install --version 0.9.49 cargo-nextest
 	cargo install --version 0.5.9 cargo-llvm-cov
-	cargo install --version 0.11.0 wasm-pack
 
 deps: cargo-deps build-cairo-1-compiler
 	pyenv install  -s pypy3.9-7.3.9
@@ -170,9 +169,6 @@ test: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED
 	cargo llvm-cov nextest --no-report --workspace --features "test_utils, cairo-1-hints"
 test-no_std: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
 	cargo llvm-cov nextest --no-report --workspace --features test_utils --no-default-features
-test-wasm: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
-	# NOTE: release mode is needed to avoid "too many locals" error
-	wasm-pack test --release --node vm --no-default-features
 
 clippy:
 	cargo clippy --workspace --all-features --benches --examples --tests -- -D warnings

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -848,12 +848,8 @@ mod tests {
     #[cfg(all(not(feature = "std"), feature = "alloc"))]
     use alloc::string::ToString;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
     // Tests that the result of adding two zeros is zero.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_zeros() {
         let a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
         let b = FeltBigInt::new(0);
@@ -863,7 +859,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the result of performing add assign with two zeros is zero.
     fn add_assign_zeros() {
         let mut a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
@@ -922,7 +917,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the result of multiplying two zeros is zero.
     fn mul_zeros() {
         let a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
@@ -933,7 +927,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the result of multiplying two zeros with assignment is zero.
     fn mul_assign_zeros() {
         let mut a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
@@ -945,7 +938,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the result of subtracting two zeros is zero.
     fn sub_zeros() {
         let a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
@@ -956,7 +948,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the result of subtracting two zeros with assignment is zero.
     fn sub_assign_zeros() {
         let mut a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);
@@ -968,7 +959,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_usize_felt() {
         let a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(4u32);
         let b = FeltBigInt::new(2u32);
@@ -978,7 +968,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the negative of zero is zero
     fn negate_zero() {
         let a = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::new(0);

--- a/felt/src/lib_bigint_felt.rs
+++ b/felt/src/lib_bigint_felt.rs
@@ -1003,7 +1003,6 @@ mod test {
 
     proptest! {
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly generated
         // each time tests are run, that a new felt doesn't fall outside the range [0, p].
         // In this and some of the following tests, The value of {x} can be either [0] or a
@@ -1016,7 +1015,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_be_bytes(ref x in any::<Felt252>()) {
             let bytes = x.to_be_bytes();
             let y = &Felt252::from_bytes_be(&bytes);
@@ -1024,7 +1022,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_le_bytes(ref x in any::<Felt252>()) {
             let mut bytes = x.to_le_bytes();
             // Convert to big endian for test
@@ -1034,7 +1031,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_le_digits(ref x in any::<Felt252>()) {
             let digits: [u64; 4] = x.to_le_digits();
             let mut bytes: Vec<_> = digits
@@ -1048,7 +1044,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_u128_ok(x in any::<u128>()) {
             let y = Felt252::from(x);
             let y = y.to_u128();
@@ -1056,7 +1051,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_u128_out_of_range(x in nonzero_felt252()) {
             let y = x + Felt252::from(u128::MAX);
             let y = y.to_u128();
@@ -1064,7 +1058,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly
         // generated each time tests are run, that a felt created using Felt252::from_bytes_be doesn't
         // fall outside the range [0, p].
@@ -1077,7 +1070,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly generated each time
         // tests are run, that the negative of a felt doesn't fall outside the range [0, p].
         fn neg_in_range(x in any::<Felt252>()) {
@@ -1094,7 +1086,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated
         // each time tests are run, that a subtraction between two felts {x} and {y} and doesn't fall
         // outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
@@ -1112,7 +1103,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated
         // each time tests are run, that a subtraction with assignment between two felts {x} and {y}
         // and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
@@ -1130,7 +1120,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly
         // generated each time tests are run, that a multiplication between two felts {x}
         // and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y}
@@ -1147,7 +1136,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 pairs of {x} and {y} values that
         // are randomly generated each time tests are run, that a multiplication with
         // assignment between two felts {x} and {y} and doesn't fall outside the range [0, p].
@@ -1161,7 +1149,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 pairs of {x} and {y} values that are
         // randomly generated each time tests are run, that the result of the division of
         // {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result
@@ -1178,7 +1165,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly generated
         // each time tests are run, that performing a bit shift to the left by {shift_amount}
         // of bits (between 0 and 999) returns a result that is inside of the range [0, p].
@@ -1193,7 +1179,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly
         // generated each time tests are run, that performing a bit shift to the right
         // by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
@@ -1204,7 +1189,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly generated
         // each time tests are run, that performing a bit shift to the right by {shift_amount}
         // of bits (between 0 and 999), with assignment, returns a result that is inside of the range [0, p].
@@ -1217,7 +1201,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitAnd
         // operation between them returns a result that is inside of the range [0, p].
@@ -1229,7 +1212,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitOr
         // operation between them returns a result that is inside of the range [0, p].
@@ -1240,7 +1222,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitXor
         // operation between them returns a result that is inside of the range [0, p].
@@ -1251,7 +1232,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 values {x} that are randomly
         // generated each time tests are run, that raising {x} to the {y}th power
         // returns a result that is inside of the range [0, p].
@@ -1269,7 +1249,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 values {x} that are randomly
         // generated each time tests are run, that raising {x} to the {y}th power
         // returns a result that is inside of the range [0, p].
@@ -1287,7 +1266,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a Sum operation
         // between them returns a result that is inside of the range [0, p].
@@ -1300,7 +1278,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property test to check that the remainder of a division between 100 pairs of
         // values {x} and {y},generated at random each time tests are run, falls in the
         // range [0, p]. x and y can either take the value of 0 or a large integer.
@@ -1320,7 +1297,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 Felt252s {x} generated at
         // random each time tests are run, that converting them into the u64 type
         // returns a result that is inside of the range [0, p].
@@ -1332,7 +1308,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn from_i64_and_to_i64_primitive(x in any::<u32>()) {
             let x: i64 = x as i64;
             let x_felt:Felt252 = Felt252::from_i64(x).unwrap();
@@ -1349,7 +1324,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property test to check that is_multiple_of(x, y) works. Since we're operating in a prime field, is_multiple_of
         // will always be true
         fn is_multiple_of_doesnt_panic(x in any::<Felt252>(), y in any::<Felt252>()) {
@@ -1560,7 +1534,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of adding two zeroes is zero
     fn sum_zeros_in_range() {
         let x = Felt252::new(0);
@@ -1570,7 +1543,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of multiplying two zeroes is zero
     fn mul_zeros_in_range() {
         let x = Felt252::new(0);
@@ -1580,7 +1552,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of performing a bit and operation between zeroes is zero
     fn bit_and_zeros_in_range() {
         let x = Felt252::new(0);
@@ -1590,7 +1561,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of perfforming a bit or operation between zeroes is zero
     fn bit_or_zeros_in_range() {
         let x = Felt252::new(0);
@@ -1600,7 +1570,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of perfforming a bit xor operation between zeroes is zero
     fn bit_xor_zeros_in_range() {
         let x = Felt252::new(0);
@@ -1610,7 +1579,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the maximum value a Felt252 can take is equal to (prime - 1)
     fn upper_bound() {
         let prime = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -1620,7 +1588,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the minimum value a Felt252 can take is equal to zero.
     fn lower_bound() {
         let zero = BigUint::zero();

--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -978,7 +978,6 @@ mod test {
 
     proptest! {
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly generated
         // each time tests are run, that a new felt doesn't fall outside the range [0, p].
         // In this and some of the following tests, The value of {x} can be either [0] or a
@@ -991,7 +990,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_be_bytes(ref x in any::<Felt252>()) {
             let bytes = x.to_be_bytes();
             let y = &Felt252::from_bytes_be(&bytes);
@@ -999,7 +997,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_le_bytes(ref x in any::<Felt252>()) {
             let mut bytes = x.to_le_bytes();
             // Convert to big endian for test
@@ -1009,7 +1006,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_le_digits(ref x in any::<Felt252>()) {
             let digits: [u64; 4] = x.to_le_digits();
             let mut bytes: Vec<_> = digits
@@ -1023,7 +1019,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_u128_ok(x in any::<u128>()) {
             let y = Felt252::from(x);
             let y = y.to_u128();
@@ -1031,7 +1026,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_u128_out_of_range(x in nonzero_felt252()) {
             let y = x + Felt252::from(u128::MAX);
             let y = y.to_u128();
@@ -1039,7 +1033,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly
         // generated each time tests are run, that a felt created using Felt252::from_bytes_be doesn't
         // fall outside the range [0, p].
@@ -1052,7 +1045,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 felt values that are randomly generated each time
         // tests are run, that the negative of a felt doesn't fall outside the range [0, p].
         fn neg_in_range(x in any::<Felt252>()) {
@@ -1069,7 +1061,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated
         // each time tests are run, that a subtraction between two felts {x} and {y} and doesn't fall
         // outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
@@ -1087,7 +1078,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated
         // each time tests are run, that a subtraction with assignment between two felts {x} and {y}
         // and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
@@ -1105,7 +1095,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly
         // generated each time tests are run, that a multiplication between two felts {x}
         // and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y}
@@ -1122,7 +1111,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 pairs of {x} and {y} values that
         // are randomly generated each time tests are run, that a multiplication with
         // assignment between two felts {x} and {y} and doesn't fall outside the range [0, p].
@@ -1136,7 +1124,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 pairs of {x} and {y} values that are
         // randomly generated each time tests are run, that the result of the division of
         // {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result
@@ -1153,7 +1140,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly generated
         // each time tests are run, that performing a bit shift to the left by {shift_amount}
         // of bits (between 0 and 999) returns a result that is inside of the range [0, p].
@@ -1168,7 +1154,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn shift_left_equals_old_shl(value in any::<Felt252>(), shift_amount in 0..1000_u32) {
             let expected = (value.to_biguint() << shift_amount).mod_floor(&Felt252::prime());
 
@@ -1180,7 +1165,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly
         // generated each time tests are run, that performing a bit shift to the right
         // by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
@@ -1191,7 +1175,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 {value}s that are randomly generated
         // each time tests are run, that performing a bit shift to the right by {shift_amount}
         // of bits (between 0 and 999), with assignment, returns a result that is inside of the range [0, p].
@@ -1204,7 +1187,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn shift_right_equals_old_shr(value in any::<Felt252>(), shift_amount in 0..1000_u32) {
             let expected = (value.to_biguint() >> shift_amount).mod_floor(&Felt252::prime());
 
@@ -1216,7 +1198,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitAnd
         // operation between them returns a result that is inside of the range [0, p].
@@ -1228,7 +1209,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitOr
         // operation between them returns a result that is inside of the range [0, p].
@@ -1239,7 +1219,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a BitXor
         // operation between them returns a result that is inside of the range [0, p].
@@ -1250,7 +1229,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 values {x} that are randomly
         // generated each time tests are run, that raising {x} to the {y}th power
         // returns a result that is inside of the range [0, p].
@@ -1268,7 +1246,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property-based test that ensures, for 100 values {x} that are randomly
         // generated each time tests are run, that raising {x} to the {y}th power
         // returns a result that is inside of the range [0, p].
@@ -1286,7 +1263,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 pairs of values {x} and {y}
         // generated at random each time tests are run, that performing a Sum operation
         // between them returns a result that is inside of the range [0, p].
@@ -1299,7 +1275,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property test to check that the remainder of a division between 100 pairs of
         // values {x} and {y},generated at random each time tests are run, falls in the
         // range [0, p]. x and y can either take the value of 0 or a large integer.
@@ -1319,7 +1294,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property based test that ensures, for 100 Felt252s {x} generated at
         // random each time tests are run, that converting them into the u64 type
         // returns a result that is inside of the range [0, p].
@@ -1331,7 +1305,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn from_i64_and_to_i64_primitive(x in any::<i64>()) {
             let x = x.checked_abs().unwrap_or(0);
             let x_felt: Felt252 = Felt252::from_i64(x).unwrap();
@@ -1348,7 +1321,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         // Property test to check that is_multiple_of(x, y) works. Since we're operating in a prime field, is_multiple_of
         // will always be true
         fn is_multiple_of_doesnt_panic(x in any::<Felt252>(), y in any::<Felt252>()) {
@@ -1574,7 +1546,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of adding two zeroes is zero
     fn sum_zeros_in_range() {
         let x = Felt252::zero();
@@ -1584,7 +1555,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of multiplying two zeroes is zero
     fn mul_zeros_in_range() {
         let x = Felt252::zero();
@@ -1594,7 +1564,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of performing a bit and operation between zeroes is zero
     fn bit_and_zeros_in_range() {
         let x = Felt252::zero();
@@ -1604,7 +1573,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of perfforming a bit or operation between zeroes is zero
     fn bit_or_zeros_in_range() {
         let x = Felt252::zero();
@@ -1614,7 +1582,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Checks that the result of perfforming a bit xor operation between zeroes is zero
     fn bit_xor_zeros_in_range() {
         let x = Felt252::zero();
@@ -1624,7 +1591,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the maximum value a Felt252 can take is equal to (prime - 1)
     fn upper_bound() {
         let prime = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -1634,7 +1600,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     // Tests that the minimum value a Felt252 can take is equal to zero.
     fn lower_bound() {
         let zero = BigUint::zero();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -65,7 +65,6 @@ bitvec = { workspace = true }
 cairo-lang-starknet = { workspace = true, optional = true }
 cairo-lang-casm = { workspace = true, optional = true }
 
-# TODO: check these dependencies for wasm compatibility
 ark-ff = { workspace = true, optional = true }
 ark-std = { workspace = true, optional = true }
 
@@ -73,11 +72,6 @@ ark-std = { workspace = true, optional = true }
 assert_matches = "1.5.0"
 rstest = { version = "0.17.0", default-features = false }
 num-prime = { version = "0.4.3", features = ["big-int"] }
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.34"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 iai-callgrind = "0.3.1"
 rusty-hook = "0.11"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -137,9 +137,6 @@ mod tests {
     use bincode::enc::write::SliceWriter;
     use felt::Felt252;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     fn run_test_program(
         program_content: &[u8],
         hint_processor: &mut dyn HintProcessor,
@@ -159,7 +156,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_run_custom_entry_point() {
         let program = Program::from_bytes(
             include_bytes!("../../cairo_programs/not_main.json"),
@@ -181,7 +177,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_run_with_no_data_program() {
         // a compiled program with no `data` key.
         // it should fail when the program is loaded.
@@ -193,7 +188,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_run_with_no_main_program() {
         // a compiled program with no main scope
         // it should fail when trying to run initialize_main_entrypoint.
@@ -205,7 +199,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_run_with_invalid_memory() {
         // the program invalid_memory.json has an invalid memory cell and errors when trying to
         // decode the instruction.
@@ -217,7 +210,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_output_program() {
         let program_content = include_bytes!("../../cairo_programs/bitwise_output.json");
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -230,7 +222,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_binary_trace_file() {
         let program_content = include_bytes!("../../cairo_programs/struct.json");
         let expected_encoded_trace =
@@ -255,7 +246,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_binary_memory_file() {
         let program_content = include_bytes!("../../cairo_programs/struct.json");
         let expected_encoded_memory =
@@ -279,7 +269,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_with_no_trace() {
         let program = Program::from_bytes(
             include_bytes!("../../cairo_programs/struct.json"),

--- a/vm/src/hint_processor/builtin_hint_processor/bigint.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bigint.rs
@@ -108,16 +108,12 @@ mod test {
     use assert_matches::assert_matches;
     use num_bigint::BigInt;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     /// Input:
     /// x = UnreducedBigInt5(0x38a23ca66202c8c2a72277, 0x6730e765376ff17ea8385, 0xca1ad489ab60ea581e6c1, 0, 0);
     /// y = UnreducedBigInt3(0x20a4b46d3c5e24cda81f22, 0x967bf895824330d4273d0, 0x541e10c21560da25ada4c);
     /// p = BigInt3(0x8a03bbfd25e8cd0364141, 0x3ffffffffffaeabb739abd, 0xfffffffffffffffffffff);
     /// expected: value = res = 109567829260688255124154626727441144629993228404337546799996747905569082729709 (py int)
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_bigint_pack_div_mod_hint() {
         // Prepare the VM context:
         let ids_data = non_continuous_ids_data![
@@ -174,7 +170,6 @@ mod test {
     /// value = 36002209591245282109880156842267569109802494162594623391338581162816748840003
     /// ids.flag = 1
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_bigint_safe_div_hint() {
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.insert_value(

--- a/vm/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
@@ -131,11 +131,7 @@ pub fn blake2s_compress(
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_a() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -155,7 +151,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_b() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -175,7 +170,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_c() {
         //Hashing "Hello World"
         let h: [u32; 8] = [
@@ -198,7 +192,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_d() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -221,7 +214,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_e() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -244,7 +236,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_f() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -267,7 +258,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_compress_test_g() {
         let h: [u32; 8] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,

--- a/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -321,11 +321,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_blake2s_output_offset_zero() {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
@@ -345,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_blake2s_output_empty_segment() {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
@@ -367,7 +362,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_blake2s_output_not_relocatable() {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
@@ -387,7 +381,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_blake2s_output_input_bigger_than_u32() {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
@@ -416,7 +409,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_blake2s_output_input_relocatable() {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
@@ -437,7 +429,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_blake2s_valid() {
         let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
@@ -484,7 +475,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_blake2s_invalid_segment_taken() {
         let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
@@ -506,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_blake2s_invalid_no_ids() {
         let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
@@ -521,7 +510,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_valid_zero() {
         let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
         //Create vm
@@ -554,7 +542,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_valid_non_zero() {
         let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
         //Create vm
@@ -587,7 +574,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_bigend_valid_zero() {
         let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])";
         //Create vm
@@ -620,7 +606,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_bigend_valid_non_zero() {
         let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])";
         //Create vm
@@ -653,7 +638,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn example_blake2s_compress_n_bytes_over_u32() {
         //Create vm
         let mut vm = vm!();
@@ -667,7 +651,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn example_blake2s_empty_input() {
         //Create vm
         let mut vm = vm!();

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -851,11 +851,7 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_alloc_hint_empty_memory() {
         let hint_code = "memory[ap] = segments.add()";
         let mut vm = vm!();
@@ -869,7 +865,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_alloc_hint_preset_memory() {
         let hint_code = "memory[ap] = segments.add()";
         let mut vm = vm!();
@@ -885,7 +880,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_alloc_hint_ap_is_not_empty() {
         let hint_code = "memory[ap] = segments.add()";
         let mut vm = vm!();
@@ -906,7 +900,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unknown_hint() {
         let hint_code = "random_invalid_code";
         let mut vm = vm!();
@@ -917,7 +910,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memcpy_enter_scope_valid() {
         let hint_code = "vm_enter_scope({'n': ids.len})";
         let mut vm = vm!();
@@ -932,7 +924,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memcpy_enter_scope_invalid() {
         let hint_code = "vm_enter_scope({'n': ids.len})";
         let mut vm = vm!();
@@ -953,7 +944,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memcpy_continue_copying_valid() {
         let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -971,7 +961,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memcpy_continue_copying_variable_not_in_scope_error() {
         let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -990,7 +979,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memcpy_continue_copying_insert_error() {
         let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -1017,7 +1005,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn exit_scope_valid() {
         let hint_code = "vm_exit_scope()";
         let mut vm = vm!();
@@ -1031,7 +1018,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn exit_scope_invalid() {
         let hint_code = "vm_exit_scope()";
         let mut vm = vm!();
@@ -1047,7 +1033,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_enter_scope() {
         let hint_code = "vm_enter_scope()";
         //Create vm
@@ -1065,7 +1050,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_valid() {
         let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1088,7 +1072,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_max_size() {
         let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1113,7 +1096,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_invalid_input_length() {
         let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1135,7 +1117,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_invalid_word_size() {
         let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1161,7 +1142,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_finalize_valid() {
         let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1182,7 +1162,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_finalize_nones_in_range() {
         let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1205,7 +1184,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsafe_keccak_finalize_expected_integer_at_range() {
         let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = vm!();
@@ -1237,7 +1215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_hint_add_same_hint_twice() {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let hint_func = Rc::new(HintFunc(Box::new(enter_scope)));

--- a/vm/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -384,11 +384,7 @@ mod tests {
     use assert_matches::assert_matches;
     use rstest::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[rstest]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[case(0, 0)]
     #[case(1, 0)]
     #[case(7, 0)]
@@ -407,7 +403,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn keccak_write_args_valid_test() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
@@ -425,7 +420,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn keccak_write_args_write_error() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
@@ -439,7 +433,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compare_bytes_in_word_nondet_valid() {
         let hint_code =
             "memory[ap] = to_felt_or_relocatable(ids.n_bytes >= ids.KECCAK_FULL_RATE_IN_BYTES)";
@@ -466,7 +459,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compare_keccak_full_rate_in_bytes_nondet_valid() {
         let hint_code =
             "memory[ap] = to_felt_or_relocatable(ids.n_bytes >= ids.KECCAK_FULL_RATE_IN_BYTES)";
@@ -495,7 +487,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn block_permutation_valid_test() {
         let hint_code =
             "memory[ap] = to_felt_or_relocatable(ids.n_bytes >= ids.KECCAK_FULL_RATE_IN_BYTES)";

--- a/vm/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -272,11 +272,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_new_with_initial_dict_empty() {
         let hint_code = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_dict(segments, initial_dict)\ndel initial_dict";
         let mut vm = vm!();
@@ -308,7 +304,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_new_with_no_initial_dict() {
         let hint_code = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_dict(segments, initial_dict)\ndel initial_dict";
         let mut vm = vm!();
@@ -320,7 +315,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_new_ap_is_taken() {
         let hint_code = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_dict(segments, initial_dict)\ndel initial_dict";
         let mut vm = vm!();
@@ -341,7 +335,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_read_valid() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]";
         let mut vm = vm!();
@@ -369,7 +362,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_read_invalid_key() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]";
         let mut vm = vm!();
@@ -387,7 +379,6 @@ mod tests {
         );
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_read_no_tracker() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]";
         let mut vm = vm!();
@@ -408,7 +399,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_default_dict_new_valid() {
         let hint_code = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)";
         let mut vm = vm!();
@@ -440,7 +430,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_default_dict_new_no_default_value() {
         let hint_code = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)";
         let mut vm = vm!();
@@ -454,7 +443,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_write_default_valid_empty_dict() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.dict_ptr.prev_value = dict_tracker.data[ids.key]\ndict_tracker.data[ids.key] = ids.new_value";
         let mut vm = vm!();
@@ -482,7 +470,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_write_default_valid_overwrite_value() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.dict_ptr.prev_value = dict_tracker.data[ids.key]\ndict_tracker.data[ids.key] = ids.new_value";
         let mut vm = vm!();
@@ -510,7 +497,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_write_simple_valid_overwrite_value() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.dict_ptr.prev_value = dict_tracker.data[ids.key]\ndict_tracker.data[ids.key] = ids.new_value";
         let mut vm = vm!();
@@ -539,7 +525,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_write_simple_valid_cant_write_new_key() {
         let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.dict_ptr.prev_value = dict_tracker.data[ids.key]\ndict_tracker.data[ids.key] = ids.new_value";
         let mut vm = vm!();
@@ -564,7 +549,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_simple_valid() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -589,7 +573,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_simple_valid_no_change() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -614,7 +597,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_simple_invalid_wrong_prev_key() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -639,7 +621,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_simple_invalid_wrong_key() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -663,7 +644,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_default_valid() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -688,7 +668,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_default_valid_no_change() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -713,7 +692,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_default_invalid_wrong_prev_key() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -738,7 +716,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_default_invalid_wrong_key() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -763,7 +740,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_update_default_valid_no_key_prev_value_equals_default() {
         let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
@@ -788,7 +764,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_copy_dict_valid_empty_dict() {
         let hint_code = "# Prepare arguments for dict_new. In particular, the same dictionary values should be copied\n# to the new (squashed) dictionary.\nvm_enter_scope({\n    # Make __dict_manager accessible.\n    '__dict_manager': __dict_manager,\n    # Create a copy of the dict, in case it changes in the future.\n    'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),\n})";
         let mut vm = vm!();
@@ -817,7 +792,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_copy_dict_valid_non_empty_dict() {
         let hint_code = "# Prepare arguments for dict_new. In particular, the same dictionary values should be copied\n# to the new (squashed) dictionary.\nvm_enter_scope({\n    # Make __dict_manager accessible.\n    '__dict_manager': __dict_manager,\n    # Create a copy of the dict, in case it changes in the future.\n    'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),\n})";
         let mut vm = vm!();
@@ -849,7 +823,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_copy_dict_invalid_no_dict() {
         let hint_code = "# Prepare arguments for dict_new. In particular, the same dictionary values should be copied\n# to the new (squashed) dictionary.\nvm_enter_scope({\n    # Make __dict_manager accessible.\n    '__dict_manager': __dict_manager,\n    # Create a copy of the dict, in case it changes in the future.\n    'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),\n})";
         let mut vm = vm!();
@@ -870,7 +843,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_update_ptr_no_tracker() {
         let hint_code = "# Update the DictTracker's current_ptr to point to the end of the squashed dict.\n__dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \\\n    ids.squashed_dict_end.address_";
         let mut vm = vm!();
@@ -891,7 +863,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_update_ptr_valid() {
         let hint_code = "# Update the DictTracker's current_ptr to point to the end of the squashed dict.\n__dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \\\n    ids.squashed_dict_end.address_";
         let mut vm = vm!();
@@ -911,7 +882,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_squash_update_ptr_mismatched_dict_ptr() {
         let hint_code = "# Update the DictTracker's current_ptr to point to the end of the squashed dict.\n__dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \\\n    ids.squashed_dict_end.address_";
         let mut vm = vm!();
@@ -931,7 +901,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_dict_write_valid_relocatable_new_value() {
         let mut vm = vm!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -208,18 +208,13 @@ mod tests {
     use crate::{relocatable, utils::test_utils::*, vm::vm_core::VirtualMachine};
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn create_dict_manager() {
         let dict_manager = DictManager::new();
         assert_eq!(dict_manager.trackers, HashMap::new());
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn create_dict_tracker_empty() {
         let dict_tracker = DictTracker::new_empty(relocatable!(1, 0));
         assert_eq!(
@@ -230,7 +225,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn create_dict_tracker_default() {
         let dict_tracker =
             DictTracker::new_default_dict(relocatable!(1, 0), &MaybeRelocatable::from(5), None);
@@ -245,7 +239,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_dict_empty() {
         let mut vm = vm!();
         let mut dict_manager = DictManager::new();
@@ -260,7 +253,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_dict_default() {
         let mut dict_manager = DictManager::new();
         let mut vm = vm!();
@@ -279,7 +271,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_dict_with_initial_dict() {
         let mut dict_manager = DictManager::new();
         let mut vm = vm!();
@@ -299,7 +290,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_default_dict_with_initial_dict() {
         let mut dict_manager = DictManager::new();
         let mut initial_dict = HashMap::<MaybeRelocatable, MaybeRelocatable>::new();
@@ -324,7 +314,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_dict_empty_same_segment() {
         let mut dict_manager = DictManager::new();
         dict_manager
@@ -338,7 +327,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_new_default_dict_empty_same_segment() {
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(
@@ -353,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dictionary_get_insert_simple() {
         let mut dictionary = Dictionary::SimpleDictionary(HashMap::new());
         dictionary.insert(&MaybeRelocatable::from(1), &MaybeRelocatable::from(2));
@@ -365,7 +352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dictionary_get_insert_default() {
         let mut dictionary = Dictionary::DefaultDictionary {
             dict: HashMap::new(),

--- a/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
@@ -130,11 +130,7 @@ mod tests {
         types::exec_scope::ExecutionScopes,
     };
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_recover_divmod_n_packed_ok() {
         let mut vm = vm!();
         let mut exec_scopes = ExecutionScopes::new();
@@ -172,7 +168,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_recover_sub_a_b_ok() {
         let mut vm = vm!();
         let mut exec_scopes = ExecutionScopes::new();
@@ -206,7 +201,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_recover_product_mod_ok() {
         let mut vm = vm!();
         let mut exec_scopes = ExecutionScopes::new();
@@ -249,7 +243,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_recover_product_div_m_ok() {
         let mut vm = vm!();
         let mut exec_scopes = ExecutionScopes::new();

--- a/vm/src/hint_processor/builtin_hint_processor/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/ec_utils.rs
@@ -229,9 +229,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
     fn test_is_quad_residue_less_than_2() {
         assert!(is_quad_residue(&BigUint::one()));
@@ -311,7 +308,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_op_random_ec_point_hint() {
         let hint_code = hint_code::RANDOM_EC_POINT;
         let mut vm = vm!();
@@ -387,7 +383,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_chained_ec_op_random_ec_point_hint() {
         let hint_code = hint_code::CHAINED_EC_OP_RANDOM_EC_POINT;
         let mut vm = vm!();
@@ -513,7 +508,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_recover_y_hint() {
         let hint_code = hint_code::RECOVER_Y;
         let mut vm = vm!();

--- a/vm/src/hint_processor/builtin_hint_processor/field_arithmetic.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/field_arithmetic.rs
@@ -280,11 +280,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u384_get_square_ok_goldilocks_prime() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -338,7 +334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u384_get_square_no_successes() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -375,7 +370,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u384_get_square_ok_success_gx() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -429,7 +423,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u256_get_square_ok_goldilocks_prime() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -475,7 +468,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u256_get_square_no_successes() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -509,7 +501,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_u256_get_square_ok_success_gx() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -555,7 +546,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint384_div_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -591,7 +581,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint384_div_b_is_zero() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -622,7 +611,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint384_div_inconsistent_memory() {
         let mut vm = vm_with_range_check!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -147,9 +147,6 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     fn init_vm_ids_data(
         values_to_override: HashMap<String, MaybeRelocatable>,
     ) -> (VirtualMachine, HashMap<String, HintReference>) {
@@ -218,7 +215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn element_found_by_search() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         assert_matches!(run_hint!(vm, ids_data, hint_code::FIND_ELEMENT), Ok(()));
@@ -226,7 +222,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn element_found_by_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         let mut exec_scopes = scope![("find_element_index", Felt252::one())];
@@ -238,7 +233,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn element_not_found_search() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "key".to_string(),
@@ -251,7 +245,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn element_not_found_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         let mut exec_scopes = scope![("find_element_index", Felt252::new(2))];
@@ -262,7 +255,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_failed_ids_get_from_mem() {
         let mut vm = vm!();
         vm.run_context.fp = 5;
@@ -274,7 +266,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_not_int_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
@@ -287,7 +278,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_zero_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
@@ -300,7 +290,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_negative_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
@@ -313,7 +302,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_not_int_n_elms() {
         let relocatable = MaybeRelocatable::from((1, 2));
         let (mut vm, ids_data) =
@@ -325,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_negative_n_elms() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "n_elms".to_string(),
@@ -338,14 +325,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_empty_scope() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         assert_matches!(run_hint!(vm, ids_data, hint_code::FIND_ELEMENT), Ok(()));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         let mut exec_scopes = scope![("find_element_max_size", Felt252::one())];
@@ -356,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn find_elm_key_not_int() {
         let relocatable = MaybeRelocatable::from((1, 4));
         let (mut vm, ids_data) =
@@ -368,7 +352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         assert_matches!(
@@ -380,7 +363,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_no_matches() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "key".to_string(),
@@ -394,7 +376,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_not_int_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
@@ -407,7 +388,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_zero_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
@@ -420,7 +400,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_not_int_n_elms() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "n_elms".to_string(),
@@ -433,7 +412,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_empty_scope() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         assert_matches!(
@@ -443,7 +421,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn search_sorted_lower_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
         let mut exec_scopes = scope![("find_element_max_size", Felt252::one())];

--- a/vm/src/hint_processor/builtin_hint_processor/garaga.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/garaga.rs
@@ -35,9 +35,6 @@ mod tests {
     use felt::Felt252;
     use num_traits::{Bounded, One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     use super::*;
 
     fn run_hint(x: Felt252) -> Result<Felt252, HintError> {
@@ -56,7 +53,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_simple() {
         let bit_length_result = run_hint(Felt252::new(7));
         assert!(bit_length_result.is_ok());
@@ -64,7 +60,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_in_range() {
         for i in 0..252_usize {
             let x: Felt252 = Felt252::one() << i;
@@ -76,7 +71,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_wraparound() {
         let x = Felt252::max_value() + Felt252::one();
         let bit_length_result = run_hint(x);

--- a/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -148,11 +148,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_var_name_immediate_value() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];
@@ -167,7 +163,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_relocatable_from_var_name_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];
@@ -181,7 +176,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_relocatable_from_var_name_invalid() {
         let mut vm = vm!();
         vm.segments.memory = Memory::new();
@@ -195,7 +189,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_var_name_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];
@@ -209,7 +202,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_var_name_invalid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 0)];
@@ -223,7 +215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_relocatable_from_var_name_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];
@@ -237,7 +228,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_relocatable_from_var_name_invalid() {
         let mut vm = vm!();
         vm.segments.memory = Memory::new();
@@ -251,7 +241,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_from_var_name_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 1)];
@@ -265,7 +254,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_from_var_name_invalid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -812,14 +812,9 @@ mod tests {
     use felt::felt_str;
     use num_traits::Zero;
 
-    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_false() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
@@ -837,7 +832,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_true() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
@@ -855,7 +849,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     //This test contemplates the case when the number itself is negative, but it is within the range (-prime, -range_check_bound)
     //Making the comparison return 1 (true)
     fn run_is_nn_hint_true_border_case() {
@@ -880,7 +873,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_no_range_check_builtin() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm!();
@@ -900,7 +892,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_incorrect_ids() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
@@ -916,7 +907,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_cant_get_ids_from_memory() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
@@ -934,7 +924,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_ids_are_relocatable_values() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
@@ -952,7 +941,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_le_felt_valid() {
         let mut constants = HashMap::new();
         constants.insert(
@@ -987,7 +975,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_le_felt_hint_true() {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm_with_range_check!();
@@ -1004,7 +991,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_le_felt_hint_inconsistent_memory() {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm_with_range_check!();
@@ -1025,7 +1011,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_le_felt_hint_incorrect_ids() {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm!();
@@ -1040,7 +1025,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_valid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
@@ -1056,7 +1040,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_invalid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
@@ -1074,7 +1057,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_incorrect_ids() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
@@ -1091,7 +1073,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_a_is_not_integer() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
@@ -1108,7 +1089,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_no_range_check_builtin() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm!();
@@ -1127,7 +1107,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_nn_reference_is_not_in_memory() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
@@ -1143,7 +1122,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_assert_le_felt_invalid() {
         let mut vm = vm_with_range_check!();
         let mut constants = HashMap::new();
@@ -1170,7 +1148,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_assert_le_felt_a_is_not_integer() {
         let mut vm = vm_with_range_check!();
         let mut constants = HashMap::new();
@@ -1196,7 +1173,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_assert_le_felt_b_is_not_integer() {
         let mut vm = vm_with_range_check!();
         let mut constants = HashMap::new();
@@ -1222,7 +1198,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_out_of_range_false() {
         let hint_code =
             "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
@@ -1240,7 +1215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_nn_hint_out_of_range_true() {
         let hint_code =
             "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
@@ -1257,7 +1231,6 @@ mod tests {
         check_memory![vm.segments.memory, ((1, 0), 0)];
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_int_false() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1275,7 +1248,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_int_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1289,7 +1261,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_int_bignum_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1313,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_relocatable_false() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1331,7 +1301,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_relocatable_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1345,7 +1314,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_non_equal_relocatable_diff_index() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1363,7 +1331,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_equal_relocatable_and_integer() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
@@ -1382,7 +1349,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_zero_true() {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
@@ -1398,7 +1364,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_zero_false() {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
@@ -1416,7 +1381,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_zero_incorrect_id() {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
@@ -1434,7 +1398,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_not_zero_expected_integer_error() {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
@@ -1452,7 +1415,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_int_assertion_invalid() {
         let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = vm!();
@@ -1469,7 +1431,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_int_assertion_valid() {
         let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = vm!();
@@ -1483,7 +1444,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_int_valid() {
         let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = vm!();
@@ -1499,7 +1459,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_int_invalid() {
         let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = vm!();
@@ -1522,7 +1481,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_positive_hint_true() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
@@ -1541,7 +1499,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_positive_hint_false() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
@@ -1559,7 +1516,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_positive_hint_outside_valid_range() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
@@ -1586,7 +1542,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_positive_hint_is_positive_not_empty() {
         let hint_code ="from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
         let mut vm = vm_with_range_check!();
@@ -1608,7 +1563,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_sqrt_valid() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)";
         let mut vm = vm!();
@@ -1625,7 +1579,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_sqrt_invalid_negative_number() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)";
         let mut vm = vm!();
@@ -1645,7 +1598,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_sqrt_invalid_mismatched_root() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)";
         let mut vm = vm!();
@@ -1667,7 +1619,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsigned_div_rem_success() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
@@ -1683,7 +1634,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsigned_div_rem_out_of_range() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
@@ -1702,7 +1652,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsigned_div_rem_no_range_check_builtin() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm!();
@@ -1721,7 +1670,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsigned_div_rem_inconsitent_memory() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
@@ -1743,7 +1691,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn unsigned_div_rem_incorrect_ids() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
@@ -1761,7 +1708,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_success() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1777,7 +1723,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_negative_quotient() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1793,7 +1738,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_out_of_range() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1812,7 +1756,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_out_of_range_bound() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1835,7 +1778,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_no_range_check_builtin() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm!();
@@ -1854,7 +1796,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_inconsitent_memory() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1876,7 +1817,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn signed_div_rem_incorrect_ids() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
@@ -1894,7 +1834,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_250_bit_valid() {
         let hint_code = hint_code::ASSERT_250_BITS;
         let constants = HashMap::from([
@@ -1919,7 +1858,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_250_bit_invalid() {
         let hint_code = hint_code::ASSERT_250_BITS;
         let constants = HashMap::from([
@@ -1948,7 +1886,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_250_bits_valid() {
         let hint_code = "ids.is_250 = 1 if ids.addr < 2**250 else 0";
         let mut vm = vm!();
@@ -1965,7 +1902,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_250_bits_invalid() {
         let hint_code = "ids.is_250 = 1 if ids.addr < 2**250 else 0";
         let mut vm = vm!();
@@ -1989,7 +1925,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_addr_bounded_ok() {
         let hint_code = hint_code::IS_ADDR_BOUNDED;
         let mut vm = vm!();
@@ -2027,7 +1962,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_addr_bounded_assert_fail() {
         let hint_code = hint_code::IS_ADDR_BOUNDED;
         let mut vm = vm!();
@@ -2059,7 +1993,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_addr_bounded_missing_const() {
         let hint_code = hint_code::IS_ADDR_BOUNDED;
         let mut vm = vm!();
@@ -2077,7 +2010,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_felt_ok() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
@@ -2106,7 +2038,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_felt_incorrect_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
@@ -2128,7 +2059,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_felt_fails_first_insert() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
@@ -2159,7 +2089,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_felt_fails_second_insert() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
@@ -2190,7 +2119,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_felt_value_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
@@ -2212,7 +2140,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_ok() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2228,7 +2155,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_assert_fails() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2245,7 +2171,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_incorrect_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2263,7 +2188,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_a_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2280,7 +2204,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_b_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2297,7 +2220,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_assert_lt_felt_ok_failed_to_get_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
@@ -2315,7 +2237,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_assert_le_felt_v_0_6_assertion_fail() {
         let mut vm = vm_with_range_check!();
         vm.set_fp(2);
@@ -2331,7 +2252,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_assert_le_felt_v_0_8_assertion_fail() {
         let mut vm = vm_with_range_check!();
         vm.set_fp(2);
@@ -2346,7 +2266,6 @@ mod tests {
         );
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         // Proptest to check is_quad_residue hint function

--- a/vm/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -50,11 +50,8 @@ mod tests {
     use assert_matches::assert_matches;
 
     use felt::Felt252;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_from_var_name_valid() {
         let mut vm = vm!();
         // initialize memory segments
@@ -80,7 +77,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_from_var_name_invalid_expected_integer() {
         let mut vm = vm!();
 

--- a/vm/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -74,11 +74,7 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_enter_scope_valid() {
         let hint_code = "vm_enter_scope({'n': ids.n})";
         let mut vm = vm!();
@@ -91,7 +87,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_enter_scope_invalid() {
         let hint_code = "vm_enter_scope({'n': ids.n})";
         let mut vm = vm!();
@@ -108,7 +103,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_continue_loop_valid_continue_loop_equal_1() {
         let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -126,7 +120,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_continue_loop_valid_continue_loop_equal_5() {
         let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -145,7 +138,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_continue_loop_variable_not_in_scope_error() {
         let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = vm!();
@@ -167,7 +159,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memset_continue_loop_insert_error() {
         let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = vm!();

--- a/vm/src/hint_processor/builtin_hint_processor/poseidon_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/poseidon_utils.rs
@@ -51,11 +51,7 @@ mod tests {
     use crate::{hint_processor::builtin_hint_processor::hint_code, utils::test_utils::*};
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_n_greater_than_10_true() {
         let hint_code = hint_code::NONDET_N_GREATER_THAN_10;
         let mut vm = vm!();
@@ -69,7 +65,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_n_greater_than_10_false() {
         let hint_code = hint_code::NONDET_N_GREATER_THAN_10;
         let mut vm = vm!();
@@ -83,7 +78,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_n_greater_than_2_true() {
         let hint_code = hint_code::NONDET_N_GREATER_THAN_2;
         let mut vm = vm!();
@@ -97,7 +91,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_n_greater_than_2_false() {
         let hint_code = hint_code::NONDET_N_GREATER_THAN_2;
         let mut vm = vm!();

--- a/vm/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -59,11 +59,7 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::One;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_pow_ok() {
         let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = vm_with_range_check!();
@@ -77,7 +73,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_pow_incorrect_ids() {
         let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = vm_with_range_check!();
@@ -94,7 +89,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_pow_incorrect_references() {
         let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = vm_with_range_check!();
@@ -111,7 +105,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_pow_prev_locs_exp_is_not_integer() {
         let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = vm_with_range_check!();
@@ -130,7 +123,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_pow_invalid_memory_insert() {
         let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = vm_with_range_check!();

--- a/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -239,11 +239,7 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::One;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_nondet_bigint3_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = vm_with_range_check!();
@@ -280,7 +276,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_nondet_bigint3_value_not_in_scope() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = vm_with_range_check!();
@@ -296,7 +291,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_nondet_bigint3_split_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = vm_with_range_check!();

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -560,11 +560,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_negate_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\ny = pack(ids.point.y, PRIME) % SECP_P\n# The modulo operation in python always returns a nonnegative number.\nvalue = (-y) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -587,7 +583,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_negate_embedded_secp_p_ok() {
         let hint_code = hint_code::EC_NEGATE_EMBEDDED_SECP;
         let mut vm = vm_with_range_check!();
@@ -613,7 +608,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_doubling_slope_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import ec_double_slope\n\n# Compute the slope.\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\nvalue = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)";
         let mut vm = vm_with_range_check!();
@@ -654,7 +648,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_double_scope_v2_hint_ok() {
         let hint_code = hint_code::EC_DOUBLE_SLOPE_V2;
         let mut vm = vm_with_range_check!();
@@ -696,7 +689,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_doubling_slope_wdivmod_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import div_mod\n\n# Compute the slope.\nx = pack(ids.pt.x, PRIME)\ny = pack(ids.pt.y, PRIME)\nvalue = slope = div_mod(3 * x ** 2, 2 * y, SECP_P)";
         let mut vm = vm_with_range_check!();
@@ -737,7 +729,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_doubling_slope_with_custom_consts_ok() {
         let hint_code = hint_code::EC_DOUBLE_SLOPE_EXTERNAL_CONSTS;
         let mut vm = vm_with_range_check!();
@@ -781,7 +772,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_slope_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import line_slope\n\n# Compute the slope.\nx0 = pack(ids.point0.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny1 = pack(ids.point1.y, PRIME)\nvalue = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP_P)";
         let mut vm = vm_with_range_check!();
@@ -832,7 +822,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_slope_v2_ok() {
         let mut vm = vm_with_range_check!();
 
@@ -887,7 +876,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_compute_slope_wdivmod_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import div_mod\n\n# Compute the slope.\nx0 = pack(ids.pt0.x, PRIME)\ny0 = pack(ids.pt0.y, PRIME)\nx1 = pack(ids.pt1.x, PRIME)\ny1 = pack(ids.pt1.y, PRIME)\nvalue = slope = div_mod(y0 - y1, x0 - x1, SECP_P)";
         let mut vm = vm_with_range_check!();
@@ -938,7 +926,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_double_assign_new_x_ok() {
         let hint_code = hint_code::EC_DOUBLE_ASSIGN_NEW_X_V1;
 
@@ -1002,7 +989,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_double_assign_new_x_v2_ok() {
         let hint_code = hint_code::EC_DOUBLE_ASSIGN_NEW_X_V2;
 
@@ -1067,7 +1053,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_double_assign_new_y_ok() {
         let hint_code = "value = new_y = (slope * (x - new_x) - y) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -1120,7 +1105,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_fast_ec_add_assign_new_x_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nslope = pack(ids.slope, PRIME)\nx0 = pack(ids.point0.x, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - x0 - x1) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -1177,7 +1161,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_fast_ec_add_assign_new_y_ok() {
         let hint_code = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -1232,7 +1215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_ec_mul_inner_ok() {
         let hint_code = "memory[ap] = (ids.scalar % PRIME) % 2";
         let mut vm = vm_with_range_check!();
@@ -1469,7 +1451,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_import_secp256r1_alpha() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA as ALPHA";
         let mut vm = vm_with_range_check!();
@@ -1491,7 +1472,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_square_slope_minus_xs_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import pack\n\nslope = pack(ids.slope, PRIME)\nx0 = pack(ids.point0.x, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - x0 - x1) % SECP_P";
         let mut vm = vm_with_range_check!();

--- a/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -215,11 +215,8 @@ mod tests {
     use assert_matches::assert_matches;
 
     use rstest::rstest;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_verify_zero_ok() {
         let hint_codes = vec![
             &hint_code::VERIFY_ZERO_V1,
@@ -242,7 +239,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_verify_zero_v3_ok() {
         let hint_codes = vec![
             "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME",
@@ -264,7 +260,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_verify_zero_with_external_const_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
@@ -287,7 +282,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_verify_zero_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
@@ -312,7 +306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_verify_zero_invalid_memory_insert() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
@@ -341,7 +334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_reduce_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -373,7 +365,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_reduce_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -399,7 +390,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_pack_ok() {
         let mut exec_scopes = ExecutionScopes::new();
         let hint_codes = vec![
@@ -441,7 +431,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_pack_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P";
         let mut vm = vm_with_range_check!();
@@ -470,7 +459,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::IS_ZERO_NONDET)]
     #[case(hint_code::IS_ZERO_INT)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_nondet_ok_true(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
 
@@ -498,7 +486,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::IS_ZERO_NONDET)]
     #[case(hint_code::IS_ZERO_INT)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_nondet_ok_false(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
 
@@ -526,7 +513,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::IS_ZERO_NONDET)]
     #[case(hint_code::IS_ZERO_INT)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_nondet_scope_error(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
 
@@ -548,7 +534,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::IS_ZERO_NONDET)]
     #[case(hint_code::IS_ZERO_INT)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_is_zero_nondet_invalid_memory_insert(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
 
@@ -573,7 +558,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_zero_assign_scope_variables_ok() {
         let mut exec_scopes = ExecutionScopes::new();
         let hint_codes = vec![
@@ -614,7 +598,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_zero_assign_scope_variables_scope_error() {
         let hint_code = hint_code::IS_ZERO_ASSIGN_SCOPE_VARS;
         let mut vm = vm_with_range_check!();

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -114,11 +114,8 @@ mod tests {
     use num_bigint::BigUint;
 
     use num_traits::One;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn secp_split() {
         let mut constants = HashMap::new();
         constants.insert(BASE_86.to_string(), Felt252::one() << 86_usize);
@@ -186,7 +183,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn secp_pack() {
         let pack_1 = bigint3_pack(Uint384 {
             d0: Cow::Borrowed(&Felt252::new(10_i32)),

--- a/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -180,11 +180,7 @@ mod tests {
     use assert_matches::assert_matches;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn safe_div_ok() {
         // "import N"
         let mut exec_scopes = ExecutionScopes::new();
@@ -216,7 +212,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn safe_div_fail() {
         let mut exec_scopes = scope![
             ("a", BigInt::zero()),
@@ -238,7 +233,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_point_from_x_ok() {
         let hint_code = hint_code::GET_POINT_FROM_X;
         let mut vm = vm!();
@@ -266,7 +260,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_point_from_x_negative_y() {
         let hint_code = hint_code::GET_POINT_FROM_X;
         let mut vm = vm!();
@@ -306,7 +299,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn pack_modn_div_modn_ok() {
         let hint_code = hint_code::PACK_MODN_DIV_MODN;
         let mut exec_scopes = scope![("N", N.clone())];

--- a/vm/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/segments.rs
@@ -63,11 +63,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_relocate_segment() {
         let hint_code = hint_code::RELOCATE_SEGMENT;
         //Initialize vm
@@ -90,7 +86,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_temporary_array() {
         let hint_code = hint_code::TEMPORARY_ARRAY;
         //Initialize vm

--- a/vm/src/hint_processor/builtin_hint_processor/set.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/set.rs
@@ -72,9 +72,6 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     const HINT_CODE: &str = "assert ids.elm_size > 0\nassert ids.set_ptr <= ids.set_end_ptr\nelm_list = memory.get_range(ids.elm_ptr, ids.elm_size)\nfor i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):\n    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:\n        ids.index = i // ids.elm_size\n        ids.is_elm_in_set = 1\n        break\nelse:\n    ids.is_elm_in_set = 0";
 
     fn init_vm_ids_data(
@@ -117,7 +114,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_add_new_elem() {
         let (mut vm, ids_data) = init_vm_ids_data(None, None, None, None);
         assert_matches!(run_hint!(vm, ids_data, HINT_CODE), Ok(()));
@@ -132,7 +128,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_add_already_exists() {
         let (mut vm, ids_data) = init_vm_ids_data(None, None, Some(1), Some(3));
         assert_matches!(run_hint!(vm, ids_data, HINT_CODE), Ok(()));
@@ -140,7 +135,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn elm_size_negative() {
         let (mut vm, ids_data) = init_vm_ids_data(None, Some(-2), None, None);
         assert_matches!(
@@ -150,7 +144,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn elm_size_zero() {
         let (mut vm, ids_data) = init_vm_ids_data(None, Some(0), None, None);
         assert_matches!(
@@ -161,7 +154,6 @@ mod tests {
         );
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_ptr_gt_set_end_ptr() {
         let (mut vm, ids_data) = init_vm_ids_data(Some((2, 3)), None, None, None);
         assert_matches!(

--- a/vm/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -230,13 +230,10 @@ mod tests {
     use assert_matches::assert_matches;
 
     use rstest::rstest;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     const SHA256_INPUT_CHUNK_SIZE_FELTS: usize = 16;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_input_one() {
         let mut vm = vm_with_range_check!();
         vm.segments = segments![((1, 1), 7)];
@@ -248,7 +245,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_input_zero() {
         let mut vm = vm_with_range_check!();
         vm.segments = segments![((1, 1), 3)];
@@ -260,7 +256,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_constant_input_length_ok() {
         let hint_code = hint_code::SHA256_MAIN_CONSTANT_INPUT_LENGTH;
         let mut vm = vm_with_range_check!();
@@ -311,7 +306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_arbitrary_input_length_ok() {
         let hint_code = hint_code::SHA256_MAIN_ARBITRARY_INPUT_LENGTH;
         let mut vm = vm_with_range_check!();
@@ -376,7 +370,6 @@ mod tests {
     }
 
     #[rstest]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[case(hint_code::SHA256_MAIN_CONSTANT_INPUT_LENGTH)]
     #[case(hint_code::SHA256_MAIN_ARBITRARY_INPUT_LENGTH)]
     fn sha256_invalid_chunk_size(#[case] hint_code: &str) {
@@ -414,7 +407,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_invalid_state_size() {
         let hint_code = hint_code::SHA256_MAIN_ARBITRARY_INPUT_LENGTH;
         let mut vm = vm_with_range_check!();
@@ -448,7 +440,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sha256_unexpected_state_size() {
         let hint_code = hint_code::SHA256_MAIN_ARBITRARY_INPUT_LENGTH;
         let state_size = Felt252::from(9);

--- a/vm/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/signature.rs
@@ -62,11 +62,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_ecdsa_signature_valid() {
         let mut vm = vm!();
         vm.builtin_runners =

--- a/vm/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -316,9 +316,6 @@ mod tests {
     use assert_matches::assert_matches;
     use felt::felt_str;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     //Hint code as consts
     const SQUASH_DICT_INNER_FIRST_ITERATION : &str = "current_access_indices = sorted(access_indices[key])[::-1]\ncurrent_access_index = current_access_indices.pop()\nmemory[ids.range_check_ptr] = current_access_index";
     const SQUASH_DICT_INNER_SKIP_LOOP: &str =
@@ -333,7 +330,6 @@ mod tests {
     const SQUASH_DICT_INNER_NEXT_KEY: &str = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()";
     const SQUASH_DICT: &str ="dict_access_size = ids.DictAccess.SIZE\naddress = ids.dict_accesses.address_\nassert ids.ptr_diff % dict_access_size == 0, \\\n    'Accesses array size must be divisible by DictAccess.SIZE'\nn_accesses = ids.n_accesses\nif '__squash_dict_max_size' in globals():\n    assert n_accesses <= __squash_dict_max_size, \\\n        f'squash_dict() can only be used with n_accesses<={__squash_dict_max_size}. ' \\\n        f'Got: n_accesses={n_accesses}.'\n# A map from key to the list of indices accessing it.\naccess_indices = {}\nfor i in range(n_accesses):\n    key = memory[address + dict_access_size * i]\n    access_indices.setdefault(key, []).append(i)\n# Descending list of keys.\nkeys = sorted(access_indices.keys(), reverse=True)\n# Are the keys used bigger than range_check bound.\nids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0\nids.first_key = key = keys.pop()";
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_first_iteration_valid() {
         let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //Prepare scope variables
@@ -374,7 +370,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_first_iteration_empty_accessed_indices() {
         let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //Prepare scope variables
@@ -400,7 +395,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_first_iteration_no_local_variables() {
         let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //No scope variables
@@ -420,7 +414,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn should_skip_loop_valid_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
         //Create vm
@@ -439,7 +432,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn should_skip_loop_valid_non_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
         //Create vm
@@ -461,7 +453,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_check_access_index_valid() {
         let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
         //Create vm
@@ -505,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_check_access_current_access_addr_empty() {
         let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
         //Create vm
@@ -529,7 +519,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn should_continue_loop_valid_non_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
         //Create vm
@@ -551,7 +540,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn should_continue_loop_valid_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
         //Create vm
@@ -570,7 +558,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn assert_current_indices_len_is_empty() {
         let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
         //Create vm
@@ -586,7 +573,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn assert_current_indices_len_is_empty_not() {
         let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
         //Create vm
@@ -602,7 +588,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_uses_accesses_assert_valid() {
         let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
@@ -630,7 +615,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_uses_accesses_assert_wrong_used_access_number() {
         let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
@@ -660,7 +644,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_uses_accesses_assert_used_access_number_relocatable() {
         let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
@@ -690,7 +673,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_assert_len_keys_empty() {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Create vm
@@ -705,7 +687,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_assert_len_keys_not_empty() {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Create vm
@@ -720,7 +701,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_assert_len_keys_no_keys() {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Create vm
@@ -733,7 +713,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_next_key_keys_non_empty() {
         let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
         //Create vm
@@ -757,7 +736,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_inner_next_key_keys_empty() {
         let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
         //Create vm
@@ -776,7 +754,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_valid_one_key_dict_no_max_size() {
         //Dict = {1: (1,1), 1: (1,2)}
         let hint_code = SQUASH_DICT;
@@ -823,7 +800,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_valid_two_key_dict_no_max_size() {
         //Dict = {1: (1,1), 1: (1,2), 2: (10,10), 2: (10,20)}
         let hint_code = SQUASH_DICT;
@@ -880,7 +856,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_valid_one_key_dict_with_max_size() {
         //Dict = {1: (1,1), 1: (1,2)}
         let hint_code = SQUASH_DICT;
@@ -928,7 +903,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_invalid_one_key_dict_with_max_size_exceeded() {
         //Dict = {1: (1,1), 1: (1,2)}
         let hint_code = SQUASH_DICT;
@@ -966,7 +940,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_invalid_one_key_dict_bad_ptr_diff() {
         //Dict = {1: (1,1), 1: (1,2)}
         let hint_code = SQUASH_DICT;
@@ -1001,7 +974,6 @@ mod tests {
         );
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_invalid_one_key_dict_with_n_access_too_big() {
         //Dict = {1: (1,1), 1: (1,2)}
         let hint_code = SQUASH_DICT;
@@ -1045,7 +1017,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn squash_dict_valid_one_key_dict_no_max_size_big_keys() {
         //Dict = {(prime - 1): (1,1), (prime - 1): (1,2)}
         let hint_code = SQUASH_DICT;

--- a/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -489,11 +489,7 @@ mod tests {
     use assert_matches::assert_matches;
     use felt::felt_str;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_add_ok() {
         let hint_code = hint_code::UINT256_ADD;
         let mut vm = vm_with_range_check!();
@@ -515,7 +511,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_add_low_only_ok() {
         let hint_code =
             "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0";
@@ -537,7 +532,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint128_add_ok() {
         let hint_code = hint_code::UINT128_ADD;
         let mut vm = vm_with_range_check!();
@@ -556,7 +550,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_add_fail_inserts() {
         let hint_code = hint_code::UINT256_ADD;
         let mut vm = vm_with_range_check!();
@@ -585,7 +578,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sub_nonnegative_ok() {
         let hint_code = hint_code::UINT256_SUB;
         let mut vm = vm_with_range_check!();
@@ -606,7 +598,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sub_negative_ok() {
         let hint_code = hint_code::UINT256_SUB;
         let mut vm = vm_with_range_check!();
@@ -631,7 +622,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sub_missing_member() {
         let hint_code = hint_code::UINT256_SUB;
         let mut vm = vm_with_range_check!();
@@ -651,7 +641,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_64_ok() {
         let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = vm_with_range_check!();
@@ -673,7 +662,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_64_with_big_a() {
         let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = vm_with_range_check!();
@@ -696,7 +684,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_64_memory_error() {
         let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = vm_with_range_check!();
@@ -721,7 +708,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sqrt_ok() {
         let hint_code = hint_code::UINT256_SQRT;
         let mut vm = vm_with_range_check!();
@@ -742,7 +728,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sqrt_felt_ok() {
         let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root = root";
         let mut vm = vm_with_range_check!();
@@ -759,7 +744,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_sqrt_assert_error() {
         let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0";
         let mut vm = vm_with_range_check!();
@@ -779,7 +763,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint256_invalid_memory_insert() {
         let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0";
         let mut vm = vm_with_range_check!();
@@ -801,7 +784,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_ok_result_one() {
         let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = vm_with_range_check!();
@@ -825,7 +807,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_ok_result_zero() {
         let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = vm_with_range_check!();
@@ -849,7 +830,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_ok_invalid_memory_insert() {
         let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = vm_with_range_check!();
@@ -870,7 +850,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_ok() {
         let hint_code = hint_code::UINT256_UNSIGNED_DIV_REM;
         let mut vm = vm_with_range_check!();
@@ -895,7 +874,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_expanded_ok() {
         let hint_code = hint_code::UINT256_EXPANDED_UNSIGNED_DIV_REM;
         let mut vm = vm_with_range_check!();
@@ -930,7 +908,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_invalid_memory_insert() {
         let hint_code = hint_code::UINT256_UNSIGNED_DIV_REM;
         let mut vm = vm_with_range_check!();
@@ -959,7 +936,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_invalid_memory_insert_2() {
         let hint_code = hint_code::UINT256_UNSIGNED_DIV_REM;
         let mut vm = vm_with_range_check!();
@@ -988,7 +964,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_mul_div_mod_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -1038,7 +1013,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_mul_div_mod_missing_ids() {
         let mut vm = vm_with_range_check!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -251,11 +251,8 @@ mod tests {
     use felt::felt_str;
 
     use num_traits::One;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -310,7 +307,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_divide_by_zero() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -337,7 +333,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_invalid_memory_insert() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -370,7 +365,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_128_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -395,7 +389,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_128_ok_big_number() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -436,7 +429,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_split_128_invalid_memory_insert() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -457,7 +449,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_add_no_check_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -508,7 +499,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_add_no_check_missing_constant() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -540,7 +530,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_sqrt_ok() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -567,7 +556,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_sqrt_assertion_fail() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -590,7 +578,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_ok_positive() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -613,7 +600,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_missing_identifier() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -634,7 +620,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_signed_nn_ok_negative() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -657,7 +642,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint384_sub_a_b_ok_a_max() {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -692,7 +676,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_uint384_sub_a_b_ok_b_max() {
         let mut vm = vm_with_range_check!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/uint384_extension.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint384_extension.rs
@@ -177,8 +177,6 @@ mod tests {
     use felt::felt_str;
     use num_traits::One;
     use rstest::rstest;
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
     fn get_uint768_from_base_addr_ok() {
@@ -309,7 +307,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384)]
     #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_ok(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
         //Initialize fp
@@ -381,7 +378,6 @@ mod tests {
     #[rstest]
     #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384)]
     #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_unsigned_div_rem_divide_by_zero(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/usort.rs
@@ -151,18 +151,13 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn usort_with_max_size() {
         let mut exec_scopes = scope![("usort_max_size", 1_u64)];
         assert_matches!(usort_enter_scope(&mut exec_scopes), Ok(()));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn usort_out_of_range() {
         let mut vm = vm_with_range_check!();
         vm.run_context.fp = 2;

--- a/vm/src/hint_processor/builtin_hint_processor/vrf/fq.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/vrf/fq.rs
@@ -122,11 +122,7 @@ mod tests {
     use crate::utils::test_utils::*;
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uint512_unsigned_div_rem_ok() {
         let hint_code = hint_code::UINT512_UNSIGNED_DIV_REM;
         let mut vm = vm_with_range_check!();
@@ -161,7 +157,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_inv_mod_p_uint256_ok() {
         let hint_code = hint_code::INV_MOD_P_UINT256;
         let mut vm = vm_with_range_check!();

--- a/vm/src/hint_processor/builtin_hint_processor/vrf/inv_mod_p_uint512.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/vrf/inv_mod_p_uint512.rs
@@ -68,8 +68,6 @@ mod tests {
     };
     use num_bigint::BigUint;
     use num_traits::{FromPrimitive, Num};
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
     fn test_pack_512() {
@@ -111,7 +109,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_inv_mod_p_uint512_ok() {
         let mut vm = vm_with_range_check!();
         add_segments!(vm, 3);

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -776,19 +776,17 @@ impl Cairo1HintProcessor {
         let mut curr = as_relocatable(vm, start)?;
         let end = as_relocatable(vm, end)?;
 
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            while curr != end {
-                let value = vm.get_integer(curr)?;
-                if let Some(shortstring) = as_cairo_short_string(&value) {
-                    println!("[DEBUG]\t{shortstring: <31}\t(raw: {value: <31})");
-                } else {
-                    println!("[DEBUG]\t{0: <31}\t(raw: {value: <31}) ", ' ');
-                }
-                curr += 1;
+        while curr != end {
+            let value = vm.get_integer(curr)?;
+            if let Some(shortstring) = as_cairo_short_string(&value) {
+                println!("[DEBUG]\t{shortstring: <31}\t(raw: {value: <31})");
+            } else {
+                println!("[DEBUG]\t{0: <31}\t(raw: {value: <31}) ", ' ');
             }
-            println!();
+            curr += 1;
         }
+        println!();
+
         Ok(())
     }
 

--- a/vm/src/hint_processor/hint_processor_utils.rs
+++ b/vm/src/hint_processor/hint_processor_utils.rs
@@ -187,11 +187,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_from_reference_with_immediate_value() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 0)];
@@ -207,7 +203,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_offset_value_reference_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 0)];
@@ -221,7 +216,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_offset_value_reference_invalid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 0)];
@@ -235,7 +229,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_reference_short_path() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (2, 0))];
@@ -251,7 +244,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_reference_with_dereference() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (3, 0))];
@@ -267,7 +259,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ptr_from_reference_with_dereference_and_imm() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (4, 0))];
@@ -281,7 +272,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_addr_from_reference_no_regiter_in_reference() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (4, 0))];
@@ -292,7 +282,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_addr_from_reference_failed_to_get_ids() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 4)];
@@ -307,7 +296,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn tracking_correction_valid() {
         let mut ref_ap_tracking = ApTracking::new();
         ref_ap_tracking.group = 1;
@@ -321,7 +309,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn tracking_correction_invalid_group() {
         let mut ref_ap_tracking = ApTracking::new();
         ref_ap_tracking.group = 1;
@@ -337,7 +324,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_relocatable_from_reference_valid() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), (0, 0))];
@@ -349,7 +335,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_relocatable_from_reference_invalid() {
         let mut vm = vm!();
         vm.segments.memory = Memory::new();

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(warnings)]
 #![forbid(unsafe_code)]
-#![cfg_attr(any(target_arch = "wasm32", not(feature = "std")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
 include!("./with_std.rs");

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -300,11 +300,7 @@ mod tests {
     #[cfg(feature = "std")]
     use num_bigint::Sign;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_divmod_a() {
         let a = bigint_str!(
             "11260647941622813594563746375280766662237311019551239924981511729608487775604310196863705127454617186486639011517352066501847110680463498585797912894788"
@@ -325,7 +321,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_divmod_b() {
         let a = bigint_str!(
             "29642372811668969595956851264770043260610851505766181624574941701711520154703788233010819515917136995474951116158286220089597404329949295479559895970988"
@@ -346,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_divmod_c() {
         let a = bigint_str!(
             "1208267356464811040667664150251401430616174694388968865551115897173431833224432165394286799069453655049199580362994484548890574931604445970825506916876"
@@ -367,7 +361,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div() {
         let x = Felt252::new(26);
         let y = Felt252::new(13);
@@ -375,7 +368,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div_non_divisor() {
         let x = Felt252::new(25);
         let y = Felt252::new(4);
@@ -386,7 +378,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div_by_zero() {
         let x = Felt252::new(25);
         let y = Felt252::zero();
@@ -395,13 +386,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div_usize() {
         assert_matches!(safe_div_usize(26, 13), Ok(2));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div_usize_non_divisor() {
         assert_matches!(
             safe_div_usize(25, 4),
@@ -410,13 +399,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_safe_div_usize_by_zero() {
         assert_matches!(safe_div_usize(25, 0), Err(MathError::DividedByZero));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_line_slope_for_valid_points() {
         let point_a = (
             bigint_str!(
@@ -444,7 +431,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_double_slope_for_valid_point_a() {
         let point = (
             bigint_str!(
@@ -465,7 +451,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_double_slope_for_valid_point_b() {
         let point = (
             bigint_str!(
@@ -486,7 +471,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_double_for_valid_point_a() {
         let point = (
             bigint_str!(
@@ -512,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_double_for_valid_point_b() {
         let point = (
             bigint_str!(
@@ -538,7 +521,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_double_for_valid_point_c() {
         let point = (
             bigint_str!(
@@ -564,7 +546,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_add_for_valid_points_a() {
         let point_a = (
             bigint_str!(
@@ -597,7 +578,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_add_for_valid_points_b() {
         let point_a = (
             bigint_str!(
@@ -630,7 +610,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_ec_add_for_valid_points_c() {
         let point_a = (
             bigint_str!(
@@ -663,21 +642,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_isqrt_a() {
         let n = biguint!(81);
         assert_matches!(isqrt(&n), Ok(x) if x == biguint!(9));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_isqrt_b() {
         let n = biguint_str!("4573659632505831259480");
         assert_matches!(isqrt(&BigUint::pow(&n, 2_u32)), Ok(num) if num == n);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_isqrt_c() {
         let n = biguint_str!(
             "3618502788666131213697322783095070105623107215331596699973092056135872020481"
@@ -686,14 +662,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn calculate_isqrt_zero() {
         let n = BigUint::zero();
         assert_matches!(isqrt(&n), Ok(inner) if inner.is_zero());
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn safe_div_bigint_by_zero() {
         let x = BigInt::one();
         let y = BigInt::zero();
@@ -701,7 +675,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power() {
         let n: BigUint = 25_u32.into();
         let p: BigUint = 18446744069414584321_u128.into();
@@ -709,7 +682,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_p_is_zero() {
         let n = BigUint::one();
         let p: BigUint = BigUint::zero();
@@ -717,7 +689,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_non_prime() {
         let p: BigUint = BigUint::from_bytes_be(&[
             69, 15, 232, 82, 215, 167, 38, 143, 173, 94, 133, 111, 1, 2, 182, 229, 110, 113, 76, 0,
@@ -732,7 +703,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_none() {
         let n: BigUint = 10_u32.into();
         let p: BigUint = 602_u32.into();
@@ -740,7 +710,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_prime_two() {
         let n: BigUint = 25_u32.into();
         let p: BigUint = 2_u32.into();
@@ -748,7 +717,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_prime_mod_8_is_5_sign_not_one() {
         let n: BigUint = 676_u32.into();
         let p: BigUint = 9956234341095173_u64.into();
@@ -759,7 +727,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_sqrt_prime_power_prime_mod_8_is_5_sign_is_one() {
         let n: BigUint = 130283432663_u64.into();
         let p: BigUint = 743900351477_u64.into();
@@ -770,13 +737,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_legendre_symbol_zero() {
         assert!(legendre_symbol(&BigUint::zero(), &BigUint::one()).is_zero())
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_is_quad_residue_prime_zero() {
         assert_eq!(
             is_quad_residue(&BigUint::one(), &BigUint::zero()),
@@ -785,13 +750,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_is_quad_residue_prime_a_one_true() {
         assert_eq!(is_quad_residue(&BigUint::one(), &BigUint::one()), Ok(true))
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn mul_inv_0_is_0() {
         let p = &(*CAIRO_PRIME).clone().into();
         let x = &BigInt::zero();

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -450,11 +450,7 @@ mod tests {
     use num_traits::One;
     use num_traits::Zero;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_bigint_from_string_json_gives_error() {
         let invalid_even_length_hex_json = r#"
             {
@@ -479,7 +475,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_bigint_invalid_char_error() {
         let invalid_char = r#"
             {
@@ -492,7 +487,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_bigint_no_prefix_error() {
         let no_prefix = r#"
             {
@@ -506,7 +500,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_from_string_json() {
         let valid_json = r#"
             {
@@ -721,7 +714,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_json_from_json_file_a() {
         // Open json file with (valid) even length encoded hex
         let reader =
@@ -739,7 +731,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_json_from_json_file_b() {
         // Open json file with (valid) odd length encoded hex
         let reader =
@@ -758,7 +749,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_json_from_json_file_gives_error() {
         // Open json file with (invalid) even length encoded hex
         let reader = include_bytes!(
@@ -779,7 +769,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_missing_entrypoint_gives_error() {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json");
@@ -794,7 +783,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_test() {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json");
@@ -853,7 +841,6 @@ mod tests {
 
     /// Deserialize a program without an entrypoint.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_without_entrypoint_test() {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json");
@@ -911,7 +898,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_constant() {
         let reader = include_bytes!(
             "../../../cairo_programs/manually_compiled/deserialize_constant_test.json"
@@ -1006,7 +992,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn value_address_no_hint_reference_default_test() {
         let valid_json = r#"
             {
@@ -1053,7 +1038,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_attributes_test() {
         let valid_json = r#"
             {
@@ -1147,7 +1131,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_instruction_locations_test_no_parent() {
         let valid_json = r#"
             {
@@ -1256,7 +1239,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_instruction_locations_test_with_parent() {
         let valid_json = r#"
             {
@@ -1357,7 +1339,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_with_type_definition() {
         let reader = include_bytes!("../../../cairo_programs/uint256_integration_tests.json");
 
@@ -1387,7 +1368,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_nonbase10_number_errors() {
         let valid_json = r#"
         {
@@ -1399,7 +1379,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_felt_from_number_with_scientific_notation() {
         let n = Number::deserialize(serde_json::Value::from(1000000000000000000000000000_u128))
             .unwrap();
@@ -1412,7 +1391,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_felt_from_number_with_scientific_notation_with_fractional_part() {
         let n = serde_json::Value::Number(Number::from_f64(64e+74).unwrap());
 
@@ -1423,7 +1401,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_felt_from_number_with_scientific_notation_with_fractional_part_f64_max() {
         let n = serde_json::Value::Number(Number::from_f64(f64::MAX).unwrap());
         assert_eq!(
@@ -1439,7 +1416,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_felt_from_number_with_scientific_notation_big_exponent() {
         #[derive(Deserialize, Debug, PartialEq)]
         struct Test {

--- a/vm/src/serde/deserialize_utils.rs
+++ b/vm/src/serde/deserialize_utils.rs
@@ -294,11 +294,7 @@ mod tests {
     use crate::stdlib::string::ToString;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn outer_brackets_test() {
         let deref_value = "[cast([fp])]";
         let parsed_deref = outer_brackets(deref_value);
@@ -310,7 +306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn take_cast_test() {
         let value = "cast([fp + (-1)], felt*)";
         let parsed = take_cast(value);
@@ -318,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn take_cast_first_arg_test() {
         let value = "cast([fp + (-1)] + (-1), felt*)";
         let parsed = take_cast_first_arg(value);
@@ -327,7 +321,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_register_test() {
         let value = "fp + (-1)";
         let parsed = register(value);
@@ -336,7 +329,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_offset_test() {
         let value_1 = " + (-1)";
         let parsed_1 = offset(value_1);
@@ -352,7 +344,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_register_and_offset_test() {
         let value_1 = "fp + 1";
         let parsed_1 = register_and_offset(value_1);
@@ -366,7 +357,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_inner_dereference_test() {
         let value = "[fp + (-1)] + 2";
         let parsed = inner_dereference(value);
@@ -378,7 +368,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_no_inner_dereference_test() {
         let value = "ap + 3";
         let parsed = no_inner_dereference(value);
@@ -390,7 +379,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_inner_dereference_test() {
         let value = "[cast([fp + (-1)] + 2, felt*)]";
         let parsed = parse_value(value);
@@ -410,7 +398,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_no_inner_dereference_test() {
         let value = "cast(ap + 2, felt*)";
         let parsed = parse_value(value);
@@ -430,7 +417,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_no_register_test() {
         let value = "cast(825323, felt*)";
         let parsed = parse_value(value);
@@ -449,7 +435,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_no_inner_deref_and_two_offsets() {
         let value = "[cast(ap - 0 + (-1), felt*)]";
         let parsed = parse_value(value);
@@ -469,7 +454,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_inner_deref_and_offset2() {
         let value = "[cast([ap] + 1, __main__.felt*)]";
         let parsed = parse_value(value);
@@ -489,7 +473,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_inner_deref_and_immediate() {
         let value = "[cast([ap] + 1, felt)]";
         let parsed = parse_value(value);
@@ -509,7 +492,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_inner_deref_to_pointer() {
         let value = "[cast([ap + 1] + 1, felt*)]";
         let parsed = parse_value(value);
@@ -529,7 +511,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_2_inner_deref() {
         let value = "[cast([ap] + [fp + 1], __main__.felt*)]";
         let parsed = parse_value(value);
@@ -549,7 +530,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_2_inner_dereferences() {
         let value = "[cast([ap + 1] + [fp + 1], __main__.felt*)]";
         let parsed = parse_value(value);
@@ -569,7 +549,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_no_reference() {
         let value = "cast(825323, felt)";
         let parsed = parse_value(value);
@@ -589,7 +568,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_one_reference() {
         let value = "[cast([ap] + 1, starkware.cairo.common.cairo_secp.ec.EcPoint*)]";
         let parsed = parse_value(value);
@@ -609,7 +587,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_with_doble_reference() {
         let value = "[cast([ap] + 1, starkware.cairo.common.cairo_secp.ec.EcPoint**)]";
         let parsed = parse_value(value);
@@ -629,7 +606,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_to_felt_with_doble_reference() {
         let value = "[cast([ap] + [ap], felt)]";
         let parsed = parse_value(value);
@@ -649,7 +625,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn parse_value_to_felt_with_doble_reference_and_offsets() {
         let value = "[cast([ap + 1] + [ap + 2], felt)]";
         let parsed = parse_value(value);
@@ -669,7 +644,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_take_until_unmatched() {
         assert_eq!(take_until_unbalanced('(', ')')("abc"), Ok(("", "abc")));
         assert_eq!(

--- a/vm/src/tests/bitwise_test.rs
+++ b/vm/src/tests/bitwise_test.rs
@@ -1,10 +1,6 @@
 use crate::tests::run_program_with_trace;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
-
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bitwise_integration_test() {
     let program_data = include_bytes!("../../../cairo_programs/bitwise_builtin_test.json");
     let trace = [

--- a/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -4,7 +4,6 @@ use crate::{tests::*, vm::runners::cairo_runner::ResourceTracker};
 use assert_matches::assert_matches;
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_init_squash_data() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/init_squash_data.casm");
@@ -18,14 +17,12 @@ fn test_init_squash_data() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_hint_test() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/dict_test.casm");
     run_cairo_1_entrypoint(program_data.as_slice(), 0, &[], &[5_usize.into()]);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_uint256_div_mod_hint_max_value() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/uint256_div_mod.casm");
@@ -34,7 +31,6 @@ fn test_uint256_div_mod_hint_max_value() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_uint256_div_mod_hint() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/uint256_div_mod.casm");
@@ -48,7 +44,6 @@ fn test_uint256_div_mod_hint() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_less_than_or_equal() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/test_less_than.casm");
@@ -75,7 +70,6 @@ fn test_less_than_or_equal() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_1() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
     run_cairo_1_entrypoint(
@@ -87,7 +81,6 @@ fn fibonacci_1() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_3() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
     run_cairo_1_entrypoint(
@@ -99,7 +92,6 @@ fn fibonacci_3() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn factorial_50() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/factorial.casm");
     run_cairo_1_entrypoint(
@@ -114,7 +106,6 @@ fn factorial_50() {
     );
 }
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn factorial_2000() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/factorial.casm");
     run_cairo_1_entrypoint(
@@ -130,7 +121,6 @@ fn factorial_2000() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u8_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u8_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -142,7 +132,6 @@ fn u8_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u8_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u8_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -154,7 +143,6 @@ fn u8_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u8_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u8_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -166,7 +154,6 @@ fn u8_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u8_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u8_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -178,7 +165,6 @@ fn u8_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u16_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u16_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -190,7 +176,6 @@ fn u16_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u16_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u16_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -202,7 +187,6 @@ fn u16_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u16_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u16_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -214,7 +198,6 @@ fn u16_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u16_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u16_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -226,7 +209,6 @@ fn u16_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u32_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u32_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -238,7 +220,6 @@ fn u32_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u32_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u32_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -250,7 +231,6 @@ fn u32_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u32_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u32_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -262,7 +242,6 @@ fn u32_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u32_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u32_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -274,7 +253,6 @@ fn u32_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u64_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u64_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -286,7 +264,6 @@ fn u64_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u64_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u64_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -298,7 +275,6 @@ fn u64_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u64_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u64_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -310,7 +286,6 @@ fn u64_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u64_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u64_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -322,7 +297,6 @@ fn u64_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u128_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u128_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -334,7 +308,6 @@ fn u128_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u128_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u128_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -346,7 +319,6 @@ fn u128_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u128_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u128_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -358,7 +330,6 @@ fn u128_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u128_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u128_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -370,7 +341,6 @@ fn u128_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_9() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -382,7 +352,6 @@ fn u256_sqrt_9() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_10() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -394,7 +363,6 @@ fn u256_sqrt_10() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_one() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -406,7 +374,6 @@ fn u256_sqrt_one() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_zero() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -418,7 +385,6 @@ fn u256_sqrt_zero() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_max_num() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
 
@@ -426,7 +392,6 @@ fn u256_sqrt_max_num() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_big_num() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(
@@ -438,7 +403,6 @@ fn u256_sqrt_big_num() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn divmod_hint_test() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/divmod.casm");
     run_cairo_1_entrypoint(
@@ -450,7 +414,6 @@ fn divmod_hint_test() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn alloc_segment_hint_test() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/alloc_segment.casm");
@@ -458,7 +421,6 @@ fn alloc_segment_hint_test() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn should_skip_squash_loop_hint_test() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/should_skip_squash_loop.casm");
@@ -466,7 +428,6 @@ fn should_skip_squash_loop_hint_test() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn get_segment_arena_test() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/get_segment_arena_index.casm");
@@ -474,7 +435,6 @@ fn get_segment_arena_test() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn boxed_fibonacci() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/alloc_constant_size.casm");
@@ -487,7 +447,6 @@ fn boxed_fibonacci() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn linear_split() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/linear_split.casm");
@@ -514,7 +473,6 @@ fn linear_split() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn alloc_felt_252_dict() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/felt_252_dict.casm");
@@ -522,7 +480,6 @@ fn alloc_felt_252_dict() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn random_ec_point() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/random_ec_point.casm");
@@ -530,7 +487,6 @@ fn random_ec_point() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_find_small_arcs() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/assert_le_find_small_arcs.casm");
@@ -538,7 +494,6 @@ fn assert_le_find_small_arcs() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn felt252_dict_entry_init() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/felt252_dict_entry_init.casm");
@@ -546,7 +501,6 @@ fn felt252_dict_entry_init() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn felt252_dict_entry_update() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/felt252_dict_entry_update.casm");
@@ -559,7 +513,6 @@ fn felt252_dict_entry_update() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn widelmul128_test() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/widemul128.casm");
     run_cairo_1_entrypoint(
@@ -576,13 +529,11 @@ fn widelmul128_test() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn field_sqrt_test() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/field_sqrt.casm");
     run_cairo_1_entrypoint(program_data.as_slice(), 0, &[], &[10.into()]);
 }
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint512_div_mod_test() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo-1-contracts/uint512_div_mod.casm");
@@ -602,7 +553,6 @@ fn uint512_div_mod_test() {
 // ================
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_ok() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
@@ -623,7 +573,6 @@ fn fibonacci_with_run_resources_ok() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_2_ok() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
@@ -646,7 +595,6 @@ fn fibonacci_with_run_resources_2_ok() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_error() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -1,28 +1,24 @@
 use crate::tests::*;
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci() {
     let program_data = include_bytes!("../../../cairo_programs/fibonacci.json");
     run_program_small(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn array_sum() {
     let program_data = include_bytes!("../../../cairo_programs/array_sum.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn big_struct() {
     let program_data = include_bytes!("../../../cairo_programs/big_struct.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn call_function_assign_param_by_name() {
     let program_data =
         include_bytes!("../../../cairo_programs/call_function_assign_param_by_name.json");
@@ -30,84 +26,72 @@ fn call_function_assign_param_by_name() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn function_return() {
     let program_data = include_bytes!("../../../cairo_programs/function_return.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn function_return_if_print() {
     let program_data = include_bytes!("../../../cairo_programs/function_return_if_print.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn function_return_to_variable() {
     let program_data = include_bytes!("../../../cairo_programs/function_return_to_variable.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn if_and_prime() {
     let program_data = include_bytes!("../../../cairo_programs/if_and_prime.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn if_in_function() {
     let program_data = include_bytes!("../../../cairo_programs/if_in_function.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn if_list() {
     let program_data = include_bytes!("../../../cairo_programs/if_list.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn jmp() {
     let program_data = include_bytes!("../../../cairo_programs/jmp.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn jmp_if_condition() {
     let program_data = include_bytes!("../../../cairo_programs/jmp_if_condition.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn pointers() {
     let program_data = include_bytes!("../../../cairo_programs/pointers.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn print() {
     let program_data = include_bytes!("../../../cairo_programs/print.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn program_return() {
     let program_data = include_bytes!("../../../cairo_programs/return.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn reversed_register_instructions() {
     let program_data =
         include_bytes!("../../../cairo_programs/reversed_register_instructions.json");
@@ -115,371 +99,318 @@ fn reversed_register_instructions() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn simple_print() {
     let program_data = include_bytes!("../../../cairo_programs/simple_print.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_addition_if() {
     let program_data = include_bytes!("../../../cairo_programs/test_addition_if.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_reverse_if() {
     let program_data = include_bytes!("../../../cairo_programs/test_reverse_if.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_subtraction_if() {
     let program_data = include_bytes!("../../../cairo_programs/test_subtraction_if.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn use_imported_module() {
     let program_data = include_bytes!("../../../cairo_programs/use_imported_module.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bitwise_output() {
     let program_data = include_bytes!("../../../cairo_programs/bitwise_output.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bitwise_recursion() {
     let program_data = include_bytes!("../../../cairo_programs/bitwise_recursion.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn integration() {
     let program_data = include_bytes!("../../../cairo_programs/integration.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn integration_with_alloc_locals() {
     let program_data = include_bytes!("../../../cairo_programs/integration_with_alloc_locals.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_arrays() {
     let program_data = include_bytes!("../../../cairo_programs/compare_arrays.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_greater_array() {
     let program_data = include_bytes!("../../../cairo_programs/compare_greater_array.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 170);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_lesser_array() {
     let program_data = include_bytes!("../../../cairo_programs/compare_lesser_array.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 200);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_felt_hint() {
     let program_data = include_bytes!("../../../cairo_programs/assert_le_felt_hint.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_250_bit_element_array() {
     let program_data = include_bytes!("../../../cairo_programs/assert_250_bit_element_array.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn abs_value_array() {
     let program_data = include_bytes!("../../../cairo_programs/abs_value_array.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_different_arrays() {
     let program_data = include_bytes!("../../../cairo_programs/compare_different_arrays.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_nn() {
     let program_data = include_bytes!("../../../cairo_programs/assert_nn.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn sqrt() {
     let program_data = include_bytes!("../../../cairo_programs/sqrt.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_not_zero() {
     let program_data = include_bytes!("../../../cairo_programs/assert_not_zero.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn split_int() {
     let program_data = include_bytes!("../../../cairo_programs/split_int.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn split_int_big() {
     let program_data = include_bytes!("../../../cairo_programs/split_int_big.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn split_felt() {
     let program_data = include_bytes!("../../../cairo_programs/split_felt.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_cmp() {
     let program_data = include_bytes!("../../../cairo_programs/math_cmp.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 372);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn unsigned_div_rem() {
     let program_data = include_bytes!("../../../cairo_programs/unsigned_div_rem.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn signed_div_rem() {
     let program_data = include_bytes!("../../../cairo_programs/signed_div_rem.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_lt_felt() {
     let program_data = include_bytes!("../../../cairo_programs/assert_lt_felt.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 8);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memcpy_test() {
     let program_data = include_bytes!("../../../cairo_programs/memcpy_test.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memset() {
     let program_data = include_bytes!("../../../cairo_programs/memset.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn pow() {
     let program_data = include_bytes!("../../../cairo_programs/pow.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 6);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict() {
     let program_data = include_bytes!("../../../cairo_programs/dict.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 4);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_update() {
     let program_data = include_bytes!("../../../cairo_programs/dict_update.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256() {
     let program_data = include_bytes!("../../../cairo_programs/uint256.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 3534);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn find_element() {
     let program_data = include_bytes!("../../../cairo_programs/find_element.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn search_sorted_lower() {
     let program_data = include_bytes!("../../../cairo_programs/search_sorted_lower.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 4);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn usort() {
     let program_data = include_bytes!("../../../cairo_programs/usort.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 3);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn squash_dict() {
     let program_data = include_bytes!("../../../cairo_programs/squash_dict.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_squash() {
     let program_data = include_bytes!("../../../cairo_programs/dict_squash.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_add() {
     let program_data = include_bytes!("../../../cairo_programs/set_add.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp() {
     let program_data = include_bytes!("../../../cairo_programs/secp.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_ec() {
     let program_data = include_bytes!("../../../cairo_programs/secp_ec.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 1752);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn signature() {
     let program_data = include_bytes!("../../../cairo_programs/signature.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_hello_world_hash() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_hello_world_hash.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn example_blake2s() {
     let program_data = include_bytes!("../../../cairo_programs/example_blake2s.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn finalize_blake2s() {
     let program_data = include_bytes!("../../../cairo_programs/finalize_blake2s.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn finalize_blake2s_v2_hint() {
     let program_data = include_bytes!("../../../cairo_programs/finalize_blake2s_v2_hint.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn unsafe_keccak() {
     let program_data = include_bytes!("../../../cairo_programs/unsafe_keccak.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_felts() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_felts.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 139);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn unsafe_keccak_finalize() {
     let program_data = include_bytes!("../../../cairo_programs/unsafe_keccak_finalize.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_add_uint256() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_add_uint256.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak() {
     let program_data = include_bytes!("../../../cairo_programs/_keccak.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 21);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_copy_inputs() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_copy_inputs.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_finalize_keccak_v1() {
     let program_data = include_bytes!("../../../cairo_programs/cairo_finalize_keccak.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 50);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_finalize_keccak_v2() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo_finalize_keccak_block_size_1000.json");
@@ -487,7 +418,6 @@ fn cairo_finalize_keccak_v2() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn operations_with_data_structures() {
     let program_data =
         include_bytes!("../../../cairo_programs/operations_with_data_structures.json");
@@ -495,14 +425,12 @@ fn operations_with_data_structures() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn packed_sha256() {
     let program_data = include_bytes!("../../../cairo_programs/packed_sha256_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_cmp_and_pow_integration_tests() {
     let program_data =
         include_bytes!("../../../cairo_programs/math_cmp_and_pow_integration_tests.json");
@@ -510,84 +438,72 @@ fn math_cmp_and_pow_integration_tests() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/uint256_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 1027);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/set_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memory_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/memory_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 5);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/dict_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 32);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/secp_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 4626);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 507);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 409);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments_with_offset() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments_with_offset.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 5);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_store_cast_ptr() {
     let program_data = include_bytes!("../../../cairo_programs/dict_store_cast_ptr.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn common_signature() {
     let program_data = include_bytes!("../../../cairo_programs/common_signature.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bad_usort() {
     let program_data = include_bytes!("../../../cairo_programs/bad_programs/bad_usort.json");
     let error_msg = "unexpected verify multiplicity fail: positions length != 0";
@@ -595,7 +511,6 @@ fn bad_usort() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bad_dict_new() {
     let program_data = include_bytes!("../../../cairo_programs/bad_programs/bad_dict_new.json");
     let error_msg = "Dict Error: Tried to create a dict without an initial dict";
@@ -603,7 +518,6 @@ fn bad_dict_new() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bad_dict_update() {
     let program_data = include_bytes!("../../../cairo_programs/bad_programs/bad_dict_update.json");
     let error_msg =
@@ -612,7 +526,6 @@ fn bad_dict_update() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn error_msg_attr() {
     let program_data = include_bytes!("../../../cairo_programs/bad_programs/error_msg_attr.json");
     let error_msg = "SafeUint256: addition overflow";
@@ -620,7 +533,6 @@ fn error_msg_attr() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn error_msg_attr_tempvar() {
     let program_data =
         include_bytes!("../../../cairo_programs/bad_programs/error_msg_attr_tempvar.json");
@@ -633,7 +545,6 @@ fn error_msg_attr_tempvar() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn error_msg_attr_struct() {
     let program_data =
         include_bytes!("../../../cairo_programs/bad_programs/error_msg_attr_struct.json");
@@ -642,329 +553,282 @@ fn error_msg_attr_struct() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn poseidon_builtin() {
     let program_data = include_bytes!("../../../cairo_programs/poseidon_builtin.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ec_op() {
     let program_data = include_bytes!("../../../cairo_programs/ec_op.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn poseidon_hash() {
     let program_data = include_bytes!("../../../cairo_programs/poseidon_hash.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_chained_run_ec_op() {
     let program_data = include_bytes!("../../../cairo_programs/chained_ec_op.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_builtin() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_builtin.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_uint256() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_uint256.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn recover_y() {
     let program_data = include_bytes!("../../../cairo_programs/recover_y.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_integration() {
     let program_data = include_bytes!("../../../cairo_programs/math_integration_tests.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 109);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn is_quad_residue_test() {
     let program_data = include_bytes!("../../../cairo_programs/is_quad_residue_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 6);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn mul_s_inv() {
     let program_data = include_bytes!("../../../cairo_programs/mul_s_inv.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_alternative_hint() {
     let program_data = include_bytes!("../../../cairo_programs/_keccak_alternative_hint.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 24);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint384() {
     let program_data = include_bytes!("../../../cairo_programs/uint384_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 54);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint384_extension() {
     let program_data = include_bytes!("../../../cairo_programs/uint384_extension_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 40);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn field_arithmetic() {
     let program_data = include_bytes!("../../../cairo_programs/field_arithmetic.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 507);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ed25519_field() {
     let program_data = include_bytes!("../../../cairo_programs/ed25519_field.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ed25519_ec() {
     let program_data = include_bytes!("../../../cairo_programs/ed25519_ec.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn efficient_secp256r1_ec() {
     let program_data = include_bytes!("../../../cairo_programs/efficient_secp256r1_ec.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_secp256r1_slope() {
     let program_data = include_bytes!("../../../cairo_programs/secp256r1_slope.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn garaga() {
     let program_data = include_bytes!("../../../cairo_programs/garaga.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_bigint_div_mod() {
     let program_data = include_bytes!("../../../cairo_programs/bigint.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn div_mod_n() {
     let program_data = include_bytes!("../../../cairo_programs/div_mod_n.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn is_zero() {
     let program_data = include_bytes!("../../../cairo_programs/is_zero.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_secp256r1_div_mod_n() {
     let program_data = include_bytes!("../../../cairo_programs/secp256r1_div_mod_n.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn is_zero_pack() {
     let program_data = include_bytes!("../../../cairo_programs/is_zero_pack.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn n_bit() {
     let program_data = include_bytes!("../../../cairo_programs/n_bit.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn highest_bitlen() {
     let program_data = include_bytes!("../../../cairo_programs/highest_bitlen.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_improvements() {
     let program_data = include_bytes!("../../../cairo_programs/uint256_improvements.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 128);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memory_holes() {
     let program_data = include_bytes!("../../../cairo_programs/memory_holes.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 5)
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ec_recover() {
     let program_data = include_bytes!("../../../cairo_programs/ec_recover.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_inv_mod_p_uint512() {
     let program_data = include_bytes!("../../../cairo_programs/inv_mod_p_uint512.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bitand_hint() {
     let program_data = include_bytes!("../../../cairo_programs/bitand_hint.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_felt_old() {
     let program_data = include_bytes!("../../../cairo_programs/assert_le_felt_old.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 35);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_fq_test() {
     let program_data = include_bytes!("../../../cairo_programs/fq_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 120);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_ec_negate() {
     let program_data = include_bytes!("../../../cairo_programs/ec_negate.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_compute_slope_v2_test() {
     let program_data = include_bytes!("../../../cairo_programs/compute_slope_v2.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_compute_doubling_slope_v2_test() {
     let program_data = include_bytes!("../../../cairo_programs/compute_doubling_slope_v2.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fast_ec_add_v2() {
     let program_data = include_bytes!("../../../cairo_programs/fast_ec_add_v2.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fast_ec_add_v3() {
     let program_data = include_bytes!("../../../cairo_programs/fast_ec_add_v3.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ec_double_assign_new_x_v3() {
     let program_data = include_bytes!("../../../cairo_programs/ec_double_assign_new_x_v3.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp256r1_fast_ec_add() {
     let program_data = include_bytes!("../../../cairo_programs/secp256r1_fast_ec_add.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn split_xx_hint() {
     let program_data = include_bytes!("../../../cairo_programs/split_xx_hint.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn nondet_bigint3_v2() {
     let program_data = include_bytes!("../../../cairo_programs/nondet_bigint3_v2.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn ec_double_v4() {
     let program_data = include_bytes!("../../../cairo_programs/ec_double_v4.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_ec_double_slope() {
     let program_data = include_bytes!("../../../cairo_programs/ec_double_slope.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_normalize_address() {
     let program_data = include_bytes!("../../../cairo_programs/normalize_address.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 110);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_sha256_test() {
     let program_data = include_bytes!("../../../cairo_programs/sha256_test.json");
     run_program_simple_with_memory_holes(program_data.as_slice(), 923);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_reduce() {
     let program_data = include_bytes!("../../../cairo_programs/reduce.json");
     run_program_simple(program_data.as_slice());

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -25,9 +25,6 @@ use crate::{
     vm::trace::trace_entry::TraceEntry,
 };
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
-
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{string::String, vec::Vec};
 

--- a/vm/src/tests/pedersen_test.rs
+++ b/vm/src/tests/pedersen_test.rs
@@ -1,10 +1,6 @@
 use crate::tests::run_program_with_trace;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
-
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn pedersen_integration_test() {
     let program_data = include_bytes!("../../../cairo_programs/pedersen_test.json");
     let expected_trace = [

--- a/vm/src/tests/skip_instruction_test.rs
+++ b/vm/src/tests/skip_instruction_test.rs
@@ -1,10 +1,6 @@
 use crate::tests::run_program_simple;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
-
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn skip_next_instruction_test() {
     let program_data = include_bytes!(
         "../../../cairo_programs/noretrocompat/test_skip_next_instruction.noretrocompat.json"

--- a/vm/src/tests/struct_test.rs
+++ b/vm/src/tests/struct_test.rs
@@ -1,10 +1,6 @@
 use crate::tests::run_program_with_trace;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
-
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn struct_integration_test() {
     let program_data = include_bytes!("../../../cairo_programs/struct.json");
     let expected_trace = [(1, 4, 4)];

--- a/vm/src/types/errors/program_errors.rs
+++ b/vm/src/types/errors/program_errors.rs
@@ -23,11 +23,7 @@ pub enum ProgramError {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn format_entrypoint_not_found_error() {
         let error = ProgramError::EntrypointNotFound(String::from("my_function"));
         let formatted_error = format!("{error}");

--- a/vm/src/types/exec_scope.rs
+++ b/vm/src/types/exec_scope.rs
@@ -197,18 +197,13 @@ mod tests {
     use felt::Felt252;
     use num_traits::One;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_execution_scopes() {
         let scopes = ExecutionScopes::new();
         assert_eq!(scopes.data.len(), 1);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_local_variables_test() {
         let var_name = String::from("a");
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2));
@@ -229,7 +224,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn enter_new_scope_test() {
         let var_name = String::from("a");
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2_i32));
@@ -272,7 +266,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn exit_scope_test() {
         let var_name = String::from("a");
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2));
@@ -309,7 +302,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn assign_local_variable_test() {
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2));
 
@@ -330,7 +322,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn re_assign_local_variable_test() {
         let var_name = String::from("a");
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2));
@@ -356,7 +347,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn delete_local_variable_test() {
         let var_name = String::from("a");
         let var_value: Box<dyn Any> = Box::new(Felt252::new(2));
@@ -379,7 +369,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn exit_main_scope_gives_error_test() {
         let mut scopes = ExecutionScopes::new();
 
@@ -387,7 +376,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_listu64_test() {
         let list_u64: Box<dyn Any> = Box::new(vec![20_u64, 18_u64]);
 
@@ -409,7 +397,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_u64_test() {
         let u64: Box<dyn Any> = Box::new(9_u64);
 
@@ -435,7 +422,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_mut_int_ref_test() {
         let bigint: Box<dyn Any> = Box::new(Felt252::new(12));
 
@@ -449,7 +435,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_any_boxed_test() {
         let list_u64: Box<dyn Any> = Box::new(vec![20_u64, 18_u64]);
 

--- a/vm/src/types/instance_definitions/bitwise_instance_def.rs
+++ b/vm/src/types/instance_definitions/bitwise_instance_def.rs
@@ -35,25 +35,19 @@ impl BitwiseInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = BitwiseInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = BitwiseInstanceDef::default();
         assert_eq!(builtin_instance._cells_per_builtin(), 5);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = BitwiseInstanceDef {
             ratio: Some(8),
@@ -63,7 +57,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = BitwiseInstanceDef {
             ratio: Some(256),

--- a/vm/src/types/instance_definitions/builtins_instance_def.rs
+++ b/vm/src/types/instance_definitions/builtins_instance_def.rs
@@ -153,11 +153,7 @@ impl BuiltinsInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_plain() {
         let builtins = BuiltinsInstanceDef::plain();
         assert!(!builtins.output);
@@ -171,7 +167,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_small() {
         let builtins = BuiltinsInstanceDef::small();
         assert!(builtins.output);
@@ -185,7 +180,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_dex() {
         let builtins = BuiltinsInstanceDef::dex();
         assert!(builtins.output);
@@ -199,7 +193,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_recursive() {
         let builtins = BuiltinsInstanceDef::recursive();
         assert!(builtins.output);

--- a/vm/src/types/instance_definitions/cpu_instance_def.rs
+++ b/vm/src/types/instance_definitions/cpu_instance_def.rs
@@ -13,11 +13,7 @@ impl CpuInstanceDef {
 mod tests {
     use super::CpuInstanceDef;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let cpu_instance = CpuInstanceDef::default();
         assert!(cpu_instance._safe_call)

--- a/vm/src/types/instance_definitions/diluted_pool_instance_def.rs
+++ b/vm/src/types/instance_definitions/diluted_pool_instance_def.rs
@@ -27,11 +27,7 @@ impl DilutedPoolInstanceDef {
 mod tests {
     use super::DilutedPoolInstanceDef;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let diluted_pool = DilutedPoolInstanceDef::default();
         assert_eq!(diluted_pool.units_per_step, 16);
@@ -40,7 +36,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let diluted_pool = DilutedPoolInstanceDef::new(1, 1, 1);
         assert_eq!(diluted_pool.units_per_step, 1);

--- a/vm/src/types/instance_definitions/ec_op_instance_def.rs
+++ b/vm/src/types/instance_definitions/ec_op_instance_def.rs
@@ -38,25 +38,19 @@ impl EcOpInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = EcOpInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = EcOpInstanceDef::default();
         assert_eq!(builtin_instance._cells_per_builtin(), 7);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = EcOpInstanceDef {
             ratio: Some(8),
@@ -67,7 +61,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = EcOpInstanceDef {
             ratio: Some(256),

--- a/vm/src/types/instance_definitions/ecdsa_instance_def.rs
+++ b/vm/src/types/instance_definitions/ecdsa_instance_def.rs
@@ -41,25 +41,19 @@ impl EcdsaInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = EcdsaInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = EcdsaInstanceDef::default();
         assert_eq!(builtin_instance._cells_per_builtin(), 2);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = EcdsaInstanceDef {
             ratio: Some(8),
@@ -71,7 +65,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = EcdsaInstanceDef {
             ratio: Some(512),

--- a/vm/src/types/instance_definitions/keccak_instance_def.rs
+++ b/vm/src/types/instance_definitions/keccak_instance_def.rs
@@ -40,25 +40,19 @@ impl KeccakInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = KeccakInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = KeccakInstanceDef::default();
         assert_eq!(builtin_instance.cells_per_builtin(), 16);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = KeccakInstanceDef {
             ratio: Some(2048),
@@ -72,7 +66,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = KeccakInstanceDef {
             ratio: Some(2048),

--- a/vm/src/types/instance_definitions/pedersen_instance_def.rs
+++ b/vm/src/types/instance_definitions/pedersen_instance_def.rs
@@ -49,25 +49,19 @@ impl PedersenInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = PedersenInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = PedersenInstanceDef::default();
         assert_eq!(builtin_instance._cells_per_builtin(), 3);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = PedersenInstanceDef {
             ratio: Some(10),
@@ -81,7 +75,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = PedersenInstanceDef {
             ratio: Some(8),

--- a/vm/src/types/instance_definitions/range_check_instance_def.rs
+++ b/vm/src/types/instance_definitions/range_check_instance_def.rs
@@ -31,25 +31,19 @@ impl RangeCheckInstanceDef {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_units_per_builtin() {
         let builtin_instance = RangeCheckInstanceDef::default();
         assert_eq!(builtin_instance._range_check_units_per_builtin(), 8);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_builtin() {
         let builtin_instance = RangeCheckInstanceDef::default();
         assert_eq!(builtin_instance._cells_per_builtin(), 1);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let builtin_instance = RangeCheckInstanceDef {
             ratio: Some(10),
@@ -59,7 +53,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
         let builtin_instance = RangeCheckInstanceDef {
             ratio: Some(8),

--- a/vm/src/types/instruction.rs
+++ b/vm/src/types/instruction.rs
@@ -102,32 +102,25 @@ pub(crate) fn is_call_instruction(encoded_instruction: &Felt252) -> bool {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_call_instruction_true() {
         let encoded_instruction = Felt252::new(1226245742482522112_i64);
         assert!(is_call_instruction(&encoded_instruction));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_call_instruction_false() {
         let encoded_instruction = Felt252::new(4612671187288031229_i64);
         assert!(!is_call_instruction(&encoded_instruction));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_call_instruction_invalid() {
         let encoded_instruction = Felt252::new(1u64 << 63);
         assert!(!is_call_instruction(&encoded_instruction));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn instruction_size() {
         let encoded_instruction = Felt252::new(1226245742482522112_i64);
         let instruction = decode_instruction(encoded_instruction.to_u64().unwrap()).unwrap();

--- a/vm/src/types/layout.rs
+++ b/vm/src/types/layout.rs
@@ -166,11 +166,7 @@ impl CairoLayout {
 mod tests {
     use super::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_plain_instance() {
         let layout = CairoLayout::plain_instance();
         let builtins = BuiltinsInstanceDef::plain();
@@ -186,7 +182,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_small_instance() {
         let layout = CairoLayout::small_instance();
         let builtins = BuiltinsInstanceDef::small();
@@ -202,7 +197,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_dex_instance() {
         let layout = CairoLayout::dex_instance();
         let builtins = BuiltinsInstanceDef::dex();

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -231,11 +231,7 @@ mod tests {
     use felt::felt_str;
     use num_traits::Zero;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn new() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -270,7 +266,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn new_program_with_identifiers() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -339,14 +334,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_prime() {
         let program = Program::default();
         assert_eq!(PRIME_STR, program.prime());
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn iter_builtins() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -383,7 +376,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn iter_data() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -415,7 +407,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn data_len() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -447,7 +438,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_identifier() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -517,7 +507,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn iter_identifiers() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -581,7 +570,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn new_program_with_invalid_identifiers() {
         let reference_manager = ReferenceManager {
             references: Vec::new(),
@@ -639,7 +627,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_test() {
         let program = Program::from_bytes(
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json"),
@@ -723,7 +710,6 @@ mod tests {
 
     /// Deserialize a program without an entrypoint.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_without_entrypoint_test() {
         let program = Program::from_bytes(
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json"),
@@ -825,7 +811,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deserialize_program_constants_test() {
         let program = Program::from_bytes(
             include_bytes!(
@@ -866,7 +851,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn default_program() {
         let shared_program_data = SharedProgramData {
             data: Vec::new(),

--- a/vm/src/types/relocatable.rs
+++ b/vm/src/types/relocatable.rs
@@ -370,9 +370,6 @@ mod tests {
     use felt::felt_str;
     use num_traits::{One, Zero};
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[cfg(feature = "std")]
     use num_traits::Bounded;
 
@@ -411,7 +408,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_bigint_to_int() {
         let addr = MaybeRelocatable::from(Felt252::new(7i32));
         let added_addr = addr.add_int(&Felt252::new(2i32));
@@ -419,7 +415,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_usize_to_int() {
         let addr = MaybeRelocatable::from(Felt252::new(7_i32));
         let added_addr = addr.add_usize(2).unwrap();
@@ -427,7 +422,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_bigint_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
         let added_addr = addr.add_int(&Felt252::new(2));
@@ -441,7 +435,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_mod_offset_exceeded() {
         let addr = MaybeRelocatable::from((0, 0));
         let error = addr.add_int(&felt_str!("18446744073709551616"));
@@ -455,7 +448,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_usize_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
         let added_addr = addr.add_usize(2);
@@ -469,7 +461,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_bigint_to_int_prime_mod() {
         let addr = MaybeRelocatable::Int(felt_str!(
             "800000000000011000000000000000000000000000000000000000000000004",
@@ -480,7 +471,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_bigint_to_relocatable_prime() {
         let addr = MaybeRelocatable::from((1, 9));
         let added_addr = addr.add_int(&felt_str!(
@@ -496,7 +486,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_to_int() {
         let addr_a = &MaybeRelocatable::from(felt_str!(
             "3618502788666131213697322783095070105623107215331596699973092056135872020488"
@@ -507,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_relocatable_to_relocatable_should_fail() {
         let addr_a = &MaybeRelocatable::from((7, 5));
         let addr_b = &MaybeRelocatable::RelocatableValue(relocatable!(7, 10));
@@ -522,7 +510,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_to_relocatable() {
         let addr_a = &MaybeRelocatable::from((7, 7));
         let addr_b = &MaybeRelocatable::from(Felt252::new(10));
@@ -537,7 +524,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_relocatable_to_int() {
         let addr_a = &MaybeRelocatable::from(Felt252::new(10_i32));
         let addr_b = &MaybeRelocatable::RelocatableValue(relocatable!(7, 7));
@@ -552,7 +538,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_to_relocatable_prime() {
         let addr_a = &MaybeRelocatable::from((7, 14));
         let addr_b = &MaybeRelocatable::Int(felt_str!(
@@ -570,7 +555,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_rel_int_offset_exceeded() {
         let addr = MaybeRelocatable::from((0, 0));
         let error = addr.add(&MaybeRelocatable::from(felt_str!("18446744073709551616")));
@@ -584,7 +568,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_int_int_rel_offset_exceeded() {
         let addr = MaybeRelocatable::Int(felt_str!("18446744073709551616"));
         let relocatable = Relocatable {
@@ -602,7 +585,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_int_from_int() {
         let addr_a = &MaybeRelocatable::from(Felt252::new(7));
         let addr_b = &MaybeRelocatable::from(Felt252::new(5));
@@ -611,7 +593,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_relocatable_from_relocatable_same_offset() {
         let addr_a = &MaybeRelocatable::from((7, 17));
         let addr_b = &MaybeRelocatable::from((7, 7));
@@ -620,7 +601,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_relocatable_from_relocatable_diff_offset() {
         let addr_a = &MaybeRelocatable::from((7, 17));
         let addr_b = &MaybeRelocatable::from((8, 7));
@@ -635,7 +615,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_int_addr_ref_from_relocatable_addr_ref() {
         let addr_a = &MaybeRelocatable::from((7, 17));
         let addr_b = &MaybeRelocatable::from(Felt252::new(5_i32));
@@ -644,7 +623,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_rel_to_int_error() {
         assert_eq!(
             MaybeRelocatable::from(Felt252::new(7_i32)).sub(&MaybeRelocatable::from((7, 10))),
@@ -656,7 +634,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn divmod_working() {
         let value = &MaybeRelocatable::from(Felt252::new(10));
         let div = &MaybeRelocatable::from(Felt252::new(3));
@@ -669,7 +646,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn divmod_bad_type() {
         let value = &MaybeRelocatable::from(Felt252::new(10));
         let div = &MaybeRelocatable::from((2, 7));
@@ -683,7 +659,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_relocatable_value() {
         let value = MaybeRelocatable::from((2, 7));
         let relocation_table = vec![1, 2, 5];
@@ -694,7 +669,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_relocatable_in_temp_segment_value() {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
@@ -705,7 +679,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_relocatable_in_temp_segment_value_with_offset() {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
@@ -716,7 +689,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_relocatable_in_temp_segment_value_error() {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
@@ -727,7 +699,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_int_value() {
         let value = MaybeRelocatable::from(Felt252::new(7));
         let relocation_table = vec![1, 2, 5];
@@ -738,7 +709,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_relocatable_value_no_relocation() {
         let value = MaybeRelocatable::from((2, 7));
         let relocation_table = vec![1, 2];
@@ -749,7 +719,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocatable_add_int() {
         assert_eq!(
             relocatable!(1, 2) + &Felt252::new(4),
@@ -762,7 +731,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocatable_add_int_mod_offset_exceeded_error() {
         assert_eq!(
             relocatable!(0, 0) + &(Felt252::new(usize::MAX) + 1_usize),
@@ -774,7 +742,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocatable_add_i32() {
         let reloc = relocatable!(1, 5);
 
@@ -796,7 +763,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn mayberelocatable_try_into_reloctable() {
         let address = mayberelocatable!(1, 2);
         assert_eq!(Ok(relocatable!(1, 2)), address.try_into());
@@ -807,7 +773,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocatable_sub_rel_test() {
         let reloc = relocatable!(7, 6);
         assert_eq!(reloc - relocatable!(7, 5), Ok(1));
@@ -821,7 +786,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sub_rel_different_indexes() {
         let a = relocatable!(7, 6);
         let b = relocatable!(8, 6);
@@ -832,7 +796,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_maybe_mod_ok() {
         assert_eq!(
             relocatable!(1, 0) + &mayberelocatable!(2),
@@ -857,7 +820,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_maybe_mod_add_two_relocatable_error() {
         assert_eq!(
             relocatable!(1, 0) + &mayberelocatable!(1, 2),
@@ -869,7 +831,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_maybe_mod_offset_exceeded_error() {
         assert_eq!(
             relocatable!(1, 0) + &mayberelocatable!(usize::MAX as i128 + 1),
@@ -881,7 +842,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_relocatable_test() {
         assert_eq!(
             mayberelocatable!(1, 2).get_relocatable(),
@@ -891,7 +851,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocatable_display() {
         assert_eq!(
             format!("{}", Relocatable::from((1, 0))),
@@ -900,7 +859,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn maybe_relocatable_relocatable_display() {
         assert_eq!(
             format!("{}", MaybeRelocatable::from((1, 0))),
@@ -909,7 +867,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn maybe_relocatable_int_display() {
         assert_eq!(
             format!("{}", MaybeRelocatable::from(Felt252::new(6))),

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -615,13 +615,9 @@ mod test {
     use felt::Felt252;
     use num_traits::One;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     use super::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memory_macro_test() {
         let mut memory = Memory::new();
         for _ in 0..2 {
@@ -641,7 +637,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_memory_macro_test() {
         let mut memory = Memory::new();
         for _ in 0..2 {
@@ -662,7 +657,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_memory_address_macro_test() {
         let mut memory = Memory::new();
         for _ in 0..2 {
@@ -684,7 +678,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn create_run_context() {
         let mut vm = vm!();
         run_context!(vm, 2, 6, 10);
@@ -695,7 +688,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn assert_trace() {
         let trace = vec![
             TraceEntry {
@@ -718,7 +710,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_non_continuous_ids_data() {
         let ids_data_macro = non_continuous_ids_data![("a", -2), ("", -6)];
         let ids_data_verbose = HashMap::from([
@@ -729,7 +720,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_hint_alloc() {
         let hint_code = "memory[ap] = segments.add()";
         let mut vm = vm!();
@@ -740,7 +730,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_scope_test_pass() {
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.assign_or_update_variable("a", any_box!(String::from("Hello")));
@@ -786,7 +775,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn scope_macro_test() {
         let scope_from_macro = scope![("a", Felt252::one())];
         let mut scope_verbose = ExecutionScopes::new();
@@ -800,7 +788,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_dictionary_pass() {
         let mut tracker = DictTracker::new_empty(relocatable!(2, 0));
         tracker.insert_value(
@@ -836,7 +823,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_dict_ptr_pass() {
         let tracker = DictTracker::new_empty(relocatable!(2, 0));
         let mut dict_manager = DictManager::new();
@@ -864,7 +850,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_macro() {
         let tracker = DictTracker::new_empty(relocatable!(2, 0));
         let mut dict_manager = DictManager::new();
@@ -878,7 +863,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn dict_manager_default_macro() {
         let tracker = DictTracker::new_default_dict(
             relocatable!(2, 0),
@@ -896,7 +880,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn data_vec_test() {
         let data = vec_data!((1), ((2, 2)), (("49128305", 10)), (("3b6f00a9", 16)));
         assert_eq!(data[0], mayberelocatable!(1));
@@ -905,7 +888,6 @@ mod test {
         assert_eq!(data[3], mayberelocatable!(997130409));
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn from_relocatable_to_indexes_test() {
         let reloc_1 = relocatable!(1, 5);
         let reloc_2 = relocatable!(0, 5);
@@ -916,7 +898,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn program_macro() {
         let shared_data = SharedProgramData {
             data: Vec::new(),
@@ -940,7 +921,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn program_macro_with_builtin() {
         let shared_data = SharedProgramData {
             data: Vec::new(),
@@ -965,7 +945,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn program_macro_custom_definition() {
         let shared_data = SharedProgramData {
             data: Vec::new(),

--- a/vm/src/vm/context/run_context.rs
+++ b/vm/src/vm/context/run_context.rs
@@ -108,11 +108,7 @@ mod tests {
     use assert_matches::assert_matches;
     use felt::Felt252;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_dst_addr_for_ap_register() {
         let instruction = Instruction {
             off0: 1,
@@ -140,7 +136,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_dst_addr_for_fp_register() {
         let instruction = Instruction {
             off0: 1,
@@ -169,7 +164,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op0_addr_for_ap_register() {
         let instruction = Instruction {
             off0: 1,
@@ -197,7 +191,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op0_addr_for_fp_register() {
         let instruction = Instruction {
             off0: 1,
@@ -225,7 +218,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_fp_op1_addr() {
         let instruction = Instruction {
             off0: 1,
@@ -253,7 +245,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_ap_op1_addr() {
         let instruction = Instruction {
             off0: 1,
@@ -281,7 +272,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_imm_op1_addr_correct_off2() {
         let instruction = Instruction {
             off0: 1,
@@ -309,7 +299,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_imm_op1_addr_incorrect_off2() {
         let instruction = Instruction {
             off0: 1,
@@ -340,7 +329,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_op0_op1_addr_with_op0() {
         let instruction = Instruction {
             off0: 1,
@@ -370,7 +358,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_with_no_relocatable_address() {
         let instruction = Instruction {
             off0: 1,
@@ -402,7 +389,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_op1_addr_for_op0_op1_addr_without_op0() {
         let instruction = Instruction {
             off0: 1,

--- a/vm/src/vm/decoding/decoder.rs
+++ b/vm/src/vm/decoding/decoder.rs
@@ -141,11 +141,7 @@ mod decoder_test {
     use crate::stdlib::string::ToString;
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn non_zero_high_bit() {
         let error = decode_instruction(0x94A7800080008000);
         assert_eq!(
@@ -155,7 +151,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn invalid_op1_reg() {
         let error = decode_instruction(0x294F800080008000);
         assert_matches!(error, Err(VirtualMachineError::InvalidOp1Reg(3)));
@@ -166,7 +161,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn invalid_pc_update() {
         let error = decode_instruction(0x29A8800080008000);
         assert_matches!(error, Err(VirtualMachineError::InvalidPcUpdate(3)));
@@ -174,7 +168,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn invalid_res_logic() {
         let error = decode_instruction(0x2968800080008000);
         assert_matches!(error, Err(VirtualMachineError::InvalidRes(3)));
@@ -182,7 +175,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn invalid_opcode() {
         let error = decode_instruction(0x3948800080008000);
         assert_matches!(error, Err(VirtualMachineError::InvalidOpcode(3)));
@@ -190,7 +182,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn invalid_ap_update() {
         let error = decode_instruction(0x2D48800080008000);
         assert_matches!(error, Err(VirtualMachineError::InvalidApUpdate(3)));
@@ -198,7 +189,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_call_add_jmp_add_imm_fp_fp() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
@@ -217,7 +207,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_ret_add1_jmp_rel_mul_fp_ap_ap() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
@@ -236,7 +225,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add_jnz_mul_ap_ap_ap() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
@@ -255,7 +243,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add2_jnz_uncon_op0_ap_ap() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
@@ -274,7 +261,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_nop_regu_regu_op1_op0_ap_ap() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
@@ -293,7 +279,6 @@ mod decoder_test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_offset_negative() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -307,12 +307,8 @@ mod test {
     use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     use super::*;
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_vm_exception_from_vm_error() {
         let pc = 0;
         let location = Location {
@@ -345,7 +341,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_to_string_no_message() {
         let location = Location {
             end_line: 2,
@@ -365,7 +360,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_to_string_with_message() {
         let location = Location {
             end_line: 2,
@@ -385,7 +379,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn vm_exception_display_instruction_no_location_no_attributes() {
         let vm_excep = VmException {
             pc: 2,
@@ -410,7 +403,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn vm_exception_display_instruction_no_location_with_attributes() {
         let vm_excep = VmException {
             pc: 2,
@@ -435,7 +427,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn vm_exception_display_instruction_no_attributes_no_parent() {
         let location = Location {
             end_line: 2,
@@ -470,7 +461,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn vm_exception_display_instruction_no_attributes_with_parent() {
         let location = Location {
             end_line: 2,
@@ -514,7 +504,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_error_attr_value_some() {
         let attributes = vec![Attribute {
             name: String::from("Error message"),
@@ -533,7 +522,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_error_attr_value_none() {
         let attributes = vec![Attribute {
             name: String::from("Error message"),
@@ -549,7 +537,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_location_some() {
         let location = Location {
             end_line: 2,
@@ -572,7 +559,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_location_none() {
         let location = Location {
             end_line: 2,
@@ -595,7 +581,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_location_some_hint_index() {
         let location_a = Location {
             end_line: 2,
@@ -632,7 +617,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_traceback_bad_dict_update() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/bad_dict_update.json"),
@@ -666,7 +650,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_traceback_bad_usort() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/bad_usort.json"),
@@ -707,7 +690,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_to_string_with_contents_no_contents() {
         let location = Location {
             end_line: 2,
@@ -727,7 +709,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_to_string_with_contents() {
         let location = Location {
             end_line: 5,
@@ -753,7 +734,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_to_string_with_contents_no_file() {
         let location = Location {
             end_line: 5,
@@ -796,7 +776,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn location_get_location_marks_empty_file() {
         let location = Location {
             end_line: 5,
@@ -813,7 +792,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_bad_range_check_and_check_error_displayed() {
         #[cfg(feature = "std")]
         let expected_error_string = r#"Error message: Failed range-check
@@ -864,7 +842,6 @@ cairo_programs/bad_programs/bad_range_check.cairo:11:5: (pc=0:6)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_bad_usort_and_check_error_displayed() {
         #[cfg(feature = "std")]
         let expected_error_string = r#"cairo_programs/bad_programs/bad_usort.cairo:79:5: Error at pc=0:75:
@@ -909,7 +886,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_value_from_simple_reference_ap_based() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_tempvar.json"),
@@ -928,7 +904,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn substitute_error_message_references_ap_based() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_tempvar.json"),
@@ -950,7 +925,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_value_from_simple_reference_complex() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_struct.json"),
@@ -969,7 +943,6 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn substitute_error_message_references_complex() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_struct.json"),

--- a/vm/src/vm/runners/builtin_runner/bitwise.rs
+++ b/vm/src/vm/runners/builtin_runner/bitwise.rs
@@ -196,11 +196,7 @@ mod tests {
     };
     use felt::Felt252;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
 
@@ -219,7 +215,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
 
@@ -243,7 +238,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
 
@@ -271,7 +265,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_notincluded() {
         let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), false);
 
@@ -295,7 +288,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
 
@@ -319,7 +311,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true).into();
@@ -366,7 +357,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true).into();
@@ -411,7 +401,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_and() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -420,7 +409,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_xor() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 8), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -429,7 +417,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_or() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 9), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -438,7 +425,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_for_preset_memory_incorrect_offset() {
         let memory = memory![((0, 3), 10), ((0, 4), 12), ((0, 5), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -447,7 +433,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_for_preset_memory_no_values_to_operate() {
         let memory = memory![((0, 5), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -456,7 +441,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
 
@@ -464,7 +448,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -479,7 +462,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -492,7 +474,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -513,7 +494,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -528,7 +508,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -541,7 +520,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -554,7 +532,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_a() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -564,7 +541,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_b() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -574,7 +550,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_c() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),

--- a/vm/src/vm/runners/builtin_runner/ec_op.rs
+++ b/vm/src/vm/runners/builtin_runner/ec_op.rs
@@ -291,11 +291,7 @@ mod tests {
     use felt::felt_str;
     use EcOpBuiltinRunner;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true);
 
@@ -306,7 +302,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true);
 
@@ -330,7 +325,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true);
 
@@ -358,7 +352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_notincluded() {
         let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), false);
 
@@ -382,7 +375,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true);
 
@@ -406,7 +398,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true).into();
@@ -452,7 +443,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::new(Some(10)), true).into();
@@ -497,7 +487,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn point_is_on_curve_a() {
         let x = felt_str!(
             "874739451078007766457464989774322083649278607533249481151382481072868806602"
@@ -513,7 +502,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn point_is_on_curve_b() {
         let x = felt_str!(
             "3139037544796708144595053687182055617920475701120786241351436619796497072089"
@@ -529,7 +517,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn point_is_not_on_curve_a() {
         let x = felt_str!(
             "874739454078007766457464989774322083649278607533249481151382481072868806602"
@@ -545,7 +532,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn point_is_not_on_curve_b() {
         let x = felt_str!(
             "3139037544756708144595053687182055617927475701120786241351436619796497072089"
@@ -561,7 +547,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_ec_op_impl_valid_a() {
         let partial_sum = (
             felt_str!(
@@ -599,7 +584,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_ec_op_impl_valid_b() {
         let partial_sum = (
             felt_str!(
@@ -637,7 +621,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[allow(deprecated)]
     fn compute_ec_op_invalid_same_x_coordinate() {
         let partial_sum = (Felt252::one(), Felt252::new(9));
@@ -668,7 +651,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Data taken from this program execution:
        %builtins output ec_op
        from starkware.cairo.common.cairo_builtins import EcOpBuiltin
@@ -736,7 +718,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_ec_op_for_preset_memory_unfilled_input_cells() {
         let memory = memory![
             (
@@ -776,7 +757,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_ec_op_for_preset_memory_addr_not_an_output_cell() {
         let memory = memory![
             (
@@ -823,7 +803,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_ec_op_for_preset_memory_non_integer_input() {
         let memory = memory![
             (
@@ -868,7 +847,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
@@ -876,7 +854,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -889,7 +866,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -900,7 +876,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -919,7 +894,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -932,7 +906,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -943,7 +916,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -954,7 +926,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stackincluded_test() {
         let ec_op_builtin: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true).into();
@@ -962,14 +933,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stack_notincluded_test() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false);
         assert_eq!(ec_op_builtin.initial_stack(), Vec::new())
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn catch_point_same_x() {
         let program =
             include_bytes!("../../../../../cairo_programs/bad_programs/ec_op_same_x.json");
@@ -994,7 +963,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn catch_point_not_in_curve() {
         let program =
             include_bytes!("../../../../../cairo_programs/bad_programs/ec_op_not_in_curve.json");

--- a/vm/src/vm/runners/builtin_runner/hash.rs
+++ b/vm/src/vm/runners/builtin_runner/hash.rs
@@ -196,11 +196,7 @@ mod tests {
     };
     use felt::felt_str;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = HashBuiltinRunner::new(Some(10), true);
 
@@ -211,7 +207,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = HashBuiltinRunner::new(Some(10), true);
 
@@ -235,7 +230,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = HashBuiltinRunner::new(Some(10), true);
 
@@ -263,7 +257,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_not_included() {
         let mut builtin = HashBuiltinRunner::new(Some(10), false);
 
@@ -287,7 +280,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = HashBuiltinRunner::new(Some(10), true);
 
@@ -311,7 +303,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner = HashBuiltinRunner::new(Some(10), true).into();
 
@@ -357,7 +348,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner = HashBuiltinRunner::new(Some(10), true).into();
 
@@ -401,7 +391,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_pedersen_for_preset_memory_valid() {
         let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(Some(8), true);
@@ -420,7 +409,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_pedersen_for_preset_memory_incorrect_offset() {
         let memory = memory![((0, 4), 32), ((0, 5), 72), ((0, 6), 0)];
         let builtin = HashBuiltinRunner::new(Some(8), true);
@@ -429,7 +417,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_pedersen_for_preset_memory_no_values_to_hash() {
         let memory = memory![((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(Some(8), true);
@@ -438,7 +425,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_pedersen_for_preset_memory_already_computed() {
         let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let mut builtin = HashBuiltinRunner::new(Some(8), true);
@@ -448,7 +434,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = HashBuiltinRunner::new(Some(256), true);
 
@@ -456,7 +441,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let vm = vm!();
@@ -468,7 +452,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let mut vm = vm!();
@@ -478,7 +461,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let mut vm = vm!();
@@ -496,7 +478,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let vm = vm!();
@@ -508,7 +489,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let mut vm = vm!();
@@ -518,7 +498,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let mut vm = vm!();

--- a/vm/src/vm/runners/builtin_runner/keccak.rs
+++ b/vm/src/vm/runners/builtin_runner/keccak.rs
@@ -247,11 +247,7 @@ mod tests {
         vm_core::VirtualMachine,
     };
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true).into();
@@ -263,7 +259,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true);
@@ -288,7 +283,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true);
@@ -316,7 +310,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_not_included() {
         let mut builtin =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), false);
@@ -341,7 +334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true);
@@ -366,7 +358,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true).into();
@@ -397,7 +388,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(Some(10), vec![200; 8]), true).into();
@@ -409,7 +399,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
 
@@ -417,7 +406,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         let vm = vm!();
@@ -429,7 +417,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         let mut vm = vm!();
@@ -439,7 +426,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         let mut vm = vm!();
@@ -457,7 +443,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
@@ -470,7 +455,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
@@ -481,7 +465,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
@@ -492,7 +475,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stackincluded_test() {
         let keccak_builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         assert_eq!(
@@ -502,14 +484,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stack_notincluded_test() {
         let keccak_builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), false);
         assert_eq!(keccak_builtin.initial_stack(), Vec::new())
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_memory_valid() {
         let memory = memory![
             ((0, 16), 43),
@@ -549,7 +529,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_non_reloc_address_err() {
         let memory = memory![
             ((0, 4), 32),
@@ -564,7 +543,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_offset_lt_input_cell_length_none() {
         let memory = memory![((0, 4), 32)];
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
@@ -573,7 +551,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_expected_integer() {
         let memory = memory![((0, 0), (1, 2))];
 
@@ -594,7 +571,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_missing_input_cells() {
         let memory = memory![((0, 1), (1, 2))];
 
@@ -609,7 +585,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_input_cell() {
         let memory = memory![((0, 0), (1, 2))];
 
@@ -624,7 +599,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_get_memory_err() {
         let memory = memory![((0, 35), 0)];
 
@@ -636,7 +610,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_memory_int_larger_than_bits() {
         let memory = memory![
             ((0, 16), 43),
@@ -677,7 +650,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_result() {
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
 

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -564,11 +564,7 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -581,7 +577,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -592,7 +587,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -611,7 +605,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_bitwise() {
         let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = bitwise.clone().into();
@@ -619,7 +612,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_hash() {
         let hash = HashBuiltinRunner::new(Some(10), true);
         let builtin: BuiltinRunner = hash.clone().into();
@@ -627,7 +619,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_range_check() {
         let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
         let builtin: BuiltinRunner = range_check.clone().into();
@@ -635,7 +626,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_ec_op() {
         let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         let builtin: BuiltinRunner = ec_op.clone().into();
@@ -643,7 +633,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = signature.clone().into();
@@ -651,7 +640,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_output() {
         let output = OutputBuiltinRunner::new(true);
         let builtin: BuiltinRunner = output.into();
@@ -659,7 +647,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_bitwise() {
         let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = bitwise.clone().into();
@@ -667,7 +654,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_hash() {
         let hash = HashBuiltinRunner::new(Some(10), true);
         let builtin: BuiltinRunner = hash.clone().into();
@@ -675,7 +661,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_range_check() {
         let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
         let builtin: BuiltinRunner = range_check.clone().into();
@@ -683,7 +668,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_ec_op() {
         let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         let builtin: BuiltinRunner = ec_op.clone().into();
@@ -691,7 +675,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = signature.clone().into();
@@ -699,7 +682,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_output() {
         let output = OutputBuiltinRunner::new(true);
         let builtin: BuiltinRunner = output.into();
@@ -707,7 +689,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_keccak() {
         let keccak = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         let builtin: BuiltinRunner = keccak.clone().into();
@@ -715,7 +696,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_bitwise() {
         let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = bitwise.into();
@@ -723,7 +703,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_hash() {
         let hash = HashBuiltinRunner::new(Some(10), true);
         let builtin: BuiltinRunner = hash.into();
@@ -731,7 +710,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_range_check() {
         let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
         let builtin: BuiltinRunner = range_check.into();
@@ -739,7 +717,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_ec_op() {
         let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         let builtin: BuiltinRunner = ec_op.into();
@@ -747,7 +724,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(Some(10)), true);
         let builtin: BuiltinRunner = signature.into();
@@ -755,7 +731,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_output() {
         let output = OutputBuiltinRunner::new(true);
         let builtin: BuiltinRunner = output.into();
@@ -763,7 +738,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_bitwise_with_items() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::new(Some(10)),
@@ -810,7 +784,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_ec_op_with_items() {
         let builtin = BuiltinRunner::EcOp(EcOpBuiltinRunner::new(
             &EcOpInstanceDef::new(Some(10)),
@@ -857,7 +830,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_hash_with_items() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(10), true));
 
@@ -901,7 +873,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_range_check_with_items() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(10), 12, true));
 
@@ -945,7 +916,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_keccak_with_items() {
         let builtin = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
             &KeccakInstanceDef::new(Some(10), vec![200; 8]),
@@ -978,7 +948,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_output() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let vm = vm!();
@@ -988,7 +957,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_range_check() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
         let mut vm = vm!();
@@ -997,7 +965,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_hash() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(1), true));
         let mut vm = vm!();
@@ -1006,7 +973,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_bitwise() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1018,7 +984,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_ec_op() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -1028,7 +993,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_keccak() {
         let builtin = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
             &KeccakInstanceDef::default(),
@@ -1040,7 +1004,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_range_check() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
@@ -1048,7 +1011,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_output() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
@@ -1056,7 +1018,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_hash() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(256), true));
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
@@ -1064,7 +1025,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_ec_op() {
         let builtin =
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true));
@@ -1073,7 +1033,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_bitwise() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1084,7 +1043,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_bitwise() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1094,7 +1052,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_keccak_zero_case() {
         let builtin = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
             &KeccakInstanceDef::default(),
@@ -1104,7 +1061,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_keccak_non_zero_case() {
         let builtin = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
             &KeccakInstanceDef::default(),
@@ -1114,7 +1070,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_ec_op() {
         let builtin = BuiltinRunner::EcOp(EcOpBuiltinRunner::new(
             &EcOpInstanceDef::new(Some(10)),
@@ -1124,28 +1079,24 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_hash() {
         let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(Some(1), true));
         assert_eq!(builtin.get_used_diluted_check_units(270, 7), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_range_check() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
         assert_eq!(builtin.get_used_diluted_check_units(270, 7), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_output() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         assert_eq!(builtin.get_used_diluted_check_units(270, 7), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses_test() {
         let bitwise_builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -1166,7 +1117,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_for_output() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let vm = vm!();
@@ -1175,7 +1125,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_empty_memory() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1187,7 +1136,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_empty_offsets() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1201,7 +1149,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_bitwise_missing_memory_cells_with_offsets() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::default(),
@@ -1224,7 +1171,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_bitwise_missing_memory_cells() {
         let mut bitwise_builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
 
@@ -1252,7 +1198,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_hash_missing_memory_cells_with_offsets() {
         let builtin: BuiltinRunner = HashBuiltinRunner::new(Some(8), true).into();
         let mut vm = vm!();
@@ -1273,7 +1218,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_hash_missing_memory_cells() {
         let hash_builtin = HashBuiltinRunner::new(Some(8), true);
 
@@ -1292,7 +1236,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_missing_memory_cells_with_offsets() {
         let range_check_builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let builtin: BuiltinRunner = range_check_builtin.into();
@@ -1316,7 +1259,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_missing_memory_cells() {
         let builtin: BuiltinRunner =
             BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
@@ -1333,7 +1275,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_empty() {
         let range_check_builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
 
@@ -1347,7 +1288,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_validate_auto_deductions() {
         let builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -1370,7 +1310,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_ec_op_check_memory_empty() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
@@ -1384,7 +1323,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_ec_op_check_memory_1_element() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
@@ -1402,7 +1340,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_ec_op_check_memory_3_elements() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
@@ -1421,7 +1358,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_ec_op_missing_memory_cells_with_offsets() {
         let builtin: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true).into();
@@ -1444,7 +1380,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_ec_op_check_memory_gap() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
@@ -1477,7 +1412,6 @@ mod tests {
     /// Test that get_used_perm_range_check_units() returns zero when the
     /// builtin is a BitwiseBuiltinRunner.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_bitwise() {
         let builtin_runner: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -1491,7 +1425,6 @@ mod tests {
     /// Test that get_used_perm_range_check_units() returns zero when the
     /// builtin is an EcOpBuiltinRunner.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_ec_op() {
         let builtin_runner: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true).into();
@@ -1505,7 +1438,6 @@ mod tests {
     /// Test that get_used_perm_range_check_units() returns zero when the
     /// builtin is a HashBuiltinRunner.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_hash() {
         let builtin_runner: BuiltinRunner = HashBuiltinRunner::new(Some(8), true).into();
         let mut vm = vm!();
@@ -1518,7 +1450,6 @@ mod tests {
     /// Test that get_used_perm_range_check_units() returns zero when the
     /// builtin is an OutputBuiltinRunner.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_output() {
         let builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
         let mut vm = vm!();
@@ -1531,7 +1462,6 @@ mod tests {
     /// Test that get_used_perm_range_check_units() calls the corresponding
     /// method when the builtin is a RangeCheckBuiltinRunner.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_range_check() {
         let builtin_runner: BuiltinRunner = RangeCheckBuiltinRunner::new(Some(8), 8, true).into();
         let mut vm = vm!();
@@ -1542,7 +1472,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_ratio_tests() {
         let bitwise_builtin: BuiltinRunner =
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
@@ -1563,7 +1492,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn bitwise_get_used_instances_test() {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1574,7 +1502,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn ec_op_get_used_instances_test() {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1585,7 +1512,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn hash_get_used_instances_test() {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1595,7 +1521,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn output_get_used_instances_test() {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1604,7 +1529,6 @@ mod tests {
         assert_eq!(output_builtin.get_used_instances(&vm.segments), Ok(4));
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn range_check_get_used_instances_test() {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1615,7 +1539,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn runners_final_stack() {
         let mut builtins = vec![
             BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
@@ -1643,7 +1566,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn runners_set_stop_ptr() {
         let builtins = vec![
             BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(

--- a/vm/src/vm/runners/builtin_runner/output.rs
+++ b/vm/src/vm/runners/builtin_runner/output.rs
@@ -129,11 +129,7 @@ mod tests {
         },
     };
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = OutputBuiltinRunner::new(true);
 
@@ -144,7 +140,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = OutputBuiltinRunner::new(true);
 
@@ -168,7 +163,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = OutputBuiltinRunner::new(true);
 
@@ -196,7 +190,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_notincluded() {
         let mut builtin = OutputBuiltinRunner::new(false);
 
@@ -220,7 +213,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = OutputBuiltinRunner::new(true);
 
@@ -244,7 +236,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner = OutputBuiltinRunner::new(true).into();
 
@@ -259,7 +250,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin = OutputBuiltinRunner::new(true);
 
@@ -269,7 +259,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_for_output() {
         let mut builtin = OutputBuiltinRunner::new(true);
         let mut segments = MemorySegmentManager::new();
@@ -278,7 +267,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_stack_for_output_with_base() {
         let mut builtin = OutputBuiltinRunner::new(true);
         builtin.base = 1;
@@ -291,7 +279,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = OutputBuiltinRunner::new(true);
 
@@ -299,7 +286,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let vm = vm!();
@@ -311,7 +297,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -321,7 +306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -339,7 +323,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let vm = vm!();
@@ -351,7 +334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -361,7 +343,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -371,7 +352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_used_instances_missing_segments() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let memory_segment_manager = MemorySegmentManager::new();
@@ -383,7 +363,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_used_instances_valid() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut memory_segment_manager = MemorySegmentManager::new();
@@ -393,7 +372,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_deduce_memory_cell_output_builtin() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -416,7 +394,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_add_validation_rule() {
         let builtin = OutputBuiltinRunner::new(true);
         let mut vm = vm!();

--- a/vm/src/vm/runners/builtin_runner/poseidon.rs
+++ b/vm/src/vm/runners/builtin_runner/poseidon.rs
@@ -175,11 +175,8 @@ mod tests {
     use crate::vm::runners::cairo_runner::CairoRunner;
 
     use crate::vm::{runners::builtin_runner::BuiltinRunner, vm_core::VirtualMachine};
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = PoseidonBuiltinRunner::new(Some(10), true);
 
@@ -190,7 +187,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances_enum() {
         let builtin: BuiltinRunner = PoseidonBuiltinRunner::new(Some(10), true).into();
 
@@ -201,7 +197,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = PoseidonBuiltinRunner::new(Some(10), true);
 
@@ -225,7 +220,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = PoseidonBuiltinRunner::new(Some(10), true);
 
@@ -253,7 +247,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_not_included() {
         let mut builtin = PoseidonBuiltinRunner::new(Some(10), false);
 
@@ -277,7 +270,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = PoseidonBuiltinRunner::new(Some(10), true);
 
@@ -301,7 +293,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner = PoseidonBuiltinRunner::new(Some(10), true).into();
 
@@ -347,7 +338,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner = PoseidonBuiltinRunner::new(Some(10), true).into();
 
@@ -391,7 +381,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_missing_input_cells_ok() {
         let builtin = PoseidonBuiltinRunner::new(Some(10), false);
 

--- a/vm/src/vm/runners/builtin_runner/range_check.rs
+++ b/vm/src/vm/runners/builtin_runner/range_check.rs
@@ -212,11 +212,7 @@ mod tests {
         },
     };
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = RangeCheckBuiltinRunner::new(Some(10), 12, true);
 
@@ -227,7 +223,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(10), 12, true);
 
@@ -251,7 +246,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(10), 12, true);
 
@@ -279,7 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_when_notincluded() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(10), 12, false);
 
@@ -303,7 +296,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(10), 12, true);
 
@@ -329,7 +321,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(Some(10), 12, true).into();
 
@@ -375,7 +366,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(Some(10), 12, true).into();
 
@@ -419,7 +409,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_for_range_check() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let mut segments = MemorySegmentManager::new();
@@ -428,7 +417,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_stack_for_range_check_with_base() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         builtin.base = 1;
@@ -441,7 +429,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
 
@@ -449,7 +436,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let vm = vm!();
@@ -461,7 +447,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let mut vm = vm!();
@@ -471,7 +456,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let mut vm = vm!();
@@ -489,21 +473,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_base() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         assert_eq!(builtin.base(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_ratio() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         assert_eq!(builtin.ratio(), Some(8));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let vm = vm!();
@@ -515,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let mut vm = vm!();
@@ -525,7 +505,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(256), 8, true));
         let mut vm = vm!();
@@ -535,7 +514,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_succesful_a() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
@@ -543,7 +521,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_succesful_b() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let memory = memory![
@@ -556,7 +533,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_succesful_c() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let memory = memory![
@@ -571,7 +547,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_empty_memory() {
         let builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let memory = Memory::new();
@@ -580,7 +555,6 @@ mod tests {
 
     /// Test that the method get_used_perm_range_check_units works as intended.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units() {
         let builtin_runner: BuiltinRunner = RangeCheckBuiltinRunner::new(Some(8), 8, true).into();
         let mut vm = vm!();

--- a/vm/src/vm/runners/builtin_runner/segment_arena.rs
+++ b/vm/src/vm/runners/builtin_runner/segment_arena.rs
@@ -145,11 +145,8 @@ mod tests {
     use crate::stdlib::collections::HashMap;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*, vm::runners::builtin_runner::BuiltinRunner};
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_test() {
         let mut segments = MemorySegmentManager::new();
         let data = &[
@@ -163,7 +160,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin = SegmentArenaBuiltinRunner::new(true);
 
@@ -174,7 +170,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances_enum() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
 
@@ -185,7 +180,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = SegmentArenaBuiltinRunner::new(true);
 
@@ -212,7 +206,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_valid() {
         let mut builtin = SegmentArenaBuiltinRunner::new(false);
 
@@ -236,7 +229,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_valid_from_enum() {
         let mut builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(false).into();
 
@@ -260,7 +252,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = SegmentArenaBuiltinRunner::new(true);
 
@@ -286,7 +277,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
 
@@ -301,7 +291,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_for_output() {
         let mut builtin = SegmentArenaBuiltinRunner::new(true);
         let mut segments = MemorySegmentManager::new();
@@ -310,7 +299,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_stack_for_output_with_base() {
         let mut builtin = SegmentArenaBuiltinRunner::new(true);
         builtin.base = relocatable!(1, 0);
@@ -323,7 +311,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = SegmentArenaBuiltinRunner::new(true);
 
@@ -331,7 +318,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let vm = vm!();
@@ -340,7 +326,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -350,7 +335,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -360,7 +344,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let vm = vm!();
@@ -372,7 +355,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -385,7 +367,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -395,7 +376,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_used_instances_missing_segments() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let memory_segment_manager = MemorySegmentManager::new();
@@ -407,7 +387,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_used_instances_valid() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut memory_segment_manager = MemorySegmentManager::new();
@@ -417,7 +396,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_deduce_memory_cell_output_builtin() {
         let builtin = BuiltinRunner::SegmentArena(SegmentArenaBuiltinRunner::new(true));
         let mut vm = vm!();
@@ -438,7 +416,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_add_validation_rule() {
         let builtin = SegmentArenaBuiltinRunner::new(true);
         let mut vm = vm!();
@@ -446,21 +423,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stackincluded_test() {
         let ec_op_builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
         assert_eq!(ec_op_builtin.initial_stack(), vec![mayberelocatable!(0, 0)])
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stack_notincluded_test() {
         let ec_op_builtin = SegmentArenaBuiltinRunner::new(false);
         assert_eq!(ec_op_builtin.initial_stack(), Vec::new())
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_add_validation_rule_enum() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
         let mut vm = vm!();
@@ -477,21 +451,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cells_per_instance_enum() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
         assert_eq!(builtin.cells_per_instance(), ARENA_BUILTIN_SIZE)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn n_input_cells_enum() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
         assert_eq!(builtin.n_input_cells(), ARENA_BUILTIN_SIZE)
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn instances_per_component_enum() {
         let builtin: BuiltinRunner = SegmentArenaBuiltinRunner::new(true).into();
         assert_eq!(builtin.instances_per_component(), 1)

--- a/vm/src/vm/runners/builtin_runner/signature.rs
+++ b/vm/src/vm/runners/builtin_runner/signature.rs
@@ -231,9 +231,6 @@ mod tests {
         },
     };
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
     fn get_used_cells_and_allocated_size_valid() {
         let builtin: BuiltinRunner =
@@ -245,7 +242,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_for_ecdsa() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut segments = MemorySegmentManager::new();
@@ -254,7 +250,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_instances() {
         let builtin: BuiltinRunner =
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into();
@@ -266,7 +261,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -290,7 +284,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_stop_pointer() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -318,7 +311,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_error_non_relocatable() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -342,7 +334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_segment_addresses() {
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -350,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -365,7 +355,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses_empty() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -378,7 +367,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_accesses() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -399,7 +387,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_missing_segment_used_sizes() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -414,7 +401,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_empty() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -427,7 +413,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells() {
         let builtin = BuiltinRunner::Signature(SignatureBuiltinRunner::new(
             &EcdsaInstanceDef::default(),
@@ -440,7 +425,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_stack_for_range_check_with_base() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         builtin.base = 1;
@@ -453,14 +437,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initial_stack_not_included_test() {
         let ecdsa_builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), false);
         assert_eq!(ecdsa_builtin.initial_stack(), Vec::new())
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_test() {
         let memory = Memory::new();
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
@@ -469,21 +451,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_ratio() {
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         assert_eq!(builtin.ratio(), Some(512));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_base() {
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         assert_eq!(builtin.base(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_memory_segment_addresses() {
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -491,7 +470,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell() {
         let memory = Memory::new();
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
@@ -500,7 +478,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_min_step_not_reached() {
         let builtin: BuiltinRunner =
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into();
@@ -518,7 +495,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_cells_and_allocated_size_insufficient_allocated() {
         let builtin: BuiltinRunner =
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into();
@@ -538,7 +514,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_invalid_stop_pointer() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut vm = vm!();
@@ -554,7 +529,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn final_stack_no_used_instances() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut vm = vm!();

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1225,11 +1225,7 @@ mod tests {
     use felt::felt_str;
     use num_traits::One;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_memory_usage_ok_case() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::range_check, BuiltinName::output];
@@ -1241,7 +1237,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_memory_usage_err_case() {
         let program = program!();
 
@@ -1265,7 +1260,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_builtins_with_disordered_builtins() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::range_check, BuiltinName::output];
@@ -1275,7 +1269,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn create_cairo_runner_with_ordered_but_missing_builtins() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output, BuiltinName::ecdsa];
@@ -1284,7 +1277,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_with_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1318,7 +1310,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_no_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1347,7 +1338,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_empty_data_and_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1368,7 +1358,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_some_data_empty_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(
@@ -1391,7 +1380,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_empty_data_some_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1408,7 +1396,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_no_program_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1447,7 +1434,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_entrypoint_empty_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1469,7 +1455,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_entrypoint_some_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -1520,7 +1505,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_main_entrypoint() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(main = Some(1),);
@@ -1533,7 +1517,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_program_segment_accessed_addrs() {
         // This test checks that all addresses from the program segment are marked as accessed at VM state initialization.
         // The fibonacci program has 24 instructions, so there should be 24 accessed addresses,
@@ -1557,7 +1540,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_no_builtins() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(main = Some(1),);
@@ -1574,7 +1556,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_with_range_check_valid() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(builtins = vec![BuiltinName::range_check], main = Some(1),);
@@ -1603,7 +1584,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_with_range_check_invalid() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(builtins = vec![BuiltinName::range_check], main = Some(1),);
@@ -1627,7 +1607,6 @@ mod tests {
     //Integration tests for initialization phase
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     func myfunc(a: felt) -> (r: felt):
         let b = a * 2
@@ -1698,7 +1677,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins output
 
@@ -1776,7 +1754,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 
@@ -1871,7 +1848,6 @@ mod tests {
     //Integration tests for initialization + execution phase
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     func myfunc(a: felt) -> (r: felt):
         let b = a * 2
@@ -1935,7 +1911,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 
@@ -2036,7 +2011,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins output
 
@@ -2149,7 +2123,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins output range_check
 
@@ -2309,7 +2282,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Memory from this test is taken from a cairo program execution
     Program used:
         func main():
@@ -2403,7 +2375,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins output
 
@@ -2562,7 +2533,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins output
 
@@ -2730,7 +2700,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_output_from_preset_memory() {
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
@@ -2749,7 +2718,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins output
 
@@ -2807,7 +2775,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins output
 
@@ -2848,7 +2815,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_output_from_preset_memory_neg_output() {
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
@@ -2873,7 +2839,6 @@ mod tests {
 
     /// Test that `get_output()` works when the `output` builtin is not the first one.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_output_unordered_builtins() {
         //Initialization Phase
         let program = program!(
@@ -2934,7 +2899,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_all_builtins_in_order() {
         let program = program![
             BuiltinName::output,
@@ -2954,7 +2918,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 
@@ -3021,7 +2984,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 
@@ -3092,7 +3054,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 
@@ -3202,7 +3163,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_constants() {
         let program_constants = HashMap::from([
             ("MAX".to_string(), Felt252::new(300)),
@@ -3214,7 +3174,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_missing_segment_used_sizes() {
         let program = program!();
 
@@ -3232,7 +3191,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_empty() {
         let program = program!();
 
@@ -3245,7 +3203,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_empty_builtins() {
         let program = program!();
 
@@ -3260,7 +3217,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_empty_accesses() {
         let program = program!();
 
@@ -3278,7 +3234,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes() {
         let program = program!();
 
@@ -3300,7 +3255,6 @@ mod tests {
     /// Test that check_diluted_check_usage() works without a diluted pool
     /// instance.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_diluted_check_usage_without_pool_instance() {
         let program = program!();
 
@@ -3313,7 +3267,6 @@ mod tests {
 
     /// Test that check_diluted_check_usage() works without builtin runners.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_diluted_check_usage_without_builtin_runners() {
         let program = program!();
 
@@ -3328,7 +3281,6 @@ mod tests {
     /// Test that check_diluted_check_usage() fails when there aren't enough
     /// allocated units.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_diluted_check_usage_insufficient_allocated_cells() {
         let program = program!();
 
@@ -3348,7 +3300,6 @@ mod tests {
     /// Test that check_diluted_check_usage() succeeds when all the conditions
     /// are met.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_diluted_check_usage() {
         let program = program!();
 
@@ -3362,7 +3313,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn end_run_run_already_finished() {
         let program = program!();
 
@@ -3380,7 +3330,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn end_run() {
         let program = program!();
 
@@ -3403,7 +3352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn end_run_proof_mode_insufficient_allocated_cells() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json"),
@@ -3426,7 +3374,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtin_segments_info_empty() {
         let program = program!();
 
@@ -3437,7 +3384,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtin_segments_info_base_not_finished() {
         let program = program!();
 
@@ -3454,7 +3400,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_resources_trace_not_enabled() {
         let program = program!();
 
@@ -3474,7 +3419,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_resources_run_program() {
         let program_data = include_bytes!("../../../../cairo_programs/fibonacci.json");
         let cairo_run_config = CairoRunConfig {
@@ -3491,7 +3435,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_resources_run_program_no_trace() {
         let program_data = include_bytes!("../../../../cairo_programs/fibonacci.json");
         let cairo_run_config = CairoRunConfig {
@@ -3508,7 +3451,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_resources_empty_builtins() {
         let program = program!();
 
@@ -3528,7 +3470,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_resources() {
         let program = program!();
 
@@ -3557,7 +3498,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_not_ended() {
         let program = program!();
         let mut cairo_runner = cairo_runner!(program);
@@ -3569,7 +3509,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_empty_no_prog_base() {
         let program = program!();
         let mut cairo_runner = cairo_runner!(program);
@@ -3583,7 +3522,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_empty_no_exec_base() {
         let program = program!();
         let mut cairo_runner = cairo_runner!(program);
@@ -3598,7 +3536,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_empty_noproof_mode() {
         let program = program!();
         let mut cairo_runner = cairo_runner!(program);
@@ -3613,7 +3550,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_emptyproof_mode() {
         let program = program!();
         let mut cairo_runner = cairo_runner!(program, "plain", true);
@@ -3627,7 +3563,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_not_emptyproof_mode_empty_execution_public_memory() {
         let mut program = program!();
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -3661,7 +3596,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_segments_run_ended_not_emptyproof_mode_with_execution_public_memory() {
         let mut program = program!();
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -3702,7 +3636,6 @@ mod tests {
     /// Test that get_perm_range_check_limits() works correctly when there are
     /// no builtins.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_perm_range_check_limits_no_builtins() {
         let program = program!();
         let mut hint_processor = BuiltinHintProcessor::new(HashMap::new(), RunResources::default());
@@ -3732,7 +3665,6 @@ mod tests {
     /// Test that get_perm_range_check_limits() works correctly when there are
     /// builtins.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_perm_range_check_limits() {
         let program = program!();
 
@@ -3753,7 +3685,6 @@ mod tests {
     /// Test that check_range_check_usage() returns successfully when trace is
     /// not enabled.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_range_check_usage_perm_range_limits_none() {
         let program = program!();
 
@@ -3767,7 +3698,6 @@ mod tests {
     /// Test that check_range_check_usage() returns successfully when all the
     /// conditions are met.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_range_check_usage_without_builtins() {
         let program = program!();
 
@@ -3790,7 +3720,6 @@ mod tests {
     /// Test that check_range_check_usage() returns an error if there are
     /// insufficient allocated cells.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_range_check_usage_insufficient_allocated_cells() {
         let program = program!();
 
@@ -3816,7 +3745,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_fp_is_none_without_initialization() {
         let program = program!();
 
@@ -3826,7 +3754,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_fp_can_be_obtained() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
@@ -3845,7 +3772,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_used_cells_valid_case() {
         let program = program![BuiltinName::range_check, BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
@@ -3858,7 +3784,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_used_cells_get_used_cells_and_allocated_size_error() {
         let program = program!();
 
@@ -3883,7 +3808,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_used_cells_check_memory_usage_error() {
         let program = program!();
 
@@ -3909,7 +3833,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_used_cells_check_diluted_check_usage_error() {
         let program = program![BuiltinName::range_check, BuiltinName::output];
         let cairo_runner = cairo_runner!(program);
@@ -3926,7 +3849,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_all_builtins() {
         let program = program!();
 
@@ -3950,7 +3872,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_all_builtins_maintain_program_order() {
         let program = program![
             BuiltinName::pedersen,
@@ -3978,7 +3899,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_all_builtins_maintain_program_order_add_segment_arena() {
         let program = program![
             BuiltinName::pedersen,
@@ -4007,7 +3927,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_runner() {
         let program = program!();
 
@@ -4047,7 +3966,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_runner_add_segment_arena_builtin() {
         let program = program!();
 
@@ -4088,7 +4006,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_incorrect_layout_plain_one_builtin() {
         let program = program![BuiltinName::output];
         let mut vm = vm!();
@@ -4103,7 +4020,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_incorrect_layout_plain_two_builtins() {
         let program = program![BuiltinName::output, BuiltinName::pedersen];
         let mut vm = vm!();
@@ -4118,7 +4034,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_incorrect_layout_small_two_builtins() {
         let program = program![BuiltinName::output, BuiltinName::bitwise];
         let mut vm = vm!();
@@ -4132,7 +4047,6 @@ mod tests {
         );
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_main_entrypoint_proof_mode_empty_program() {
         let program = program!(start = Some(0), end = Some(0), main = Some(8),);
         let mut runner = cairo_runner!(program);
@@ -4151,7 +4065,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_main_entrypoint_proof_mode_empty_program_two_builtins() {
         let program = program!(
             start = Some(0),
@@ -4176,7 +4089,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn can_get_the_runner_program_builtins() {
         let program = program!(
             start = Some(0),
@@ -4190,7 +4102,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_default() {
         let program = program!(
             identifiers = [(
@@ -4217,7 +4128,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main() {
         let program = program!(
             identifiers = [
@@ -4258,7 +4168,6 @@ mod tests {
 
     /// Test that set_entrypoint() fails when the entrypoint doesn't exist.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_non_existent() {
         let program = program!(
             identifiers = [(
@@ -4285,7 +4194,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_test() {
         let mut program = program!();
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4309,7 +4217,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_test_with_run_not_ended() {
         let mut program = program!();
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4327,7 +4234,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_test_with_segments_finalized() {
         let mut program = program!();
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4346,7 +4252,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_updates_builtin_stop_ptr_one_builtin_empty() {
         let mut program = program![BuiltinName::output];
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4377,7 +4282,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_updates_builtin_stop_ptr_one_builtin_one_element() {
         let mut program = program![BuiltinName::output];
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4408,7 +4312,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn read_return_values_updates_builtin_stop_ptr_two_builtins() {
         let mut program = program![BuiltinName::output, BuiltinName::bitwise];
         Arc::get_mut(&mut program.shared_program_data).unwrap().data =
@@ -4453,7 +4356,6 @@ mod tests {
 
     /// Test that add_additional_hash_builtin() creates an additional builtin.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_additional_hash_builtin() {
         let program = program!();
         let cairo_runner = cairo_runner!(program);
@@ -4478,7 +4380,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_from_entrypoint_custom_program_test() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/example_program.json"),
@@ -4547,7 +4448,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_from_entrypoint_bitwise_test_check_memory_holes() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bitwise_builtin_test.json"),
@@ -4587,7 +4487,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_arg_from_single() {
         let expected = CairoArg::Single(MaybeRelocatable::from((0, 0)));
         let value = MaybeRelocatable::from((0, 0));
@@ -4595,7 +4494,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cairo_arg_from_array() {
         let expected = CairoArg::Array(vec![MaybeRelocatable::from((0, 0))]);
         let value = vec![MaybeRelocatable::from((0, 0))];
@@ -4625,7 +4523,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn execution_resources_add() {
         let (execution_resources_1, execution_resources_2) = setup_execution_resources();
         let combined_resources = &execution_resources_1 + &execution_resources_2;
@@ -4645,7 +4542,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn execution_resources_sub() {
         let (execution_resources_1, execution_resources_2) = setup_execution_resources();
 
@@ -4666,7 +4562,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_from_entrypoint_substitute_error_message_test() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_function.json"),
@@ -4710,7 +4605,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_final_stack_range_check_builtin() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/assert_le_felt_hint.json"),
@@ -4733,7 +4627,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_final_stack_4_builtins() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/integration.json"),
@@ -4756,7 +4649,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_builtins_final_stack_no_builtins() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
@@ -4779,7 +4671,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 
     fn filter_unused_builtins_test() {
         let program = Program::from_bytes(
@@ -4868,7 +4759,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_run_resources_none() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
@@ -4887,7 +4777,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_run_resources_ok() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
@@ -4908,7 +4797,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_run_resources_ok_2() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
@@ -4929,7 +4817,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_run_resources_error() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/fibonacci.json"),

--- a/vm/src/vm/security.rs
+++ b/vm/src/vm/security.rs
@@ -96,11 +96,7 @@ mod test {
     use felt::Felt252;
     use num_traits::Zero;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_without_program_base() {
         let program = program!();
 
@@ -114,7 +110,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_empty_memory() {
         let program = program!(main = Some(0),);
 
@@ -127,7 +122,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_program_access_out_of_bounds() {
         let program = program!(main = Some(0),);
 
@@ -146,7 +140,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_program_with_program_size() {
         let program = program!(main = Some(0),);
 
@@ -165,7 +158,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_builtin_access_out_of_bounds() {
         let program = program!(main = Some(0), builtins = vec![BuiltinName::range_check],);
 
@@ -183,7 +175,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_builtin_access_correct() {
         let program = program!(main = Some(0), builtins = vec![BuiltinName::range_check],);
 
@@ -203,7 +194,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_success() {
         let program = program!(
             data = vec![
@@ -231,7 +221,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_temporary_memory_properly_relocated() {
         let program = program!(
             data = vec![
@@ -259,7 +248,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_secure_runner_temporary_memory_not_fully_relocated() {
         let program = program!(
             data = vec![

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1153,11 +1153,7 @@ mod tests {
 
     use felt::felt_str;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_fp_ap_plus2() {
         let instruction = Instruction {
             off0: 1,
@@ -1190,7 +1186,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_fp_dst() {
         let instruction = Instruction {
             off0: 1,
@@ -1223,7 +1218,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_fp_regular() {
         let instruction = Instruction {
             off0: 1,
@@ -1256,7 +1250,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_fp_dst_num() {
         let instruction = Instruction {
             off0: 1,
@@ -1290,7 +1283,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_ap_add_with_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1326,7 +1318,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_ap_add_without_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1361,7 +1352,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_ap_add1() {
         let instruction = Instruction {
             off0: 1,
@@ -1397,7 +1387,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_ap_add2() {
         let instruction = Instruction {
             off0: 1,
@@ -1433,7 +1422,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_ap_regular() {
         let instruction = Instruction {
             off0: 1,
@@ -1469,7 +1457,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_regular_instruction_no_imm() {
         let instruction = Instruction {
             off0: 1,
@@ -1502,7 +1489,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_regular_instruction_has_imm() {
         let instruction = Instruction {
             off0: 1,
@@ -1535,7 +1521,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jump_with_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1568,7 +1553,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jump_without_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1603,7 +1587,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jump_rel_with_int_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1637,7 +1620,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jump_rel_without_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1669,7 +1651,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jump_rel_with_non_int_res() {
         let instruction = Instruction {
             off0: 1,
@@ -1700,7 +1681,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jnz_dst_is_zero() {
         let instruction = Instruction {
             off0: 1,
@@ -1733,7 +1713,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_pc_jnz_dst_is_not_zero() {
         let instruction = Instruction {
             off0: 1,
@@ -1766,7 +1745,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_registers_all_regular() {
         let instruction = Instruction {
             off0: 1,
@@ -1804,7 +1782,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn update_registers_mixed_types() {
         let instruction = Instruction {
             off0: 1,
@@ -1840,21 +1817,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_zero_int_value() {
         let value = MaybeRelocatable::Int(Felt252::new(1));
         assert!(!VirtualMachine::is_zero(&value));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_zero_relocatable_value() {
         let value = MaybeRelocatable::from((1, 2));
         assert!(!VirtualMachine::is_zero(&value));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_call() {
         let instruction = Instruction {
             off0: 1,
@@ -1882,7 +1856,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_assert_eq_res_add_with_optionals() {
         let instruction = Instruction {
             off0: 1,
@@ -1914,7 +1887,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_assert_eq_res_add_without_optionals() {
         let instruction = Instruction {
             off0: 1,
@@ -1941,7 +1913,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_assert_eq_res_mul_non_zero_op1() {
         let instruction = Instruction {
             off0: 1,
@@ -1973,7 +1944,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_assert_eq_res_mul_zero_op1() {
         let instruction = Instruction {
             off0: 1,
@@ -2002,7 +1972,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_assert_eq_res_op1() {
         let instruction = Instruction {
             off0: 1,
@@ -2031,7 +2000,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op0_opcode_ret() {
         let instruction = Instruction {
             off0: 1,
@@ -2061,7 +2029,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_call() {
         let instruction = Instruction {
             off0: 1,
@@ -2088,7 +2055,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_add_with_optionals() {
         let instruction = Instruction {
             off0: 1,
@@ -2119,7 +2085,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_add_without_optionals() {
         let instruction = Instruction {
             off0: 1,
@@ -2145,7 +2110,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_mul_non_zero_op0() {
         let instruction = Instruction {
             off0: 1,
@@ -2176,7 +2140,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_mul_zero_op0() {
         let instruction = Instruction {
             off0: 1,
@@ -2205,7 +2168,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_op1_without_dst() {
         let instruction = Instruction {
             off0: 1,
@@ -2233,7 +2195,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_op1_opcode_assert_eq_res_op1_with_dst() {
         let instruction = Instruction {
             off0: 1,
@@ -2263,7 +2224,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_res_op1() {
         let instruction = Instruction {
             off0: 1,
@@ -2292,7 +2252,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_res_add() {
         let instruction = Instruction {
             off0: 1,
@@ -2321,7 +2280,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_res_mul_int_operands() {
         let instruction = Instruction {
             off0: 1,
@@ -2350,7 +2308,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_res_mul_relocatable_values() {
         let instruction = Instruction {
             off0: 1,
@@ -2377,7 +2334,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_res_unconstrained() {
         let instruction = Instruction {
             off0: 1,
@@ -2404,7 +2360,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_dst_opcode_assert_eq_with_res() {
         let instruction = Instruction {
             off0: 1,
@@ -2430,7 +2385,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_dst_opcode_assert_eq_without_res() {
         let instruction = Instruction {
             off0: 1,
@@ -2452,7 +2406,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_dst_opcode_call() {
         let instruction = Instruction {
             off0: 1,
@@ -2477,7 +2430,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_dst_opcode_ret() {
         let instruction = Instruction {
             off0: 1,
@@ -2499,7 +2451,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_operands_add_ap() {
         let inst = Instruction {
             off0: 0,
@@ -2559,7 +2510,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_operands_mul_fp() {
         let inst = Instruction {
             off0: 0,
@@ -2618,7 +2568,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_jnz() {
         let instruction = Instruction {
             off0: 1,
@@ -2671,7 +2620,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_operands_deduce_dst_none() {
         let instruction = Instruction {
             off0: 2,
@@ -2696,7 +2644,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn opcode_assertions_res_unconstrained() {
         let instruction = Instruction {
             off0: 1,
@@ -2726,7 +2673,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn opcode_assertions_instruction_failed() {
         let instruction = Instruction {
             off0: 1,
@@ -2760,7 +2706,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn opcode_assertions_instruction_failed_relocatables() {
         let instruction = Instruction {
             off0: 1,
@@ -2792,7 +2737,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn opcode_assertions_inconsistent_op0() {
         let instruction = Instruction {
             off0: 1,
@@ -2825,7 +2769,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn opcode_assertions_inconsistent_dst() {
         let instruction = Instruction {
             off0: 1,
@@ -2857,7 +2800,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /// Test for a simple program execution
     /// Used program code:
     /// func main():
@@ -2911,7 +2853,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*
     Test for a simple program execution
     Used program code:
@@ -3020,7 +2961,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /// Test the following program:
     /// ...
     /// [ap] = 4
@@ -3131,14 +3071,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_no_pedersen_builtin() {
         let vm = vm!();
         assert_matches!(vm.deduce_memory_cell(Relocatable::from((0, 0))), Ok(None));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_pedersen_builtin_valid() {
         let mut vm = vm!();
         let builtin = HashBuiltinRunner::new(Some(8), true);
@@ -3153,7 +3091,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins output pedersen
     from starkware.cairo.common.cairo_builtins import HashBuiltin
@@ -3239,7 +3176,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_bitwise_builtin_valid_and() {
         let mut vm = vm!();
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
@@ -3252,7 +3188,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins bitwise
     from starkware.cairo.common.bitwise import bitwise_and
@@ -3318,7 +3253,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn deduce_memory_cell_ec_op_builtin_valid() {
         let mut vm = vm!();
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
@@ -3372,7 +3306,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Data taken from this program execution:
        %builtins output ec_op
        from starkware.cairo.common.cairo_builtins import EcOpBuiltin
@@ -3436,7 +3369,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn verify_auto_deductions_for_ec_op_builtin_valid_points_invalid_result() {
         let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         builtin.base = 3;
@@ -3496,7 +3428,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins bitwise
     from starkware.cairo.common.bitwise import bitwise_and
@@ -3519,7 +3450,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins bitwise
     from starkware.cairo.common.bitwise import bitwise_and
@@ -3549,7 +3479,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /* Program used:
     %builtins output pedersen
     from starkware.cairo.common.cairo_builtins import HashBuiltin
@@ -3583,7 +3512,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn can_get_return_values() {
         let mut vm = vm!();
         vm.set_ap(4);
@@ -3598,7 +3526,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_return_values_fails_when_ap_is_0() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
@@ -3629,7 +3556,6 @@ mod tests {
      */
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_step_for_preset_memory_with_alloc_hint() {
         let mut vm = vm!(true);
         let hint_data_dictionary = HashMap::from([(
@@ -3708,7 +3634,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_builtin_runners() {
         let mut vm = vm!();
         let hash_builtin = HashBuiltinRunner::new(Some(8), true);
@@ -3723,7 +3648,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn disable_trace() {
         let mut vm = VirtualMachine::new(true);
         assert!(vm.trace.is_some());
@@ -3732,7 +3656,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_for_continuous_memory() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
@@ -3750,7 +3673,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_for_non_continuous_memory() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
@@ -3769,7 +3691,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_continuous_range_for_continuous_memory() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
@@ -3786,7 +3707,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_continuous_range_for_non_continuous_memory() {
         let mut vm = vm!();
         vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
@@ -3798,7 +3718,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_used_size_after_computing_used() {
         let mut vm = vm!();
         vm.segments = segments![
@@ -3815,14 +3734,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_size_before_computing_used() {
         let vm = vm!();
         assert_eq!(None, vm.get_segment_size(2));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_size_before_computing_used_set_size() {
         let mut vm = vm!();
         vm.segments.segment_sizes.insert(2, 2);
@@ -3830,7 +3747,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_size_after_computing_used() {
         let mut vm = vm!();
         vm.segments = segments![
@@ -3847,14 +3763,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_used_size_before_computing_used() {
         let vm = vm!();
         assert_eq!(None, vm.get_segment_used_size(2));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_and_set_pc() {
         let mut vm = vm!();
         vm.set_pc(Relocatable {
@@ -3871,7 +3785,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_and_set_fp() {
         let mut vm = vm!();
         vm.set_fp(3);
@@ -3885,7 +3798,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_key_not_in_memory() {
         let vm = vm!();
         assert_eq!(
@@ -3898,7 +3810,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_maybe_error() {
         let vm = vm!();
         assert_eq!(
@@ -3908,7 +3819,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn end_run_error() {
         let mut vm = vm!();
         let scopes = exec_scopes_ref!();
@@ -3923,7 +3833,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_temporary_segments() {
         let mut vm = vm!();
         let mut _base = vm.add_temporary_segment();
@@ -3945,7 +3854,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_current_instruction_invalid_encoding() {
         let mut vm = vm!();
         vm.segments = segments![((0, 0), ("112233445566778899", 16))];
@@ -3956,7 +3864,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_relocation_rule_test() {
         let mut vm = vm!();
 
@@ -3983,7 +3890,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_relocatable() {
         let mut vm = vm!();
 
@@ -3996,7 +3902,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a bigint and no prime number just
     /// passes the value through.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_bigint() {
         let mut vm = vm!();
 
@@ -4009,7 +3914,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a bigint and a prime number passes
     /// the value through after applying the modulo.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_bigint_prime() {
         let mut vm = vm!();
         let prime = felt_str!(felt::PRIME_STR[2..], 16);
@@ -4021,7 +3925,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a Vec<MaybeRelocatable> writes its
     /// contents into a new segment and returns a pointer to it.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_vec() {
         let mut vm = vm!();
 
@@ -4042,7 +3945,6 @@ mod tests {
 
     /// Test that compute_effective_sizes() works as intended.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes() {
         let mut vm = vm!();
 
@@ -4063,7 +3965,6 @@ mod tests {
 
     /// Test that compute_segment_effective_sizes() works as intended.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_segment_effective_sizes() {
         let mut vm = vm!();
 
@@ -4083,7 +3984,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn mark_as_accessed() {
         let mut vm = vm!();
         vm.run_finished = true;
@@ -4121,7 +4021,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn mark_as_accessed_run_not_finished() {
         let mut vm = vm!();
         assert_matches!(
@@ -4131,7 +4030,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn mark_as_accessed_missing_accessed_addresses() {
         let mut vm = vm!();
         assert_matches!(
@@ -4141,7 +4039,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_traceback_entries_bad_usort() {
         let program = Program::from_bytes(
             include_bytes!("../../../cairo_programs/bad_programs/bad_usort.json"),
@@ -4166,7 +4063,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_traceback_entries_bad_dict_update() {
         let program = Program::from_bytes(
             include_bytes!("../../../cairo_programs/bad_programs/bad_dict_update.json"),

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -604,11 +604,7 @@ mod memory_tests {
     use crate::utils::test_utils::memory_from_memory;
     use crate::utils::test_utils::memory_inner;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_and_get_succesful() {
         let key = Relocatable::from((0, 0));
         let val = MaybeRelocatable::from(Felt252::new(5));
@@ -622,7 +618,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_valuef_from_temp_segment() {
         let mut memory = Memory::new();
         memory.temp_data = vec![vec![
@@ -637,7 +632,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_value_in_temp_segment() {
         let key = Relocatable::from((-1, 3));
         let val = MaybeRelocatable::from(Felt252::new(8));
@@ -651,7 +645,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_and_get_from_temp_segment_succesful() {
         let key = Relocatable::from((-1, 0));
         let val = MaybeRelocatable::from(Felt252::new(5));
@@ -665,7 +658,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_and_get_from_temp_segment_failed() {
         let key = relocatable!(-1, 1);
         let mut memory = Memory::new();
@@ -681,7 +673,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_non_allocated_memory() {
         let key = Relocatable::from((0, 0));
         let memory = Memory::new();
@@ -689,7 +680,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_non_existant_element() {
         let key = Relocatable::from((0, 0));
         let memory = Memory::new();
@@ -697,7 +687,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_non_allocated_memory() {
         let key = Relocatable::from((0, 0));
         let val = MaybeRelocatable::from(Felt252::new(5));
@@ -710,7 +699,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_inconsistent_memory() {
         let key = Relocatable::from((0, 0));
         let val_a = MaybeRelocatable::from(Felt252::new(5));
@@ -730,7 +718,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_non_contiguous_element() {
         let key_a = Relocatable::from((0, 0));
         let key_b = Relocatable::from((0, 2));
@@ -743,7 +730,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_non_contiguous_element_memory_gaps_none() {
         let key_a = Relocatable::from((0, 0));
         let key_b = Relocatable::from((0, 5));
@@ -760,7 +746,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_within_bounds() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let mut segments = MemorySegmentManager::new();
@@ -785,7 +770,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_outside_bounds() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let mut segments = MemorySegmentManager::new();
@@ -810,7 +794,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_invalid_signature() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut segments = MemorySegmentManager::new();
@@ -840,7 +823,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_valid_signature() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
@@ -878,7 +860,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_relocatable_value() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let mut segments = MemorySegmentManager::new();
@@ -895,7 +876,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_out_of_bounds_diff_segment() {
         let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
         let mut segments = MemorySegmentManager::new();
@@ -914,7 +894,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_valid() {
         let memory = memory![((0, 0), 10)];
         assert_eq!(
@@ -927,7 +906,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_integer_invalid_expected_integer() {
         let mut segments = MemorySegmentManager::new();
         segments.add();
@@ -944,14 +922,12 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn default_memory() {
         let mem: Memory = Default::default();
         assert_eq!(mem.data.len(), 0);
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn insert_and_get_temporary_succesful() {
         let mut memory = Memory::new();
         memory.temp_data.push(Vec::new());
@@ -964,7 +940,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_relocation_rule() {
         let mut memory = Memory::new();
 
@@ -991,7 +966,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_value_bigint() {
         let mut memory = Memory::new();
         memory
@@ -1009,7 +983,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_value_mayberelocatable() {
         let mut memory = Memory::new();
         memory
@@ -1031,7 +1004,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_value_mayberelocatable_temporary_segment_no_rules() {
         let mut memory = Memory::new();
         memory
@@ -1050,7 +1022,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_value_mayberelocatable_temporary_segment_rules() {
         let mut memory = Memory::new();
         memory
@@ -1081,7 +1052,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_for_continuous_memory() {
         let memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
 
@@ -1098,7 +1068,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_for_non_continuous_memory() {
         let memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
 
@@ -1116,7 +1085,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_continuous_range_for_continuous_memory() {
         let memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
 
@@ -1132,7 +1100,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_continuous_range_for_non_continuous_memory() {
         let memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
 
@@ -1144,7 +1111,6 @@ mod memory_tests {
 
     /// Test that relocate_memory() works when there are no relocation rules.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_empty_relocation_rules() {
         let mut memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3)];
 
@@ -1153,7 +1119,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_new_segment_with_gap() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1188,7 +1153,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_new_segment() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1224,7 +1188,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_new_segment_unallocated() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1248,7 +1211,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_into_existing_segment() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1283,7 +1245,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_into_existing_segment_inconsistent_memory() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1311,7 +1272,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_new_segment_2_temporary_segments_one_relocated() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1349,7 +1309,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_new_segment_2_temporary_segments_relocated() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1393,7 +1352,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_memory_display() {
         let memory = memory![
             ((0, 0), 1),
@@ -1413,7 +1371,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_memory_into_existing_segment_temporary_values_in_temporary_memory() {
         let mut memory = memory![
             ((0, 0), 1),
@@ -1447,7 +1404,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_address_with_rules() {
         let mut memory = Memory::new();
         memory
@@ -1468,7 +1424,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_address_no_rules() {
         let memory = Memory::new();
         assert_eq!(
@@ -1482,7 +1437,6 @@ mod memory_tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_address_real_addr() {
         let memory = Memory::new();
         assert_eq!(

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -247,11 +247,7 @@ mod tests {
     use felt::Felt252;
     use num_traits::Num;
 
-    #[cfg(target_arch = "wasm32")]
-    use wasm_bindgen_test::*;
-
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_segment_no_size() {
         let mut segments = MemorySegmentManager::new();
         let base = segments.add();
@@ -260,7 +256,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_segment_no_size_test_two_segments() {
         let mut segments = MemorySegmentManager::new();
         let mut _base = segments.add();
@@ -276,7 +271,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_one_temporary_segment() {
         let mut segments = MemorySegmentManager::new();
         let base = segments.add_temporary_segment();
@@ -285,7 +279,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn add_two_temporary_segments() {
         let mut segments = MemorySegmentManager::new();
         segments.add_temporary_segment();
@@ -301,7 +294,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn load_data_empty() {
         let data = Vec::new();
         let ptr = Relocatable::from((0, 3));
@@ -311,7 +303,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn load_data_one_element() {
         let data = vec![MaybeRelocatable::from(Felt252::new(4))];
         let ptr = Relocatable::from((0, 0));
@@ -326,7 +317,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn load_data_three_elements() {
         let data = vec![
             MaybeRelocatable::from(Felt252::new(4)),
@@ -361,7 +351,6 @@ mod tests {
         );
     }
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes_for_one_segment_memory() {
         let mut segments = segments![((0, 0), 1), ((0, 1), 1), ((0, 2), 1)];
         segments.compute_effective_sizes();
@@ -369,7 +358,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes_for_one_segment_memory_with_gap() {
         let mut segments = MemorySegmentManager::new();
         segments.add();
@@ -385,7 +373,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes_for_one_segment_memory_with_gaps() {
         let mut segments = segments![((0, 3), 1), ((0, 4), 1), ((0, 7), 1), ((0, 9), 1)];
         segments.compute_effective_sizes();
@@ -393,7 +380,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes_for_three_segment_memory() {
         let mut segments = segments![
             ((0, 0), 1),
@@ -411,7 +397,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn compute_effective_sizes_for_three_segment_memory_with_gaps() {
         let mut segments = segments![
             ((0, 2), 1),
@@ -427,7 +412,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_used_size_after_computing_used() {
         let mut segments = segments![
             ((0, 2), 1),
@@ -443,14 +427,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_segment_used_size_before_computing_used() {
         let segments = MemorySegmentManager::new();
         assert_eq!(None, segments.get_segment_used_size(2));
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_segments_one_segment() {
         let mut segments = MemorySegmentManager::new();
         segments.segment_used_sizes = Some(vec![3]);
@@ -463,7 +445,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn relocate_segments_five_segment() {
         let mut segments = MemorySegmentManager::new();
         segments.segment_used_sizes = Some(vec![3, 3, 56, 78, 8]);
@@ -476,7 +457,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_arg_with_apply_modulo() {
         let mut big_num = num_bigint::BigInt::from_str_radix(&felt::PRIME_STR[2..], 16)
             .expect("Couldn't parse prime");
@@ -503,7 +483,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn write_arg_relocatable() {
         let data = vec![
             Relocatable::from((0, 1)),
@@ -530,7 +509,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn segment_default() {
         let segment_mng_new = MemorySegmentManager::new();
         let segment_mng_def: MemorySegmentManager = Default::default();
@@ -545,7 +523,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_valid_memory_value_missing_effective_sizes() {
         let segment_manager = MemorySegmentManager::new();
 
@@ -556,7 +533,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_valid_memory_value_temporary_segment() {
         let mut segment_manager = MemorySegmentManager::new();
 
@@ -568,7 +544,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_valid_memory_value_invalid_segment() {
         let mut segment_manager = MemorySegmentManager::new();
 
@@ -580,7 +555,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_valid_memory_value() {
         let mut segment_manager = MemorySegmentManager::new();
 
@@ -592,7 +566,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_missing_segment_used_sizes() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.memory = memory![((0, 0), 0)];
@@ -606,7 +579,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_out_of_address_offset_bigger_than_size() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(vec![2]);
@@ -625,7 +597,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_empty() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(Vec::new());
@@ -633,7 +604,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes_empty2() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(vec![4]);
@@ -641,7 +611,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(vec![10]);
@@ -664,7 +633,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_holes2() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -689,7 +657,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_size_missing_segment() {
         let memory_segment_manager = MemorySegmentManager::new();
 
@@ -697,7 +664,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_size_used() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(vec![5]);
@@ -706,7 +672,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_size() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_sizes = HashMap::from([(0, 5)]);
@@ -715,7 +680,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_memory_size2() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_sizes = HashMap::from([(0, 5)]);
@@ -727,7 +691,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a relocatable just passes the
     /// value through.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -740,7 +703,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a bigint and no prime number just
     /// passes the value through.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_bigint() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -753,7 +715,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a Vec<MaybeRelocatable> writes its
     /// contents into a new segment and returns a pointer to it.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_vec() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -777,7 +738,6 @@ mod tests {
     /// Test that the call to .gen_arg() with a Vec<Relocatable> writes its
     /// contents into a new segment and returns a pointer to it.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_vec_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -797,7 +757,6 @@ mod tests {
     /// Test that the call to .gen_arg() with any other argument returns a not
     /// implemented error.
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_arg_invalid_type() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -808,7 +767,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_no_size_nor_memory_no_change() {
         let mut segments = MemorySegmentManager::new();
         segments.finalize(None, 0, None);
@@ -820,7 +778,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_no_memory() {
         let mut segments = MemorySegmentManager::new();
         segments.finalize(Some(42), 0, None);
@@ -829,7 +786,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_no_size() {
         let mut segments = MemorySegmentManager::new();
         segments.finalize(None, 0, Some(&vec![(1_usize, 2_usize)]));
@@ -841,7 +797,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn finalize_all_args() {
         let mut segments = MemorySegmentManager::new();
         segments.finalize(Some(42), 0, Some(&vec![(1_usize, 2_usize)]));
@@ -853,7 +808,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_cairo_arg_single() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -864,7 +818,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_cairo_arg_array() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
@@ -887,7 +840,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn gen_cairo_arg_composed() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         let cairo_args = CairoArg::Composed(vec![


### PR DESCRIPTION
# remove the wasm32 testing targe

## Description

I added the whole wasm-bingen, wasm32 testing target at the beginning of the no_std integration.
But with time it became more and more obvious to me that it is not needed. Everything that compiles in no_std always also compiles in wasm32.
On the other hand, it makes the code messier and adds a thrid round of tests in the CI which takes time and resources.

 I think we can safely get rid of it.