### PR TITLE
fix: add missing call to `initialize` in `cairo_run_parsed_program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig`
+* feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig` [#1306](https://github.com/lambdaclass/cairo-vm/pull/1306) [#1330](https://github.com/lambdaclass/cairo-vm/pull/1330)
 
 * perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig` [#1306](https://github.com/lambdaclass/cairo-vm/pull/1306) [#1330](https://github.com/lambdaclass/cairo-vm/pull/1330)
+* feat(fuzzing): add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig` [#1306](https://github.com/lambdaclass/cairo-vm/pull/1306) [#1330](https://github.com/lambdaclass/cairo-vm/pull/1330)
 
 * perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)
 
-
 #### [0.8.2] - 2023-7-10
 
 * chore: update dependencies, particularly lamdaworks 0.1.2 -> 0.1.3 [#1323](https://github.com/lambdaclass/cairo-vm/pull/1323)
@@ -14,7 +13,6 @@
 * fix: fix `UINT256_MUL_DIV_MOD` hint [#1320](https://github.com/lambdaclass/cairo-vm/pull/1320)
 
 * feat: add dependency installation script `install.sh` [#1298](https://github.com/lambdaclass/cairo-vm/pull/1298)
-
 
 * fix: specify resolver version 2 in the virtual workspace's manifest [#1311](https://github.com/lambdaclass/cairo-vm/pull/1311)
 

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -86,6 +86,8 @@ pub fn cairo_run_parsed_program(
     hint_executor: &mut dyn HintProcessor,
     steps_limit: usize,
 ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
+    use crate::vm::errors::vm_errors::VirtualMachineError;
+
     let secure_run = cairo_run_config
         .secure_run
         .unwrap_or(!cairo_run_config.proof_mode);
@@ -100,9 +102,13 @@ pub fn cairo_run_parsed_program(
 
     let _end = cairo_runner.initialize(&mut vm)?;
 
-    cairo_runner
-        .run_until_steps(steps_limit, &mut vm, hint_executor)
-        .map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
+    let res = match cairo_runner.run_until_steps(steps_limit, &mut vm, hint_executor) {
+        Err(VirtualMachineError::EndOfProgram(_remaining)) => Ok(()), // program ran OK but ended before steps limit
+        res => res,
+    };
+
+    res.map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
+
     cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 
     vm.verify_auto_deductions()?;

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -98,6 +98,8 @@ pub fn cairo_run_parsed_program(
 
     let mut vm = VirtualMachine::new(cairo_run_config.trace_enabled);
 
+    let _end = cairo_runner.initialize(&mut vm)?;
+
     cairo_runner
         .run_until_steps(steps_limit, &mut vm, hint_executor)
         .map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -3022,6 +3022,18 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_empty() {
+        let program = program!();
+        let mut cairo_runner = cairo_runner!(&program);
+        let mut vm = vm!(true);
+        assert_matches!(
+            cairo_runner.initialize(&mut vm),
+            Err(RunnerError::MissingMain)
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     /*Program used:
     %builtins range_check
 


### PR DESCRIPTION
## Description

This missing call meant passing an empty program would cause a _panic_. Also, now it ignores the error caused by reaching the program's end with steps remaining.

## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

