### PR TITLE
build(vm): remove thiserror form deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* build: remove dependecy to `thiserror` (use `thiserror-no-std/std` instead)
+
 * chore: use LambdaWorks' implementation of bit operations for `Felt252` [#1291](https://github.com/lambdaclass/cairo-rs/pull/1291)
 
 #### [0.8.0] - 2023-6-26
@@ -23,6 +25,7 @@
   * Remove argument `run_resources: &mut RunResources` from `CairoRunner::run_until_pc` & `CairoRunner::run_from_entrypoint`
 
 * build: remove unused implicit features from cairo-vm [#1266](https://github.com/lambdaclass/cairo-rs/pull/1266)
+
 
 #### [0.6.1] - 2023-6-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,6 @@ dependencies = [
  "sha2",
  "sha3",
  "starknet-crypto",
- "thiserror",
  "thiserror-no-std",
  "wasm-bindgen-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ generic-array = { version = "0.14.6", default-features = false }
 keccak = { version = "0.1.2", default-features = false }
 hashbrown = { version = "0.13.2", features = ["serde"] }
 anyhow = { version = "1.0.69", default-features = false }
-thiserror = { version = "1.0.32", default-features = false }
 thiserror-no-std = { version = "2.0.2", default-features = false }
 
 felt = { package = "cairo-felt", path = "./felt", version = "0.8.0", default-features = false, features = [

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -18,6 +18,7 @@ std = [
     "starknet-crypto/std",
     "felt/std",
     "dep:num-prime",
+    "thiserror-no-std/std",
 ]
 cairo-1-hints = ["dep:cairo-lang-starknet", "dep:cairo-lang-casm", "dep:ark-ff", "dep:ark-std"]
 lambdaworks-felt = [
@@ -53,7 +54,6 @@ generic-array = { workspace = true }
 keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 thiserror-no-std = { workspace = true }
 
 # only for std

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -12,9 +12,6 @@ use crate::{
 use bincode::enc::write::Writer;
 use felt::Felt252;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 pub struct CairoRunConfig<'a> {

--- a/vm/src/types/errors/math_errors.rs
+++ b/vm/src/types/errors/math_errors.rs
@@ -5,9 +5,6 @@ use crate::stdlib::boxed::Box;
 use felt::Felt252;
 use num_bigint::{BigInt, BigUint};
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};

--- a/vm/src/types/errors/program_errors.rs
+++ b/vm/src/types/errors/program_errors.rs
@@ -1,8 +1,5 @@
 use crate::stdlib::prelude::*;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use felt::PRIME_STR;

--- a/vm/src/vm/errors/cairo_run_errors.rs
+++ b/vm/src/vm/errors/cairo_run_errors.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use super::memory_errors::MemoryError;

--- a/vm/src/vm/errors/exec_scope_errors.rs
+++ b/vm/src/vm/errors/exec_scope_errors.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 #[derive(Eq, Hash, PartialEq, Debug, Error)]

--- a/vm/src/vm/errors/hint_errors.rs
+++ b/vm/src/vm/errors/hint_errors.rs
@@ -3,9 +3,6 @@
 
 use crate::stdlib::prelude::*;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use felt::Felt252;

--- a/vm/src/vm/errors/memory_errors.rs
+++ b/vm/src/vm/errors/memory_errors.rs
@@ -3,9 +3,6 @@
 
 use crate::stdlib::prelude::*;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use felt::Felt252;

--- a/vm/src/vm/errors/runner_errors.rs
+++ b/vm/src/vm/errors/runner_errors.rs
@@ -3,9 +3,6 @@
 
 use crate::stdlib::{collections::HashSet, prelude::*};
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use super::memory_errors::MemoryError;

--- a/vm/src/vm/errors/trace_errors.rs
+++ b/vm/src/vm/errors/trace_errors.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use crate::vm::errors::memory_errors::MemoryError;

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -3,9 +3,6 @@
 
 use crate::stdlib::prelude::*;
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use crate::{

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -4,9 +4,6 @@ use crate::stdlib::{
     str,
 };
 
-#[cfg(feature = "std")]
-use thiserror::Error;
-#[cfg(not(feature = "std"))]
 use thiserror_no_std::Error;
 
 use crate::{


### PR DESCRIPTION
# Remove dep to thiserror

## Description

Rather than alternating between thiserror and thiserror-no-std depending on the feature "std", we can use thiserror-no-std/std.

## Checklist
  - [x] CHANGELOG has been updated.

