### PR TITLE
perf: change expensive usage of `ok_or` for `ok_or_else`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Upcoming Changes
 
-* feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig`
+* perf: changed `ok_or` usage for `ok_or_else` in expensive cases [#1332](https://github.com/lambdaclass/cairo-vm/pull/1332)
+
+* feat: add `arbitrary` feature to enable arbitrary derive in `Program` and `CairoRunConfig` [#1306](https://github.com/lambdaclass/cairo-vm/pull/1306)
 
 * perf: remove pointless iterator from rc limits tracking [#1316](https://github.com/lambdaclass/cairo-vm/pull/1316)
 

--- a/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -283,10 +283,9 @@ pub fn example_blake2s_compress(
     let blake2s_start = get_ptr_from_var_name("blake2s_start", vm, ids_data, ap_tracking)?;
     let output = get_ptr_from_var_name("output", vm, ids_data, ap_tracking)?;
     let n_bytes = get_integer_from_var_name("n_bytes", vm, ids_data, ap_tracking).map(|x| {
-        x.to_u32()
-            .ok_or(HintError::Math(MathError::Felt252ToU32Conversion(
-                Box::new(x.into_owned()),
-            )))
+        x.to_u32().ok_or_else(|| {
+            HintError::Math(MathError::Felt252ToU32Conversion(Box::new(x.into_owned())))
+        })
     })??;
 
     let message = get_fixed_size_u32_array::<16>(&vm.get_integer_range(blake2s_start, 16)?)?;

--- a/vm/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -232,10 +232,9 @@ pub fn split_n_bytes(
 ) -> Result<(), HintError> {
     let n_bytes =
         get_integer_from_var_name("n_bytes", vm, ids_data, ap_tracking).and_then(|x| {
-            x.to_u64()
-                .ok_or(HintError::Math(MathError::Felt252ToU64Conversion(
-                    Box::new(x.into_owned()),
-                )))
+            x.to_u64().ok_or_else(|| {
+                HintError::Math(MathError::Felt252ToU64Conversion(Box::new(x.into_owned())))
+            })
         })?;
     let bytes_in_word = constants
         .get(BYTES_IN_WORD)

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -56,13 +56,13 @@ impl DictManagerExecScope {
 
     /// Returns a reference for a dict tracker corresponding to a given pointer to a dict segment.
     fn get_dict_tracker(&self, dict_end: Relocatable) -> Result<&DictTrackerExecScope, HintError> {
-        self.trackers
-            .get(&dict_end.segment_index)
-            .ok_or(HintError::CustomHint(
+        self.trackers.get(&dict_end.segment_index).ok_or_else(|| {
+            HintError::CustomHint(
                 "The given value does not point to a known dictionary."
                     .to_string()
                     .into_boxed_str(),
-            ))
+            )
+        })
     }
 
     /// Returns a mut reference for a dict tracker corresponding to a given pointer to a dict
@@ -108,15 +108,12 @@ impl DictSquashExecScope {
     /// Removes the current key, and its access indices. Should be called when only the
     /// last key access is in the corresponding indices list.
     pub fn pop_current_key(&mut self) -> Result<(), HintError> {
-        let current_key = self.current_key().ok_or(HintError::CustomHint(
-            "Failed to get current key".to_string().into_boxed_str(),
-        ))?;
-        let key_accesses =
-            self.access_indices
-                .remove(&current_key)
-                .ok_or(HintError::CustomHint(
-                    format!("No key accesses for key {current_key}").into_boxed_str(),
-                ))?;
+        let current_key = self.current_key().ok_or_else(|| {
+            HintError::CustomHint("Failed to get current key".to_string().into_boxed_str())
+        })?;
+        let key_accesses = self.access_indices.remove(&current_key).ok_or_else(|| {
+            HintError::CustomHint(format!("No key accesses for key {current_key}").into_boxed_str())
+        })?;
         if !key_accesses.len().is_one() {
             return Err(HintError::CustomHint(
                 "Key popped but not all accesses were processed."

--- a/vm/src/vm/runners/builtin_runner/keccak.rs
+++ b/vm/src/vm/runners/builtin_runner/keccak.rs
@@ -84,17 +84,18 @@ impl KeccakBuiltinRunner {
         let mut input_felts = vec![];
 
         for i in 0..self.n_input_cells as usize {
-            let val = match memory.get(&(first_input_addr + i)?) {
+            let m_index = (first_input_addr + i)?;
+            let val = match memory.get(&m_index) {
                 Some(value) => {
-                    let num = value
-                        .get_int_ref()
-                        .ok_or(RunnerError::BuiltinExpectedInteger(Box::new((
+                    let num = value.get_int_ref().ok_or_else(|| {
+                        RunnerError::BuiltinExpectedInteger(Box::new((
                             KECCAK_BUILTIN_NAME,
-                            (first_input_addr + i)?,
-                        ))))?;
+                            m_index,
+                        )))
+                    })?;
                     if num >= &(Felt252::one() << self.state_rep[i]) {
                         return Err(RunnerError::IntegerBiggerThanPowerOfTwo(Box::new((
-                            (first_input_addr + i)?,
+                            m_index,
                             self.state_rep[i],
                             num.clone(),
                         ))));

--- a/vm/src/vm/runners/builtin_runner/poseidon.rs
+++ b/vm/src/vm/runners/builtin_runner/poseidon.rs
@@ -76,17 +76,18 @@ impl PoseidonBuiltinRunner {
         let first_input_addr = (address - index)?;
         let first_output_addr = (first_input_addr + self.n_input_cells as usize)?;
 
-        let mut input_felts = Vec::<FieldElement>::new();
+        let mut input_felts = vec![];
 
         for i in 0..self.n_input_cells as usize {
-            let val = match memory.get(&(first_input_addr + i)?) {
+            let m_index = (first_input_addr + i)?;
+            let val = match memory.get(&m_index) {
                 Some(value) => {
-                    let num = value
-                        .get_int_ref()
-                        .ok_or(RunnerError::BuiltinExpectedInteger(Box::new((
+                    let num = value.get_int_ref().ok_or_else(|| {
+                        RunnerError::BuiltinExpectedInteger(Box::new((
                             POSEIDON_BUILTIN_NAME,
-                            (first_input_addr + i)?,
-                        ))))?;
+                            m_index,
+                        )))
+                    })?;
                     FieldElement::from_dec_str(&num.to_str_radix(10))
                         .map_err(|_| RunnerError::FailedStringConversion)?
                 }


### PR DESCRIPTION
Closes #1195

## Description

In some cases, we were using `ok_or` with error variants that needed heap allocations. This PR changes those to `ok_or_else`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

