### PR TITLE
V0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Upcoming Changes
 
+#### [0.6.2] - 2023-7-12
+
+* fix: fix `UINT256_MUL_DIV_MOD` hint [#1320](https://github.com/lambdaclass/cairo-vm/pull/1320)
+
+
 #### [0.6.1] - 2023-6-23
 
 * fix: updated the `custom_hint_example` and added it to the workspace [#1258](https://github.com/lambdaclass/cairo-rs/pull/1258)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-felt"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -708,7 +708,7 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bitvec",
- "cairo-felt 0.6.1",
+ "cairo-felt 0.6.2",
  "cairo-lang-casm",
  "cairo-lang-starknet",
  "cairo-take_until_unbalanced",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1424,7 +1424,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cairo-vm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ thiserror-no-std = { version = "2.0.2", default-features = false }
 parse-hyperlinks = { package = "cairo-take_until_unbalanced", path = "./deps/parse-hyperlinks", version = "0.30.0", default-features = false, features = [
     "alloc",
 ] }
-felt = { package = "cairo-felt", path = "./felt", version = "0.6.1", default-features = false, features = [
+felt = { package = "cairo-felt", path = "./felt", version = "0.6.2", default-features = false, features = [
     "alloc",
 ] }
 bitvec = { version = "1", default-features = false, features = ["alloc"] }

--- a/cairo-vm-cli/Cargo.toml
+++ b/cairo-vm-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "cairo-vm-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [dependencies]
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }
-cairo-vm = { path = "../vm", version = "0.6.1" }
+cairo-vm = { path = "../vm", version = "0.6.2" }
 clap = { version = "3.2.5", features = ["derive"] }
 mimalloc = { version = "0.1.29", default-features = false, optional = true }
 nom = "7"

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-felt"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Field elements representation for the Cairo VM"

--- a/hint_accountant/Cargo.toml
+++ b/hint_accountant/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "hint_accountant"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A script to check which whitelisted hints we're missing"
 
 [dependencies]
-cairo-vm = { path = "../vm", version = "0.6.1" }
+cairo-vm = { path = "../vm", version = "0.6.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-vm"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Blazing fast Cairo interpreter"

--- a/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -435,10 +435,10 @@ pub fn uint256_mul_div_mod(
     let div_high = div_high.as_ref();
 
     // Main Logic
-    let a = a_high.shl(128_usize) + a_low;
-    let b = b_high.shl(128_usize) + b_low;
-    let div = div_high.shl(128_usize) + div_low;
-    let (quotient, remainder) = (a.to_biguint() * b.to_biguint()).div_mod_floor(&div.to_biguint());
+    let a = a_high.to_biguint().shl(128_usize) + a_low.to_biguint();
+    let b = b_high.to_biguint().shl(128_usize) + b_low.to_biguint();
+    let div = div_high.to_biguint().shl(128_usize) + div_low.to_biguint();
+    let (quotient, remainder) = (a * b).div_mod_floor(&div);
 
     // ids.quotient_low.low
     vm.insert_value(


### PR DESCRIPTION
# v0.6.2

## Description

- Bump version to 0.6.2 in all crates
- Cherry picks the uint256 bugfix from 0.8.2 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

