### PR TITLE
fix: explicitly set resolver version in virtual manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: specify resolver version 2 in the virtual workspace's manifest [#1311](https://github.com/lambdaclass/cairo-vm/pull/1311)
+
 * chore: remove unused dependencies [#1307](https://github.com/lambdaclass/cairo-vm/pull/1307)
   * rand_core
   * serde_bytes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = ["cairo-vm-cli", "felt", "vm", "hint_accountant"]
 exclude = ["ensure-no_std"]
 
+# Explicitly set the resolver to the default for edition >= 2021
+# https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
+resolver = "2"
+
 [workspace.package]
 version = "0.8.1"
 edition = "2021"


### PR DESCRIPTION
Closes: #1260

## Description

The default for crates with edition >= 2021 is version 2 of the resolver. Virtual manifests, however, default to version 1.
When we moved the VM to its own directory, we unknowingly changed the resolver we used.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [X] CHANGELOG has been updated.

