### PR TITLE
Add test for uint256_mul_div_mod possible overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,22 +205,22 @@ compare_benchmarks: $(COMPILED_BENCHES)
 	cd bench && ./run_benchmarks.sh
 
 compare_trace_memory: $(CAIRO_RS_TRACE) $(CAIRO_TRACE) $(CAIRO_RS_MEM) $(CAIRO_MEM)
-	cd src/tests; ./compare_vm_state.sh trace memory
+	cd vm/src/tests; ./compare_vm_state.sh trace memory
 
 compare_trace: $(CAIRO_RS_TRACE) $(CAIRO_TRACE)
-	cd src/tests; ./compare_vm_state.sh trace
+	cd vm/src/tests; ./compare_vm_state.sh trace
 
 compare_memory: $(CAIRO_RS_MEM) $(CAIRO_MEM)
-	cd src/tests; ./compare_vm_state.sh memory
+	cd vm/src/tests; ./compare_vm_state.sh memory
 
 compare_trace_memory_proof: $(COMPILED_PROOF_TESTS) $(CAIRO_RS_TRACE_PROOF) $(CAIRO_TRACE_PROOF) $(CAIRO_RS_MEM_PROOF) $(CAIRO_MEM_PROOF)
-	cd src/tests; ./compare_vm_state.sh trace memory proof_mode
+	cd vm/src/tests; ./compare_vm_state.sh trace memory proof_mode
 
 compare_trace_proof: $(CAIRO_RS_TRACE_PROOF) $(CAIRO_TRACE_PROOF)
-	cd src/tests; ./compare_vm_state.sh trace proof_mode
+	cd vm/src/tests; ./compare_vm_state.sh trace proof_mode
 
 compare_memory_proof: $(CAIRO_RS_MEM_PROOF) $(CAIRO_MEM_PROOF)
-	cd src/tests; ./compare_vm_state.sh memory proof_mode
+	cd vm/src/tests; ./compare_vm_state.sh memory proof_mode
 
 # Run with nightly enable the `doc_cfg` feature wich let us provide clear explaination about which parts of the code are behind a feature flag
 docs:

--- a/cairo_programs/uint256.cairo
+++ b/cairo_programs/uint256.cairo
@@ -84,6 +84,16 @@ func main{range_check_ptr: felt}() {
     assert b_quotient_high = Uint256(0, 0);
     assert b_remainder = Uint256(170141183460469231731687303715884105854, 1);
 
+    let (c_quotient_low, c_quotient_high, c_remainder) = uint256_mul_div_mod(
+        Uint256(340281070833283907490476236129005105807, 340282366920938463463374607431768211455),
+        Uint256(2447157533618445569039502, 0),
+        Uint256(0, 1),
+    );
+
+    assert c_quotient_low = Uint256(340282366920938463454053728725133866491, 2447157533618445569039501);
+    assert c_quotient_high = Uint256(0, 0);
+    assert c_remainder = Uint256(326588112914912836985603897252688572242, 0);
+
     let (mult_low_a, mult_high_a) = uint256_mul(Uint256(59, 2), Uint256(10, 0));
     assert mult_low_a = Uint256(590, 20);
     assert mult_high_a = Uint256(0, 0);

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -335,7 +335,7 @@ fn dict_update() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256() {
     let program_data = include_bytes!("../../../cairo_programs/uint256.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 3534);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 3554);
 }
 
 #[test]


### PR DESCRIPTION
# Add test for uint256_mul_div_mod possible overflow

## Description

* Test the bug fixed in the PR #1320 
* Fix Makefile: The path to the `vm/src/tests/compare_vm_state.sh` script was outdated

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

