### PR TITLE
chore(fuzzer): bump `actions/checkout` from v2 to v3

### DIFF
--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -56,7 +56,7 @@ jobs:
 
     # Checkout current and last commit for the diff
     - name: Checkout commits  
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
 


### PR DESCRIPTION
Using the old version is causing the following warning:
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2