### PR TITLE
perf: use `simd-json` instead of `serde_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
+ "simd-json",
  "starknet-crypto",
  "thiserror-no-std",
  "wasm-bindgen-test",
@@ -1145,6 +1146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "halfbrown"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5681137554ddff44396e5f149892c769d45301dd9aa19c51602a89ee214cb0ec"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1561,6 +1590,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2402,6 +2495,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d0815e7ff0f1f05e09d4b029f86d8a330f0ab15b35b28736f3758325f59e14"
+dependencies = [
+ "halfbrown",
+ "lexical-core",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,6 +2636,12 @@ dependencies = [
  "getrandom",
  "hex",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -2731,6 +2850,18 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "value-trait"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a5b6c8ceb01263b969cac48d4a6705134d490ded13d889e52c0cfc80c6945e"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { version = "1.0", features = [
     "arbitrary_precision",
     "alloc",
 ], default-features = false }
+simd-json = "0.10.3"
 hex = { version = "0.4.3", default-features = false }
 bincode = { version = "2.0.0-rc.3", tag = "v2.0.0-rc.3", git = "https://github.com/bincode-org/bincode.git", default-features = false, features = [
     "serde",

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
+ "simd-json",
  "starknet-crypto",
  "thiserror-no-std",
 ]
@@ -286,6 +287,15 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "funty"
@@ -427,12 +437,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5681137554ddff44396e5f149892c769d45301dd9aa19c51602a89ee214cb0ec"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -513,6 +542,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
 ]
 
 [[package]]
@@ -840,6 +933,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d0815e7ff0f1f05e09d4b029f86d8a330f0ab15b35b28736f3758325f59e14"
+dependencies = [
+ "halfbrown",
+ "lexical-core",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1027,12 @@ dependencies = [
  "getrandom",
  "hex",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1000,6 +1119,18 @@ name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
+name = "value-trait"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a5b6c8ceb01263b969cac48d4a6705134d490ded13d889e52c0cfc80c6945e"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "version_check"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -19,6 +19,7 @@ std = [
     "felt/std",
     "dep:num-prime",
     "thiserror-no-std/std",
+    "dep:simd-json",
 ]
 cairo-1-hints = [
     "dep:cairo-lang-starknet",
@@ -45,6 +46,7 @@ num-traits = { workspace = true }
 num-integer = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+simd-json = { workspace = true, optional = true }
 hex = { workspace = true }
 bincode = { workspace = true }
 starknet-crypto = { workspace = true }

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -391,7 +391,7 @@ pub fn deserialize_value_address<'de, D: Deserializer<'de>>(
 }
 
 pub fn deserialize_program_json(reader: &[u8]) -> Result<ProgramJson, ProgramError> {
-    let program_json = serde_json::from_slice(reader)?;
+    let program_json = crate::serde::from_slice(reader)?;
     Ok(program_json)
 }
 pub fn deserialize_and_parse_program(
@@ -491,7 +491,7 @@ mod tests {
 
         // ProgramJson result instance for the json with an even length encoded hex.
         let even_result: Result<ProgramJson, _> =
-            serde_json::from_str(invalid_even_length_hex_json);
+            crate::serde::from_str(invalid_even_length_hex_json);
 
         assert!(even_result.is_err());
 
@@ -501,7 +501,8 @@ mod tests {
             }"#;
 
         // ProgramJson result instance for the json with an odd length encoded hex.
-        let odd_result: Result<ProgramJson, _> = serde_json::from_str(invalid_odd_length_hex_json);
+        let odd_result: Result<ProgramJson, _> =
+            crate::serde::from_str(invalid_odd_length_hex_json);
 
         assert!(odd_result.is_err());
     }
@@ -514,7 +515,7 @@ mod tests {
                 "prime": "0xlambda"
             }"#;
 
-        let invalid_char_error: Result<ProgramJson, _> = serde_json::from_str(invalid_char);
+        let invalid_char_error: Result<ProgramJson, _> = crate::serde::from_str(invalid_char);
 
         assert!(invalid_char_error.is_err());
     }
@@ -528,7 +529,7 @@ mod tests {
             }"#;
 
         // ProgramJson result instance for the json with an odd length encoded hex.
-        let no_prefix_error: Result<ProgramJson, _> = serde_json::from_str(no_prefix);
+        let no_prefix_error: Result<ProgramJson, _> = crate::serde::from_str(no_prefix);
 
         assert!(no_prefix_error.is_err());
     }
@@ -633,7 +634,7 @@ mod tests {
             }"#;
 
         // ProgramJson instance for the json with an even length encoded hex.
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = crate::serde::from_str(valid_json).unwrap();
 
         let data: Vec<MaybeRelocatable> = vec![
             MaybeRelocatable::Int(Felt252::new(5189976364521848832_i64)),
@@ -755,7 +756,7 @@ mod tests {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_a.json");
 
-        let program_json: ProgramJson = serde_json::from_slice(reader).unwrap();
+        let program_json: ProgramJson = crate::serde::from_slice(reader).unwrap();
 
         assert_eq!(
             program_json.prime,
@@ -773,7 +774,7 @@ mod tests {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/valid_program_b.json");
 
-        let program_json: ProgramJson = serde_json::from_slice(reader).unwrap();
+        let program_json: ProgramJson = crate::serde::from_slice(reader).unwrap();
         let builtins: Vec<BuiltinName> = vec![BuiltinName::output, BuiltinName::range_check];
 
         assert_eq!(
@@ -793,7 +794,7 @@ mod tests {
             "../../../cairo_programs/manually_compiled/invalid_even_length_hex.json"
         );
 
-        let even_result: Result<ProgramJson, _> = serde_json::from_slice(reader);
+        let even_result: Result<ProgramJson, _> = crate::serde::from_slice(reader);
 
         assert!(even_result.is_err());
 
@@ -801,7 +802,7 @@ mod tests {
         let reader =
             include_bytes!("../../../cairo_programs/manually_compiled/invalid_odd_length_hex.json");
 
-        let odd_result: Result<ProgramJson, _> = serde_json::from_slice(reader);
+        let odd_result: Result<ProgramJson, _> = crate::serde::from_slice(reader);
 
         assert!(odd_result.is_err());
     }
@@ -981,7 +982,7 @@ mod tests {
             "../../../cairo_programs/manually_compiled/deserialize_constant_test.json"
         );
 
-        let program_json: ProgramJson = serde_json::from_slice(reader).unwrap();
+        let program_json: ProgramJson = crate::serde::from_slice(reader).unwrap();
         let mut identifiers: HashMap<String, Identifier> = HashMap::new();
 
         identifiers.insert(
@@ -1100,7 +1101,7 @@ mod tests {
                 }
             }"#;
 
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = crate::serde::from_str(valid_json).unwrap();
 
         let reference_manager = ReferenceManager {
             references: vec![Reference {
@@ -1176,7 +1177,7 @@ mod tests {
                 }
             }"#;
 
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = crate::serde::from_str(valid_json).unwrap();
 
         let attributes: Vec<Attribute> = vec![
             Attribute {
@@ -1281,7 +1282,7 @@ mod tests {
                 }
             }"#;
 
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = crate::serde::from_str(valid_json).unwrap();
 
         let debug_info: DebugInfo = DebugInfo {
             instruction_locations: HashMap::from([
@@ -1386,7 +1387,7 @@ mod tests {
                 }
             }"#;
 
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = crate::serde::from_str(valid_json).unwrap();
 
         let debug_info: DebugInfo = DebugInfo { instruction_locations: HashMap::from(
             [
@@ -1425,7 +1426,7 @@ mod tests {
     fn deserialize_program_with_type_definition() {
         let reader = include_bytes!("../../../cairo_programs/uint256_integration_tests.json");
 
-        let program_json: ProgramJson = serde_json::from_slice(reader).unwrap();
+        let program_json: ProgramJson = crate::serde::from_slice(reader).unwrap();
 
         assert_eq!(
             program_json.identifiers["starkware.cairo.common.alloc.alloc.Return"]
@@ -1458,7 +1459,7 @@ mod tests {
             "value" : 0x123
         }"#;
 
-        let iden: Result<Identifier, serde_json::Error> = serde_json::from_str(valid_json);
+        let iden: Result<Identifier, serde_json::Error> = crate::serde::from_str(valid_json);
         assert!(iden.err().is_some());
     }
 
@@ -1515,7 +1516,7 @@ mod tests {
             String::from_utf8(vec![b'9'; 1000]).unwrap(),
             u32::MAX
         );
-        let f = serde_json::from_str::<Test>(malicious_input)
+        let f = crate::serde::from_str::<Test>(malicious_input)
             .unwrap()
             .f
             .unwrap();

--- a/vm/src/serde/mod.rs
+++ b/vm/src/serde/mod.rs
@@ -1,2 +1,35 @@
 pub mod deserialize_program;
 mod deserialize_utils;
+
+pub(crate) fn from_slice<'a, T>(v: &'a [u8]) -> serde_json::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    #[cfg(not(feature = "std"))]
+    let res = serde_json::from_slice(v);
+
+    #[cfg(feature = "std")]
+    let res = {
+        let mut copy = v.to_vec();
+        simd_json::from_slice(&mut copy).map_err(|e| serde::de::Error::custom(e.to_string()))
+    };
+
+    res
+}
+
+#[cfg(test)]
+pub(crate) fn from_str<'a, T>(s: &'a str) -> serde_json::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    #[cfg(not(feature = "std"))]
+    let res = serde_json::from_str(s);
+
+    #[cfg(feature = "std")]
+    let res = {
+        let mut copy = s.as_bytes().to_vec();
+        simd_json::from_slice(&mut copy).map_err(|e| serde::de::Error::custom(e.to_string()))
+    };
+
+    res
+}

--- a/vm/src/serde/mod.rs
+++ b/vm/src/serde/mod.rs
@@ -1,7 +1,7 @@
 pub mod deserialize_program;
 mod deserialize_utils;
 
-pub(crate) fn from_slice<'a, T>(v: &'a [u8]) -> serde_json::Result<T>
+pub(crate) fn from_slice<T>(v: &[u8]) -> serde_json::Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -18,7 +18,7 @@ where
 }
 
 #[cfg(test)]
-pub(crate) fn from_str<'a, T>(s: &'a str) -> serde_json::Result<T>
+pub(crate) fn from_str<T>(s: &str) -> serde_json::Result<T>
 where
     T: serde::de::DeserializeOwned,
 {

--- a/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -605,13 +605,13 @@ fn uint512_div_mod_test() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_ok() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
-    let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
+    let contract_class: CasmContractClass = crate::serde::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
         Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(621));
     assert_matches!(
         run_cairo_1_entrypoint_with_run_resources(
-            serde_json::from_slice(program_data.as_slice()).unwrap(),
+            crate::serde::from_slice(program_data.as_slice()).unwrap(),
             0,
             &mut hint_processor,
             &[1_usize.into(), 1_usize.into(), 20_usize.into()],
@@ -626,7 +626,7 @@ fn fibonacci_with_run_resources_ok() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_2_ok() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
-    let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
+    let contract_class: CasmContractClass = crate::serde::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
         Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(1000));
@@ -649,7 +649,7 @@ fn fibonacci_with_run_resources_2_ok() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_with_run_resources_error() {
     let program_data = include_bytes!("../../../cairo_programs/cairo-1-contracts/fib.casm");
-    let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
+    let contract_class: CasmContractClass = crate::serde::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
         Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(100));

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -114,7 +114,7 @@ pub(self) fn run_cairo_1_entrypoint(
     args: &[MaybeRelocatable],
     expected_retdata: &[Felt252],
 ) {
-    let contract_class: CasmContractClass = serde_json::from_slice(program_content).unwrap();
+    let contract_class: CasmContractClass = crate::serde::from_slice(program_content).unwrap();
     let mut hint_processor =
         Cairo1HintProcessor::new(&contract_class.hints, RunResources::default());
 

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -649,7 +649,7 @@ mod test {
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
 
-        #[cfg(all(feature = "std"))]
+        #[cfg(feature = "std")]
         let expected_traceback = String::from("Cairo traceback (most recent call last):\ncairo_programs/bad_programs/bad_dict_update.cairo:10:5: (pc=0:34)\n    dict_update{dict_ptr=my_dict}(key=2, prev_value=3, new_value=4);\n    ^*************************************************************^\n");
         #[cfg(not(feature = "std"))]
         let expected_traceback = String::from("Cairo traceback (most recent call last):\ncairo_programs/bad_programs/bad_dict_update.cairo:10:5: (pc=0:34)\n");


### PR DESCRIPTION
Closes #1295

## Description

This PR replaces the `simd-json` crate, based on the `simdjson` C++ library, instead of `serde_json` when the `std` feature is enabled.

NOTE: this is a work in progress. ***DO NOT MERGE!***

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

