### PR TITLE
feat: make "arbitrary" feature enable `proptest` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-feat: add "proptest" feature, that makes public `proptest` related implementations [#1355](https://github.com/lambdaclass/cairo-vm/pull/1355)
+feat: make *arbitrary* feature also enable a `proptest::arbitrary::Arbitrary` implementation for `Felt252` [#1355](https://github.com/lambdaclass/cairo-vm/pull/1355)
 
 #### [0.8.5] - 2023-7-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+feat: add "proptest" feature, that makes public `proptest` related implementations [#1355](https://github.com/lambdaclass/cairo-vm/pull/1355)
+
 #### [0.8.5] - 2023-7-31
 
 * fix: `Program` comparison depending on `hints_ranges` ordering [#1351](https://github.com/lambdaclass/cairo-rs/pull/1351)

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -14,6 +14,7 @@ std = []
 alloc = []
 lambdaworks-felt = ["dep:lambdaworks-math"]
 arbitrary = ["dep:arbitrary", "num-bigint/arbitrary"]
+proptest = ["dep:proptest"]
 
 [dependencies]
 num-integer = { version = "0.1.45", default-features = false }
@@ -25,6 +26,7 @@ lazy_static = { version = "1.4.0", default-features = false, features = [
 serde = { version = "1.0", features = ["derive"], default-features = false }
 lambdaworks-math = { version = "0.1.2", default-features = false, optional = true }
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
+proptest = { version = "1.2.0", optional = true }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -13,8 +13,7 @@ default = ["std"]
 std = []
 alloc = []
 lambdaworks-felt = ["dep:lambdaworks-math"]
-arbitrary = ["dep:arbitrary", "num-bigint/arbitrary"]
-proptest = ["dep:proptest"]
+arbitrary = ["dep:arbitrary", "num-bigint/arbitrary", "dep:proptest"]
 
 [dependencies]
 num-integer = { version = "0.1.45", default-features = false }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -15,10 +15,10 @@ mod lib_lambdaworks;
 use core::fmt;
 
 #[cfg(feature = "lambdaworks-felt")]
-pub use lib_lambdaworks::*;
+pub use lib_lambdaworks::Felt252;
 
 #[cfg(not(feature = "lambdaworks-felt"))]
-pub use lib_bigint_felt::*;
+pub use lib_bigint_felt::Felt252;
 
 pub const PRIME_STR: &str = "0x800000000000011000000000000000000000000000000000000000000000001"; // in decimal, this is equal to 3618502788666131213697322783095070105623107215331596699973092056135872020481
 pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64); // this is equal to 10633823966279327296825105735305134080

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -5,10 +5,6 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 pub extern crate alloc;
 
-#[cfg(all(test, not(feature = "lambdaworks-felt")))]
-mod arbitrary_bigint_felt;
-#[cfg(all(test, feature = "lambdaworks-felt"))]
-mod arbitrary_lambdaworks;
 #[cfg(not(feature = "lambdaworks-felt"))]
 mod bigint_felt;
 #[cfg(not(feature = "lambdaworks-felt"))]
@@ -19,10 +15,10 @@ mod lib_lambdaworks;
 use core::fmt;
 
 #[cfg(feature = "lambdaworks-felt")]
-pub use lib_lambdaworks::Felt252;
+pub use lib_lambdaworks::*;
 
 #[cfg(not(feature = "lambdaworks-felt"))]
-pub use lib_bigint_felt::Felt252;
+pub use lib_bigint_felt::*;
 
 pub const PRIME_STR: &str = "0x800000000000011000000000000000000000000000000000000000000000001"; // in decimal, this is equal to 3618502788666131213697322783095070105623107215331596699973092056135872020481
 pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64); // this is equal to 10633823966279327296825105735305134080
@@ -36,3 +32,8 @@ impl fmt::Display for ParseFeltError {
         write!(f, "{ParseFeltError:?}")
     }
 }
+
+#[cfg(any(feature = "proptest", test))]
+#[cfg_attr(feature = "lambdaworks-felt", path = "arbitrary_lambdaworks.rs")]
+#[cfg_attr(not(feature = "lambdaworks-felt"), path = "arbitrary_bigint_felt.rs")]
+pub mod arbitrary;

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -33,7 +33,10 @@ impl fmt::Display for ParseFeltError {
     }
 }
 
-#[cfg(any(feature = "proptest", test))]
+#[cfg(any(feature = "arbitrary", test))]
 #[cfg_attr(feature = "lambdaworks-felt", path = "arbitrary_lambdaworks.rs")]
 #[cfg_attr(not(feature = "lambdaworks-felt"), path = "arbitrary_bigint_felt.rs")]
+/// [`proptest::arbitrary::Arbitrary`] implementation for [`Felt252`], and [`Strategy`] generating functions.
+///
+/// Not to be confused with [`arbitrary::Arbitrary`], which is also enabled by the _arbitrary_ feature.
 pub mod arbitrary;

--- a/felt/src/lib_bigint_felt.rs
+++ b/felt/src/lib_bigint_felt.rs
@@ -1014,7 +1014,7 @@ assert_felt_impl!(Felt252);
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{arbitrary_bigint_felt::nonzero_felt252, PRIME_STR};
+    use crate::{arbitrary::nonzero_felt252, PRIME_STR};
     use core::cmp;
     use rstest::rstest;
 

--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -996,7 +996,7 @@ mod test {
     use core::cmp;
 
     use super::*;
-    use crate::{arbitrary_lambdaworks::nonzero_felt252, PRIME_STR};
+    use crate::{arbitrary::nonzero_felt252, PRIME_STR};
     use num_integer::Integer;
     use rstest::rstest;
 


### PR DESCRIPTION
## Description

This PR makes public the `arbitrary` module, with the `proptest::arbitrary::Arbitrary` implementation for `Felt252` along with some helper functions, via the *arbitrary* feature.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.
