### PR TITLE
Unpin sha minor versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* chore: unpin sha minor version [#1318](https://github.com/lambdaclass/cairo-vm/pull/1318)
+
 * feat: add dependency installation script `install.sh` [#1298](https://github.com/lambdaclass/cairo-vm/pull/1298)
 
 * fix: specify resolver version 2 in the virtual workspace's manifest [#1311](https://github.com/lambdaclass/cairo-vm/pull/1311)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ starknet-crypto = { version = "0.5.0", default-features = false, features = [
     "signature-display",
     "alloc",
 ] }
-sha3 = { version = "0.10.8", default-features = false }
+sha3 = { version = "0.10", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, features = [
     "spin_no_std",
 ] }
 nom = { version = "7", default-features = false }
-sha2 = { version = "0.10.7", features = ["compress"], default-features = false }
+sha2 = { version = "0.10", features = ["compress"], default-features = false }
 generic-array = { version = "0.14.7", default-features = false }
 keccak = { version = "0.1.2", default-features = false }
 hashbrown = { version = "0.14.0", features = ["serde"] }


### PR DESCRIPTION
# Unpin sha minor versions

## Description

Unpin sha's minor version so users of the library can use their own, and if they use another library with a pinned version, the conflict can be resolved