### PR TITLE
fix: check all features on each crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,9 @@ jobs:
 
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+
     - name: Install cargo-all-features
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,7 +158,12 @@ jobs:
         key: cairo_1_test_contracts-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
 
     - name: Check all features
-      run: cargo check-all-features --workspace --all-targets
+      run: |
+        # NOTE: we do this separately because --workspace operates in weird ways
+        cargo check-all-features -p cairo-felt
+        cargo check-all-features -p cairo-vm
+        cargo check-all-features -p cairo-vm-cli
+        cargo check-all-features --workspace --all-targets
 
     - name: Check no-std
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,12 +157,25 @@ jobs:
           cairo_programs/**/*.json
         key: cairo_1_test_contracts-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
 
-    - name: Check all features
+    # NOTE: we do this separately because --workspace operates in weird ways
+    - name: Check all features (felt)
       run: |
-        # NOTE: we do this separately because --workspace operates in weird ways
-        cargo check-all-features -p cairo-felt
-        cargo check-all-features -p cairo-vm
-        cargo check-all-features -p cairo-vm-cli
+        cd felt
+        cargo check-all-features
+        cargo check-all-features --workspace --all-targets
+
+    - name: Check all features (vm)
+      run: |
+        cd vm
+        cargo check-all-features
+
+    - name: Check all features (CLI)
+      run: |
+        cd cairo-vm-cli
+        cargo check-all-features
+    
+    - name: Check all features (workspace)
+      run: |
         cargo check-all-features --workspace --all-targets
 
     - name: Check no-std

--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -955,13 +955,13 @@ impl FromPrimitive for Felt252 {
 
 impl fmt::Display for Felt252 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_str_radix(10))
+        write!(f, "{}", self.to_biguint().to_str_radix(10))
     }
 }
 
 impl fmt::Debug for Felt252 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_str_radix(10))
+        write!(f, "{}", self.to_biguint().to_str_radix(10))
     }
 }
 

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -23,11 +23,11 @@ use cairo_lang_casm::{
     operand::{CellRef, ResOperand},
 };
 use core::any::Any;
+use core::ops::Shl;
 
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::{cast::ToPrimitive, Zero};
-use std::ops::Shl;
 
 /// Execution scope for constant memory allocation.
 struct MemoryExecScope {
@@ -1066,7 +1066,7 @@ impl Cairo1HintProcessor {
         if let Some(root) = res.sqrt() {
             let root0: BigUint = root.into_bigint().into();
             let root1: BigUint = (-root).into_bigint().into();
-            let root = Felt252::from(std::cmp::min(root0, root1));
+            let root = Felt252::from(core::cmp::min(root0, root1));
             vm.insert_value(cell_ref_to_relocatable(sqrt, vm)?, root)
                 .map_err(HintError::from)
         } else {

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -767,17 +767,17 @@ impl Cairo1HintProcessor {
             .map_err(HintError::from)
     }
 
+    #[allow(unused_variables)]
     fn debug_print(
         &self,
         vm: &mut VirtualMachine,
         start: &ResOperand,
         end: &ResOperand,
     ) -> Result<(), HintError> {
-        let mut curr = as_relocatable(vm, start)?;
-        let end = as_relocatable(vm, end)?;
-
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "std")]
         {
+            let mut curr = as_relocatable(vm, start)?;
+            let end = as_relocatable(vm, end)?;
             while curr != end {
                 let value = vm.get_integer(curr)?;
                 if let Some(shortstring) = as_cairo_short_string(&value) {

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor_utils.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor_utils.rs
@@ -4,7 +4,7 @@ use crate::vm::errors::{hint_errors::HintError, vm_errors::VirtualMachineError};
 use crate::vm::vm_core::VirtualMachine;
 use cairo_lang_casm::operand::{CellRef, DerefOrImmediate, Operation, Register, ResOperand};
 use felt::Felt252;
-use num_traits::Zero;
+
 /// Extracts a parameter assumed to be a buffer.
 pub(crate) fn extract_buffer(buffer: &ResOperand) -> Result<(&CellRef, Felt252), HintError> {
     let (cell, base_offset) = match buffer {
@@ -58,6 +58,7 @@ pub(crate) fn get_ptr(
     Ok((vm.get_relocatable(cell_ref_to_relocatable(cell, vm)?)? + offset)?)
 }
 
+#[cfg(feature = "std")]
 pub(crate) fn as_relocatable(
     vm: &mut VirtualMachine,
     value: &ResOperand,
@@ -97,10 +98,15 @@ pub(crate) fn res_operand_get_val(
     }
 }
 
+#[cfg(feature = "std")]
 pub(crate) fn as_cairo_short_string(value: &Felt252) -> Option<String> {
     let mut as_string = String::default();
     let mut is_end = false;
-    for byte in value.to_be_bytes().into_iter().skip_while(Zero::is_zero) {
+    for byte in value
+        .to_be_bytes()
+        .into_iter()
+        .skip_while(num_traits::Zero::is_zero)
+    {
         if byte == 0 {
             is_end = true;
         } else if is_end || !byte.is_ascii() {


### PR DESCRIPTION
Closes: #1304

## Description

`cargo check-all-features` seems to compile crates while using their default features (noticed after running it with `--verbose` and no compiled dependencies). This results in no compile failures reported when running it even if one combination doesn't really work (for example, _cairo-felt_ without any features).

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

