### PR TITLE
refactor: change `bigint3_pack` uses for `BigInt3::pack86`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* refactor: remove private function `bigint3_pack` in favor of equivalent `BigInt3::pack86` method [#1329](https://github.com/lambdaclass/cairo-vm/pull/1329)
+
 * feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig`
 
 * perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 #### Upcoming Changes
 
-* refactor: remove private function `bigint3_pack` in favor of equivalent `BigInt3::pack86` method [#1329](https://github.com/lambdaclass/cairo-vm/pull/1329)
-
 * feat: updated the old WASM example and moved it to [`examples/wasm-demo`](examples/wasm-demo/) [#1315](https://github.com/lambdaclass/cairo-vm/pull/1315)
-
 
 * feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig`
 

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -167,8 +167,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cairo-felt"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
+ "arbitrary",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -178,9 +179,10 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bincode",
  "bitvec",
  "cairo-felt",
@@ -590,6 +592,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
+ "arbitrary",
  "autocfg",
  "num-integer",
  "num-traits",

--- a/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
@@ -1,7 +1,6 @@
 use num_integer::Integer;
 
 use super::secp::bigint_utils::BigInt3;
-use super::secp::secp_utils::bigint3_pack;
 use crate::stdlib::{collections::HashMap, prelude::*};
 use crate::{
     hint_processor::hint_processor_definition::HintReference,
@@ -29,9 +28,13 @@ pub fn ec_recover_divmod_n_packed(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let n = bigint3_pack(BigInt3::from_var_name("n", vm, ids_data, ap_tracking)?);
-    let x = bigint3_pack(BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?).mod_floor(&n);
-    let s = bigint3_pack(BigInt3::from_var_name("s", vm, ids_data, ap_tracking)?).mod_floor(&n);
+    let n = BigInt3::from_var_name("n", vm, ids_data, ap_tracking)?.pack86();
+    let x = BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?
+        .pack86()
+        .mod_floor(&n);
+    let s = BigInt3::from_var_name("s", vm, ids_data, ap_tracking)?
+        .pack86()
+        .mod_floor(&n);
 
     let value = div_mod(&x, &s, &n);
     exec_scopes.insert_value("value", value.clone());
@@ -55,8 +58,8 @@ pub fn ec_recover_sub_a_b(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let a = bigint3_pack(BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?);
-    let b = bigint3_pack(BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?);
+    let a = BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
+    let b = BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
 
     let value = a - b;
     exec_scopes.insert_value("value", value.clone());
@@ -83,9 +86,9 @@ pub fn ec_recover_product_mod(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let a = bigint3_pack(BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?);
-    let b = bigint3_pack(BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?);
-    let m = bigint3_pack(BigInt3::from_var_name("m", vm, ids_data, ap_tracking)?);
+    let a = BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
+    let b = BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
+    let m = BigInt3::from_var_name("m", vm, ids_data, ap_tracking)?.pack86();
 
     let product = a * b;
     let value = product.mod_floor(&m);

--- a/vm/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -82,7 +82,7 @@ pub fn unsafe_keccak(
         let word = vm.get_integer(word_addr)?;
         let n_bytes = cmp::min(16, u64_length - byte_i);
 
-        if word.is_negative() || word.as_ref() >= &(Felt252::one() << (8 * (n_bytes as u32))) {
+        if word.is_negative() || word.bits() > 8 * n_bytes {
             return Err(HintError::InvalidWordSize(Box::new(word.into_owned())));
         }
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::vm::vm_core::VirtualMachine;
 
     use assert_matches::assert_matches;
+    use felt::felt_str;
     use num_traits::One;
 
     #[cfg(target_arch = "wasm32")]
@@ -474,5 +475,31 @@ mod tests {
         assert!(run_hint!(vm, ids_data, hint_code, exec_scopes_ref!()).is_ok());
         //Check hint memory inserts
         check_memory![vm.segments.memory, ((1, 6), 0)];
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn u384_pack86() {
+        let pack_1 = Uint384 {
+            d0: Cow::Borrowed(&Felt252::new(10_i32)),
+            d1: Cow::Borrowed(&Felt252::new(10_i32)),
+            d2: Cow::Borrowed(&Felt252::new(10_i32)),
+        }
+        .pack86();
+        assert_eq!(
+            pack_1,
+            bigint_str!("59863107065073783529622931521771477038469668772249610")
+        );
+
+        let pack_2 = Uint384 {
+            d0: Cow::Borrowed(&felt_str!("773712524553362")),
+            d1: Cow::Borrowed(&felt_str!("57408430697461422066401280")),
+            d2: Cow::Borrowed(&felt_str!("1292469707114105")),
+        }
+        .pack86();
+        assert_eq!(
+            pack_2,
+            bigint_str!("7737125245533626718119526477371252455336267181195264773712524553362")
+        );
     }
 }

--- a/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -2,10 +2,7 @@ use crate::{
     hint_processor::{
         builtin_hint_processor::{
             hint_utils::{insert_value_from_var_name, insert_value_into_ap},
-            secp::{
-                bigint_utils::Uint384,
-                secp_utils::{bigint3_pack, SECP_P},
-            },
+            secp::{bigint_utils::Uint384, secp_utils::SECP_P},
         },
         hint_processor_definition::HintReference,
     },
@@ -38,7 +35,7 @@ pub fn verify_zero(
     secp_p: &BigInt,
 ) -> Result<(), HintError> {
     exec_scopes.insert_value("SECP_P", secp_p.clone());
-    let val = bigint3_pack(Uint384::from_var_name("val", vm, ids_data, ap_tracking)?);
+    let val = Uint384::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
     let (q, r) = val.div_rem(secp_p);
     if !r.is_zero() {
         return Err(HintError::SecpVerifyZero(Box::new(val)));
@@ -64,7 +61,7 @@ pub fn verify_zero_with_external_const(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let secp_p = exec_scopes.get_ref("SECP_P")?;
-    let val = bigint3_pack(Uint384::from_var_name("val", vm, ids_data, ap_tracking)?);
+    let val = Uint384::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
     let (q, r) = val.div_rem(secp_p);
     if !r.is_zero() {
         return Err(HintError::SecpVerifyZero(Box::new(val)));
@@ -88,7 +85,7 @@ pub fn reduce(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     exec_scopes.insert_value("SECP_P", SECP_P.clone());
-    let value = bigint3_pack(Uint384::from_var_name("x", vm, ids_data, ap_tracking)?);
+    let value = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
     exec_scopes.insert_value("value", value.mod_floor(&SECP_P));
     Ok(())
 }
@@ -108,7 +105,7 @@ pub fn is_zero_pack(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     exec_scopes.insert_value("SECP_P", SECP_P.clone());
-    let x_packed = bigint3_pack(Uint384::from_var_name("x", vm, ids_data, ap_tracking)?);
+    let x_packed = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
     let x = x_packed.mod_floor(&SECP_P);
     exec_scopes.insert_value("x", x);
     Ok(())
@@ -121,7 +118,7 @@ pub fn is_zero_pack_external_secp(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let secp_p = exec_scopes.get_ref("SECP_P")?;
-    let x_packed = bigint3_pack(Uint384::from_var_name("x", vm, ids_data, ap_tracking)?);
+    let x_packed = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
     let x = x_packed.mod_floor(secp_p);
     exec_scopes.insert_value("x", x);
     Ok(())

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -1,14 +1,12 @@
 use core::str::FromStr;
 
-use crate::stdlib::{boxed::Box, ops::Shl, prelude::*};
+use crate::stdlib::{boxed::Box, prelude::*};
 
 use crate::vm::errors::hint_errors::HintError;
 
 use lazy_static::lazy_static;
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
-
-use super::bigint_utils::Uint384;
 
 // Constants in package "starkware.cairo.common.cairo_secp.constants".
 pub const BASE_86: &str = "starkware.cairo.common.cairo_secp.constants.BASE";
@@ -89,28 +87,13 @@ pub fn bigint3_split(integer: &num_bigint::BigUint) -> Result<[num_bigint::BigUi
     Ok(canonical_repr)
 }
 
-/*
-Takes an UnreducedFelt2523 struct which represents a triple of limbs (d0, d1, d2) of field
-elements and reconstructs the corresponding 256-bit integer (see split()).
-Note that the limbs do not have to be in the range [0, BASE).
-*/
-pub(crate) fn bigint3_pack(num: Uint384) -> num_bigint::BigInt {
-    let limbs = [num.d0, num.d1, num.d2];
-    #[allow(deprecated)]
-    limbs
-        .into_iter()
-        .enumerate()
-        .map(|(idx, value)| value.to_signed_felt().shl(idx * 86))
-        .sum()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stdlib::{borrow::Cow, collections::HashMap, string::ToString};
+    use crate::stdlib::{collections::HashMap, string::ToString};
     use crate::utils::test_utils::*;
     use assert_matches::assert_matches;
-    use felt::{felt_str, Felt252};
+    use felt::Felt252;
     use num_bigint::BigUint;
 
     use num_traits::One;
@@ -182,30 +165,6 @@ mod tests {
                     .to_biguint()
                     .expect("Couldn't convert to BigUint")
 
-        );
-    }
-
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn secp_pack() {
-        let pack_1 = bigint3_pack(Uint384 {
-            d0: Cow::Borrowed(&Felt252::new(10_i32)),
-            d1: Cow::Borrowed(&Felt252::new(10_i32)),
-            d2: Cow::Borrowed(&Felt252::new(10_i32)),
-        });
-        assert_eq!(
-            pack_1,
-            bigint_str!("59863107065073783529622931521771477038469668772249610")
-        );
-
-        let pack_2 = bigint3_pack(Uint384 {
-            d0: Cow::Borrowed(&felt_str!("773712524553362")),
-            d1: Cow::Borrowed(&felt_str!("57408430697461422066401280")),
-            d2: Cow::Borrowed(&felt_str!("1292469707114105")),
-        });
-        assert_eq!(
-            pack_2,
-            bigint_str!("7737125245533626718119526477371252455336267181195264773712524553362")
         );
     }
 }

--- a/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -1,10 +1,7 @@
 use crate::{
     any_box,
     hint_processor::{
-        builtin_hint_processor::{
-            hint_utils::get_integer_from_var_name,
-            secp::secp_utils::{bigint3_pack, BETA},
-        },
+        builtin_hint_processor::{hint_utils::get_integer_from_var_name, secp::secp_utils::BETA},
         hint_processor_definition::HintReference,
     },
     math_utils::{div_mod, safe_div_bigint},
@@ -38,8 +35,8 @@ pub fn div_mod_n_packed(
     ap_tracking: &ApTracking,
     n: &BigInt,
 ) -> Result<(), HintError> {
-    let a = bigint3_pack(Uint384::from_var_name("a", vm, ids_data, ap_tracking)?);
-    let b = bigint3_pack(Uint384::from_var_name("b", vm, ids_data, ap_tracking)?);
+    let a = Uint384::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
+    let b = Uint384::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
 
     let value = div_mod(&a, &b, n);
     exec_scopes.insert_value("a", a);
@@ -118,7 +115,8 @@ pub fn get_point_from_x(
         .ok_or_else(|| HintError::MissingConstant(Box::new(BETA)))?
         .to_bigint();
 
-    let x_cube_int = bigint3_pack(Uint384::from_var_name("x_cube", vm, ids_data, ap_tracking)?)
+    let x_cube_int = Uint384::from_var_name("x_cube", vm, ids_data, ap_tracking)?
+        .pack86()
         .mod_floor(&SECP_P);
     let y_cube_int = (x_cube_int + beta).mod_floor(&SECP_P);
     // Divide by 4
@@ -147,8 +145,12 @@ pub fn pack_modn_div_modn(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let x = bigint3_pack(Uint384::from_var_name("x", vm, ids_data, ap_tracking)?).mod_floor(&N);
-    let s = bigint3_pack(Uint384::from_var_name("s", vm, ids_data, ap_tracking)?).mod_floor(&N);
+    let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?
+        .pack86()
+        .mod_floor(&N);
+    let s = Uint384::from_var_name("s", vm, ids_data, ap_tracking)?
+        .pack86()
+        .mod_floor(&N);
 
     let value = div_mod(&x, &s, &N);
     exec_scopes.insert_value("x", x);

--- a/vm/src/hint_processor/builtin_hint_processor/uint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint_utils.rs
@@ -2,18 +2,18 @@ use felt::Felt252;
 use num_bigint::BigUint;
 use num_traits::One;
 
-pub(crate) fn split<const T: usize>(num: &BigUint, num_bits_shift: u32) -> [Felt252; T] {
+pub(crate) fn split<const N: usize>(num: &BigUint, num_bits_shift: u32) -> [Felt252; N] {
     let mut num = num.clone();
     let bitmask = &((BigUint::one() << num_bits_shift) - 1_u32);
-    [0; T].map(|_| {
+    [0; N].map(|_| {
         let a = &num & bitmask;
         num >>= num_bits_shift;
         Felt252::from(a)
     })
 }
 
-pub(crate) fn pack<const T: usize>(
-    limbs: [impl AsRef<Felt252>; T],
+pub(crate) fn pack<const N: usize>(
+    limbs: [impl AsRef<Felt252>; N],
     num_bits_shift: usize,
 ) -> BigUint {
     limbs


### PR DESCRIPTION
## Description

This PR removes `bigint3_pack` in favor of `BigInt3::pack86`. Also changes a shift + comparison in `unsafe_keccak` for a call to `bits` and a comparison.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

