### PR TITLE
bump version of starknet deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * chore: use LambdaWorks' implementation of bit operations for `Felt252` [#1291](https://github.com/lambdaclass/cairo-rs/pull/1291)
 
-* update `cairo-lang-starknet` and `cairo-lang-casm` dependencies to v2.0.0-rc5 [#1297](https://github.com/lambdaclass/cairo-vm/pull/1297)
+* update `cairo-lang-starknet` and `cairo-lang-casm` dependencies to v2.0.0-rc6 [#1299](https://github.com/lambdaclass/cairo-vm/pull/1299)
 
 #### [0.8.0] - 2023-6-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ thiserror-no-std = { version = "2.0.2", default-features = false }
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 
 # Dependencies for cairo-1-hints feature
-cairo-lang-starknet = { version = "2.0.0-rc5", default-features = false }
-cairo-lang-casm = { version = "2.0.0-rc5", default-features = false }
+cairo-lang-starknet = { version = "2.0.0-rc6", default-features = false }
+cairo-lang-casm = { version = "2.0.0-rc6", default-features = false }
 
 # TODO: check these dependencies for wasm compatibility
 ark-ff = { version = "0.4.0-alpha.7", default-features = false }


### PR DESCRIPTION
# bump version of starknet deps to v2.0.0-rc6

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

