### PR TITLE
create vm diff fuzzer

### DIFF
--- a/fuzzer_program.py
+++ b/fuzzer_program.py
@@ -1,0 +1,44 @@
+import sys
+import atheris 
+import subprocess
+
+def diff_fuzzer(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    num1 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    num2 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    num3 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    num4 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    num5 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    num6 = fdp.ConsumeIntInRange(1,3618502788666131213697322783095070105623107215331596699973092056135872020481)
+    
+
+    with open('test_256.json', 'r', encoding='utf-8') as file:
+        data = file.readlines()
+
+    data[331] = '"' + hex(num1) + '"' + ",\n" 
+    data[333] = '"' + hex(num2) + '"' + ",\n" 
+    data[335] = '"' + hex(num3) + '"' + ",\n" 
+    data[337] = '"' + hex(num4) + '"' + ",\n" 
+    data[339] = '"' + hex(num5) + '"' + ",\n" 
+    data[341] = '"' + hex(num6) + '"' + ",\n" 
+
+    with open('test_256_a.json', 'w', encoding='utf-8') as file:
+        file.writelines(data)
+
+    rust_output = subprocess.run(["./target/release/cairo-vm-cli", "--layout", "starknet", "--print_output", "test_256_a.json"], stdout=subprocess.PIPE)
+    python_output = subprocess.run(["cairo-run", "--layout", "starknet", "--print_output", "--program", "test_256_a.json"], stdout=subprocess.PIPE)
+
+    rust_nums = [int(n) for n in rust_output.stdout.split() if n.isdigit()]
+    python_nums = [int(n) for n in python_output.stdout.split() if n.isdigit()]
+
+    print(rust_nums)
+    print(python_nums)
+    assert rust_nums == python_nums
+    
+
+atheris.instrument_all()
+atheris.Setup(sys.argv, diff_fuzzer)
+atheris.Fuzz()
+
+fdp = atheris.FuzzedDataProvider(data)
+

--- a/test_256.cairo
+++ b/test_256.cairo
@@ -1,0 +1,24 @@
+%builtins output range_check
+
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_mul_div_mod
+)
+from starkware.cairo.common.serialize import serialize_word
+
+func main{output_ptr: felt*, range_check_ptr: felt}() {
+    let (c_quotient_low, c_quotient_high, c_remainder) = uint256_mul_div_mod(
+        Uint256(340281070833283907490476236129005105804, 340282366920938463463374607431768311459),
+        Uint256(2447157533618445569039523, 2),
+        Uint256(1, 0),
+    );
+
+    serialize_word(c_quotient_low.low);
+    serialize_word(c_quotient_low.high);
+    serialize_word(c_quotient_high.low);
+    serialize_word(c_quotient_high.high);
+    serialize_word(c_remainder.low);
+    serialize_word(c_remainder.high);
+
+    return ();
+}

--- a/test_256.json
+++ b/test_256.json
@@ -1,0 +1,17232 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output",
+        "range_check"
+    ],
+    "compiler_version": "0.11.0",
+    "data": [
+        "0x480280007ffb8000",
+        "0x480280017ffb8000",
+        "0x484480017fff8000",
+        "0x2aaaaaaaaaaaab05555555555555556",
+        "0x48307fff7ffd8000",
+        "0x480280027ffb8000",
+        "0x480280037ffb8000",
+        "0x484480017fff8000",
+        "0x4000000000000088000000000000001",
+        "0x48307fff7ffd8000",
+        "0xa0680017fff8000",
+        "0xe",
+        "0x480680017fff8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x48287ffc80007fff",
+        "0x40307ffc7ff87fff",
+        "0x48297ffd80007ffc",
+        "0x482680017ffd8000",
+        "0x1",
+        "0x48507fff7ffe8000",
+        "0x40507ff97ff57fff",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0xa0680017fff8000",
+        "0xc",
+        "0x480680017fff8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x48287ffd80007fff",
+        "0x48327fff7ffc8000",
+        "0x40307ffa7ff67fff",
+        "0x48527ffe7ffc8000",
+        "0x40507ff97ff57fff",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0x40317ffd7ff97ffd",
+        "0x48297ffc80007ffd",
+        "0x48527fff7ffc8000",
+        "0x40507ffb7ff77fff",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0xa0680017fff8000",
+        "0xa",
+        "0x400380007ffc7ffd",
+        "0x40780017fff7fff",
+        "0x14",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0xa0680017fff8000",
+        "0xe",
+        "0x484680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x482480017fff8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x400280007ffc7fff",
+        "0x40780017fff7fff",
+        "0x11",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x0",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x480680017fff8000",
+        "0x100000000000000000000000000000000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb8",
+        "0x480680017fff8000",
+        "0x0",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffb7fff8000",
+        "0x48297ffc80007ffd",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffde",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x2",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x4",
+        "0x404b800280028002",
+        "0x404b800380038003",
+        "0x482a7ffc7ffa8000",
+        "0x4846800180028000",
+        "0x100000000000000000000000000000000",
+        "0x40327fff80007ffe",
+        "0x482a7ffd7ffb8000",
+        "0x482880027fff8000",
+        "0x4846800180038000",
+        "0x100000000000000000000000000000000",
+        "0x40327fff80017ffe",
+        "0x480a7ff97fff8000",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x480a80037fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x4846800180018000",
+        "0x10000000000000000",
+        "0x40337fff80007ffd",
+        "0x400380007ffc8000",
+        "0x480680017fff8000",
+        "0xffffffffffffffff",
+        "0x4828800080007fff",
+        "0x400280017ffc7fff",
+        "0x400380027ffc8001",
+        "0x482680017ffc8000",
+        "0x3",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x0",
+        "0x480a7ff97fff8000",
+        "0x480a7ffa7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+        "0x48127ffd7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+        "0x48127ffd7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe5",
+        "0x48127ffd7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe1",
+        "0x48127ffd7fff8000",
+        "0x48507ff17fd98000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x48507fe67fcf8000",
+        "0x48507fe67fcd8000",
+        "0x48307fff7ffe8000",
+        "0x48127ffa7fff8000",
+        "0x48307ffb7ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
+        "0x48507fd77fcb8000",
+        "0x48507fd77fbf8000",
+        "0x48307fff7ffe8000",
+        "0x48507fe07fbc8000",
+        "0x48307fff7ffe8000",
+        "0x48127ff87fff8000",
+        "0x48307ff97ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcd",
+        "0x48507fc67fbb8000",
+        "0x48507fc67fb98000",
+        "0x48307fff7ffe8000",
+        "0x48507fcf7fac8000",
+        "0x48307fff7ffe8000",
+        "0x48507fce7fa98000",
+        "0x48307fff7ffe8000",
+        "0x48127ff67fff8000",
+        "0x48307ff77ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc2",
+        "0x48507fb47fa88000",
+        "0x48507fbe7fa68000",
+        "0x48307fff7ffe8000",
+        "0x48507fbd7f998000",
+        "0x48307fff7ffe8000",
+        "0x48127ff87fff8000",
+        "0x48307ff97ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb9",
+        "0x48507fae7f978000",
+        "0x48507fae7f958000",
+        "0x48307fff7ffe8000",
+        "0x48127ffa7fff8000",
+        "0x48307ffb7ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb2",
+        "0x48507fa07f888000",
+        "0x48127ffc7fff8000",
+        "0x48307ffd7ffe8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffad",
+        "0x480680017fff8000",
+        "0x10000000000000000",
+        "0x48507fac7fff8000",
+        "0x480680017fff8000",
+        "0x10000000000000000",
+        "0x48507fce7fff8000",
+        "0x480680017fff8000",
+        "0x10000000000000000",
+        "0x48507fec7fff8000",
+        "0x480680017fff8000",
+        "0x10000000000000000",
+        "0x48507ff87fff8000",
+        "0x48127ff57fff8000",
+        "0x48307ff87f958000",
+        "0x48307ff97fb48000",
+        "0x48307ffa7fd78000",
+        "0x48307ffb7ff28000",
+        "0x208b7fff7fff7ffe",
+        "0x48297ffd80007ffb",
+        "0x20680017fff7fff",
+        "0x9",
+        "0x480a7ff97fff8000",
+        "0x482680017ffa8000",
+        "0x1",
+        "0x480a7ffc7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff72",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ff97fff8000",
+        "0x482680017ffb8000",
+        "0x1",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff6b",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x6",
+        "0x480a7ff77fff8000",
+        "0x480a7ff87fff8000",
+        "0x480a7ff97fff8000",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff91",
+        "0x48127ffb7fff8000",
+        "0x480a80027fff8000",
+        "0x480a80037fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff61",
+        "0x480a80027fff8000",
+        "0x480a80037fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff86",
+        "0x48127ffb7fff8000",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff56",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff7b",
+        "0x400680017fff7f49",
+        "0x0",
+        "0x400680017fff7f4a",
+        "0x0",
+        "0x48127ffb7fff8000",
+        "0x480a80047fff8000",
+        "0x480a80057fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff47",
+        "0x48127ff67fff8000",
+        "0x48127ff67fff8000",
+        "0x480a80047fff8000",
+        "0x480a80057fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff46",
+        "0x40127e747fff7ffd",
+        "0x40127e757fff7ffe",
+        "0x48127ffc7fff8000",
+        "0x48127fdf7fff8000",
+        "0x48127fdf7fff8000",
+        "0x48127f267fff8000",
+        "0x48127f267fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff3d",
+        "0x400680017fff7fff",
+        "0x0",
+        "0x48127ffc7fff8000",
+        "0x48127ffc7fff8000",
+        "0x48127ffc7fff8000",
+        "0x48127fe37fff8000",
+        "0x480680017fff8000",
+        "0x0",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff33",
+        "0x400680017fff7fff",
+        "0x0",
+        "0x40127e447fff7ffd",
+        "0x40127e457fff7ffe",
+        "0x48127ffc7fff8000",
+        "0x480a80047fff8000",
+        "0x480a80057fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffa6",
+        "0x400680017fff7fff",
+        "0x1",
+        "0x48127ffe7fff8000",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x480a80027fff8000",
+        "0x480a80037fff8000",
+        "0x480a80047fff8000",
+        "0x480a80057fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffd7fff8000",
+        "0x480680017fff8000",
+        "0xffffc01912ebfb629bf75c4dfbd6728c",
+        "0x480680017fff8000",
+        "0x1000000000000000000000000000186a3",
+        "0x480680017fff8000",
+        "0x20634acfbddaec9711ca3",
+        "0x480680017fff8000",
+        "0x2",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff9a",
+        "0x480a7ffc7fff8000",
+        "0x48127ff97fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
+        "0x48127ff67fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+        "0x48127ff37fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe6",
+        "0x48127ff07fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
+        "0x48127fed7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe0",
+        "0x48127fea7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x48127fe07fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 184,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 164
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 186
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 186
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 86,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 186
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 86,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 186
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 187
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 48,
+                    "start_line": 187
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 89,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 48,
+                    "start_line": 187
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 89,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 187
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 49,
+                            "end_line": 196,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 196
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 197,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 197
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 198
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 198
+                }
+            },
+            "15": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 198
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 199
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 16,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 199
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 16,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 17,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 199
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 18,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 16,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 17,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 199
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 18,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 16,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 17,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 200,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 200
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 18,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 14,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 15,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 16,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 17,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 200,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 200
+                }
+            },
+            "24": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 49,
+                            "end_line": 204,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 204
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 205,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 205
+                }
+            },
+            "26": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 206,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 206
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 206,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 206
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 207,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 207
+                }
+            },
+            "30": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 21,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 207,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 207
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 21,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 208,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 208
+                }
+            },
+            "32": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 21,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 22,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 208,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 208
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 21,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 22,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 209,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 209
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "35": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 19,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 21,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 22,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 20,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 209,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 209
+                }
+            },
+            "36": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 31,
+                            "end_line": 213,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 213
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 214,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 214
+                }
+            },
+            "37": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 215
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 23,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 215
+                }
+            },
+            "39": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 23,
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 24,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 215
+                }
+            },
+            "40": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 23,
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 24,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 216,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 216
+                }
+            },
+            "42": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 23,
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 24,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 217,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 217
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "44": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 23,
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 24,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 217,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 217
+                }
+            },
+            "45": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 84,
+                            "end_line": 19,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 19
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 20
+                }
+            },
+            "47": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 21,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 21
+                }
+            },
+            "48": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 22
+                }
+            },
+            "50": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 21
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 27
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 24,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 24
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 23
+                }
+            },
+            "52": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 22
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 27
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 24
+                }
+            },
+            "54": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 23
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 27
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 24
+                }
+            },
+            "55": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 91,
+                            "end_line": 27,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 27
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 48,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 28
+                }
+            },
+            "57": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 29,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 33,
+                    "start_line": 29
+                }
+            },
+            "59": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 29,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 29
+                }
+            },
+            "61": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.__temp17": 29,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 29,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 29
+                }
+            },
+            "62": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.__temp17": 29,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 30
+                }
+            },
+            "64": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 21
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.__temp17": 29,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 30
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 32,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 32
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 31
+                }
+            },
+            "66": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 22
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.__temp17": 29,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 30
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 32,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 32
+                }
+            },
+            "68": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 23
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.__temp16": 28,
+                        "starkware.cairo.common.math_cmp.is_nn.__temp17": 29,
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 30
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 32,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 32
+                }
+            },
+            "69": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 32,
+                                    "end_line": 35,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 35
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 12,
+                    "start_line": 18
+                }
+            },
+            "70": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 35
+                }
+            },
+            "72": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 31,
+                            "end_line": 35,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "start_col": 30,
+                            "start_line": 35
+                        },
+                        "While expanding the reference 'a' in:"
+                    ],
+                    "start_col": 29,
+                    "start_line": 18
+                }
+            },
+            "73": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 35
+                }
+            },
+            "75": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 22
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 36
+                }
+            },
+            "77": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 23
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 36
+                }
+            },
+            "78": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_le"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_le.a": 32,
+                        "starkware.cairo.common.math_cmp.is_le.b": 33,
+                        "starkware.cairo.common.math_cmp.is_le.range_check_ptr": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 42,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 24,
+                                    "end_line": 43,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                                    },
+                                    "start_col": 12,
+                                    "start_line": 43
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 12,
+                    "start_line": 42
+                }
+            },
+            "79": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_le"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_le.a": 32,
+                        "starkware.cairo.common.math_cmp.is_le.b": 33,
+                        "starkware.cairo.common.math_cmp.is_le.range_check_ptr": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 43
+                }
+            },
+            "80": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_le"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_le.a": 32,
+                        "starkware.cairo.common.math_cmp.is_le.b": 33,
+                        "starkware.cairo.common.math_cmp.is_le.range_check_ptr": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 43
+                }
+            },
+            "82": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_le"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 27
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_le.a": 32,
+                        "starkware.cairo.common.math_cmp.is_le.b": 33,
+                        "starkware.cairo.common.math_cmp.is_le.range_check_ptr": 35
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 43
+                }
+            },
+            "83": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_check"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_check.a": 36,
+                        "starkware.cairo.common.uint256.uint256_check.range_check_ptr": 37
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 22
+                }
+            },
+            "84": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_check"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_check.a": 36,
+                        "starkware.cairo.common.uint256.uint256_check.range_check_ptr": 37
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 23
+                }
+            },
+            "85": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_check"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_check.a": 36,
+                        "starkware.cairo.common.uint256.uint256_check.range_check_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 21,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 25,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 25
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 21
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 24
+                }
+            },
+            "87": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_check"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_check.a": 36,
+                        "starkware.cairo.common.uint256.uint256_check.range_check_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 25
+                }
+            },
+            "88": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 32,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 32
+                }
+            },
+            "90": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 41,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 36
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 43
+                }
+            },
+            "91": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 44,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 44
+                }
+            },
+            "92": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 46,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 46
+                }
+            },
+            "93": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 55,
+                    "end_line": 46,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 38,
+                    "start_line": 46
+                }
+            },
+            "95": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 46,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 46
+                }
+            },
+            "96": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 47,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 47
+                }
+            },
+            "97": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 47,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 47
+                }
+            },
+            "98": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 47,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 53,
+                    "start_line": 47
+                }
+            },
+            "100": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 72,
+                    "end_line": 47,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 47
+                }
+            },
+            "101": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 21,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 23,
+                                    "end_line": 48,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 48
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 21
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 31
+                }
+            },
+            "102": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 22,
+                            "end_line": 48,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 48
+                        },
+                        "While expanding the reference 'res' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 33
+                }
+            },
+            "103": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 22,
+                            "end_line": 48,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 48
+                        },
+                        "While expanding the reference 'res' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 33
+                }
+            },
+            "104": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 48,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 48
+                }
+            },
+            "106": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 50,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 16,
+                            "end_line": 50,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 13,
+                            "start_line": 50
+                        },
+                        "While expanding the reference 'res' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 33
+                }
+            },
+            "107": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 16
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 50,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 16,
+                            "end_line": 50,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 13,
+                            "start_line": 50
+                        },
+                        "While expanding the reference 'res' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 33
+                }
+            },
+            "108": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 17
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 50,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 21,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 50,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 18,
+                            "start_line": 50
+                        },
+                        "While expanding the reference 'carry_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 35
+                }
+            },
+            "109": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 18
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.__temp18": 45,
+                        "starkware.cairo.common.uint256.uint256_add.__temp19": 46,
+                        "starkware.cairo.common.uint256.uint256_add.__temp20": 47,
+                        "starkware.cairo.common.uint256.uint256_add.__temp21": 48,
+                        "starkware.cairo.common.uint256.uint256_add.__temp22": 49,
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 50,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 50,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 50
+                }
+            },
+            "110": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 56,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 56
+                }
+            },
+            "112": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 60
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 64,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 64
+                }
+            },
+            "114": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 64,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 64
+                }
+            },
+            "115": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 65,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 65
+                }
+            },
+            "116": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 66
+                }
+            },
+            "118": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 66
+                }
+            },
+            "119": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 57,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 66
+                }
+            },
+            "120": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 67,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 67
+                }
+            },
+            "121": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 58
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 68,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 30,
+                            "end_line": 55,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 24,
+                                    "end_line": 69,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 69
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 15,
+                            "start_line": 55
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 68
+                }
+            },
+            "123": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 58
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 57,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 16,
+                            "end_line": 69,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 13,
+                            "start_line": 69
+                        },
+                        "While expanding the reference 'low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 57
+                }
+            },
+            "124": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 58
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 58,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 22,
+                            "end_line": 69,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 18,
+                            "start_line": 69
+                        },
+                        "While expanding the reference 'high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 58
+                }
+            },
+            "125": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.__temp23": 55,
+                        "starkware.cairo.common.uint256.split_64.__temp24": 56,
+                        "starkware.cairo.common.uint256.split_64.__temp25": 57,
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 58
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 69,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 69
+                }
+            },
+            "126": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 61
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 74,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 74
+                }
+            },
+            "128": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 61
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 73,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 30,
+                            "end_line": 55,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 35,
+                                    "end_line": 75,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 20,
+                                    "start_line": 75
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 15,
+                            "start_line": 55
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 73
+                }
+            },
+            "129": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 61
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 75,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 75
+                }
+            },
+            "130": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 61
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 75,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 75
+                }
+            },
+            "132": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 62
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 75,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 36,
+                                            "end_line": 76,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 20,
+                                            "start_line": 76
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 75
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "133": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 62
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 76,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 76
+                }
+            },
+            "134": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 62
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 76,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 76
+                }
+            },
+            "136": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 24
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 65
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 76,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 35,
+                                            "end_line": 77,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 20,
+                                            "start_line": 77
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 76
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "137": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 25
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 65
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 77
+                }
+            },
+            "138": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 26
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 65
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 77
+                }
+            },
+            "140": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 36
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 68
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 77,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 36,
+                                            "end_line": 78,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 20,
+                                            "start_line": 78
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 77
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "141": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 37
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 68
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 78,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 78
+                }
+            },
+            "142": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 38
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 68
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 78,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 78
+                }
+            },
+            "144": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 48
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 71
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 78,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 42,
+                                            "end_line": 80,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 80
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 78
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "145": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 49
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 71
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 80,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 80
+                }
+            },
+            "146": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 50
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 71
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 80,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 80
+                }
+            },
+            "148": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 60
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 81
+                }
+            },
+            "149": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 61
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 81
+                }
+            },
+            "150": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 62
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 81
+                }
+            },
+            "151": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 63
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 80,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 60,
+                                            "end_line": 81,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 81
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 80
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "152": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 64
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 81
+                }
+            },
+            "153": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 65
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 76,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 74,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 81
+                }
+            },
+            "155": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 75
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 82
+                }
+            },
+            "156": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 76
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 82
+                }
+            },
+            "157": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 77
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 82
+                }
+            },
+            "158": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 78
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 54,
+                    "start_line": 82
+                }
+            },
+            "159": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 79
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 82
+                }
+            },
+            "160": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 80
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 60,
+                            "end_line": 81,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 70,
+                                            "end_line": 82,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 82
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 81
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "161": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 81
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 82
+                }
+            },
+            "162": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 82
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 82,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 80,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 70,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 82
+                }
+            },
+            "164": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 92
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 83
+                }
+            },
+            "165": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 93
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 83
+                }
+            },
+            "166": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 94
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 83
+                }
+            },
+            "167": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 95
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 54,
+                    "start_line": 83
+                }
+            },
+            "168": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 96
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 83
+                }
+            },
+            "169": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 97
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 64,
+                    "start_line": 83
+                }
+            },
+            "170": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 98
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 83
+                }
+            },
+            "171": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 99
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 70,
+                            "end_line": 82,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 80,
+                                            "end_line": 83,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 83
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 82
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "172": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 100
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 83
+                }
+            },
+            "173": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 101
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 90,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 88,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 80,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 83
+                }
+            },
+            "175": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 111
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 84
+                }
+            },
+            "176": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 112
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 84
+                }
+            },
+            "177": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 113
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 84
+                }
+            },
+            "178": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 114
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 54,
+                    "start_line": 84
+                }
+            },
+            "179": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 115
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 84
+                }
+            },
+            "180": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 116
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 80,
+                            "end_line": 83,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 70,
+                                            "end_line": 84,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 84
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 83
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "181": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 117
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 84
+                }
+            },
+            "182": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 118
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 100,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 98,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 70,
+                    "end_line": 84,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 84
+                }
+            },
+            "184": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 128
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 85,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 85
+                }
+            },
+            "185": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 129
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 85,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 85
+                }
+            },
+            "186": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 130
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 85,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 85
+                }
+            },
+            "187": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 131
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 70,
+                            "end_line": 84,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 60,
+                                            "end_line": 85,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 85
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 84
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "188": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 132
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 85,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 85
+                }
+            },
+            "189": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 133
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 108,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 106,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 85,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 85
+                }
+            },
+            "191": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 143
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 114,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 112,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 86,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 86
+                }
+            },
+            "192": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 144
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 114,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 112,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 60,
+                            "end_line": 85,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 30,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 50,
+                                            "end_line": 86,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 25,
+                                            "start_line": 86
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 15,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 85
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "193": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 145
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 114,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 112,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 86,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 86
+                }
+            },
+            "194": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 146
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 114,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 112,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 86,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 86
+                }
+            },
+            "196": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 156
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 89
+                }
+            },
+            "198": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 157
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 89
+                }
+            },
+            "199": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 158
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 73,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 63,
+                    "start_line": 89
+                }
+            },
+            "201": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 159
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 80,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 63,
+                    "start_line": 89
+                }
+            },
+            "202": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 160
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 33,
+                    "start_line": 90
+                }
+            },
+            "204": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 161
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 33,
+                    "start_line": 90
+                }
+            },
+            "205": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 162
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 64,
+                    "start_line": 90
+                }
+            },
+            "207": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 163
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 82,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 64,
+                    "start_line": 90
+                }
+            },
+            "208": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 164
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 86,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 33,
+                                    "end_line": 73,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 7,
+                                            "end_line": 91,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 88
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 73
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 86
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 55
+                }
+            },
+            "209": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 165
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 89
+                }
+            },
+            "210": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 166
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 80,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 56,
+                    "start_line": 89
+                }
+            },
+            "211": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 167
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 26,
+                    "start_line": 90
+                }
+            },
+            "212": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 168
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 82,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 57,
+                    "start_line": 90
+                }
+            },
+            "213": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 169
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul.__temp26": 77,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp27": 78,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp28": 79,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp29": 83,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp30": 84,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp31": 85,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp32": 86,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp33": 87,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp34": 91,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp35": 92,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp36": 93,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp37": 94,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp38": 95,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp39": 96,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp40": 97,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp41": 101,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp42": 102,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp43": 103,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp44": 104,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp45": 105,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp46": 109,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp47": 110,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp48": 111,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp49": 115,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp50": 119,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp51": 120,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp52": 121,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp53": 122,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp54": 123,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp55": 124,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp56": 125,
+                        "starkware.cairo.common.uint256.uint256_mul.__temp57": 126,
+                        "starkware.cairo.common.uint256.uint256_mul.a": 59,
+                        "starkware.cairo.common.uint256.uint256_mul.a0": 63,
+                        "starkware.cairo.common.uint256.uint256_mul.a1": 64,
+                        "starkware.cairo.common.uint256.uint256_mul.a2": 66,
+                        "starkware.cairo.common.uint256.uint256_mul.a3": 67,
+                        "starkware.cairo.common.uint256.uint256_mul.b": 60,
+                        "starkware.cairo.common.uint256.uint256_mul.b0": 69,
+                        "starkware.cairo.common.uint256.uint256_mul.b1": 70,
+                        "starkware.cairo.common.uint256.uint256_mul.b2": 72,
+                        "starkware.cairo.common.uint256.uint256_mul.b3": 73,
+                        "starkware.cairo.common.uint256.uint256_mul.carry": 118,
+                        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": 116,
+                        "starkware.cairo.common.uint256.uint256_mul.res0": 75,
+                        "starkware.cairo.common.uint256.uint256_mul.res1": 81,
+                        "starkware.cairo.common.uint256.uint256_mul.res2": 89,
+                        "starkware.cairo.common.uint256.uint256_mul.res3": 99,
+                        "starkware.cairo.common.uint256.uint256_mul.res4": 107,
+                        "starkware.cairo.common.uint256.uint256_mul.res5": 113,
+                        "starkware.cairo.common.uint256.uint256_mul.res6": 117
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 91,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 88
+                }
+            },
+            "214": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 134,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 134
+                }
+            },
+            "215": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 134,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 134
+                }
+            },
+            "217": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 133,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 42,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 40,
+                                    "end_line": 135,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 17,
+                                    "start_line": 135
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 42
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 133
+                }
+            },
+            "218": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 135,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 135
+                }
+            },
+            "220": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 135,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 135
+                }
+            },
+            "221": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 135,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 135
+                }
+            },
+            "223": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 33
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 131
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 135,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 135
+                }
+            },
+            "224": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 133,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 42,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/math_cmp.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 38,
+                                    "end_line": 137,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 13,
+                                    "start_line": 137
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 42
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 133
+                }
+            },
+            "225": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 137,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 19,
+                    "start_line": 137
+                }
+            },
+            "227": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 137,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 137
+                }
+            },
+            "228": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 129
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 137,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 13,
+                    "start_line": 137
+                }
+            },
+            "230": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_lt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 33
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_lt.__temp58": 130,
+                        "starkware.cairo.common.uint256.uint256_lt.a": 127,
+                        "starkware.cairo.common.uint256.uint256_lt.b": 128,
+                        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": 132
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 137,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 137
+                }
+            },
+            "231": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 232,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 232
+                }
+            },
+            "233": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 33,
+                            "end_line": 73,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 46,
+                                    "end_line": 235,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "start_col": 29,
+                                    "start_line": 235
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 73
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 229
+                }
+            },
+            "234": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 53,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 41,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'a' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 229
+                }
+            },
+            "235": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 53,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 41,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'a' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 229
+                }
+            },
+            "236": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 45,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 44,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'b' in:"
+                    ],
+                    "start_col": 55,
+                    "start_line": 229
+                }
+            },
+            "237": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 45,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 44,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'b' in:"
+                    ],
+                    "start_col": 55,
+                    "start_line": 229
+                }
+            },
+            "238": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 235,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 235
+                }
+            },
+            "240": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 137,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 254,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 242
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 73,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 35,
+                                    "end_line": 21,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 33,
+                                            "end_line": 257,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 257
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 20,
+                                    "start_line": 21
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 29,
+                            "start_line": 235
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 73
+                }
+            },
+            "241": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 183
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 137,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 32,
+                            "end_line": 257,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 257
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "242": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 184
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 137,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 32,
+                            "end_line": 257,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 257
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "243": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 185
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 137,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 257,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 257
+                }
+            },
+            "245": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 188
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 143,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 69,
+                            "end_line": 258,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 56,
+                            "start_line": 258
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "246": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 189
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 143,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 69,
+                            "end_line": 258,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 56,
+                            "start_line": 258
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "247": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 190
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 143,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 74,
+                            "end_line": 258,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 71,
+                            "start_line": 258
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "248": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 191
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 143,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 74,
+                            "end_line": 258,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 71,
+                            "start_line": 258
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "249": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 192
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 143,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 258,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 258
+                }
+            },
+            "251": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 363
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 144,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 73,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 75,
+                            "end_line": 258,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 35,
+                                    "end_line": 21,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 32,
+                                            "end_line": 259,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 259
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 20,
+                                    "start_line": 21
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 44,
+                            "start_line": 258
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 73
+                }
+            },
+            "252": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 364
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 144,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 31,
+                            "end_line": 259,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 259
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "253": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 365
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 144,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 31,
+                            "end_line": 259,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 259
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "254": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 366
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 144,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 259,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 259
+                }
+            },
+            "256": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 369
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 147,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 68,
+                            "end_line": 260,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 56,
+                            "start_line": 260
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "257": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 370
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 147,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 68,
+                            "end_line": 260,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 56,
+                            "start_line": 260
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "258": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 371
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 147,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 73,
+                            "end_line": 260,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 70,
+                            "start_line": 260
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "259": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 372
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 147,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 73,
+                            "end_line": 260,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 70,
+                            "start_line": 260
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "260": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 373
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 147,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 260,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 260
+                }
+            },
+            "262": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 262,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 262
+                }
+            },
+            "264": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 262,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 262
+                }
+            },
+            "266": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 73,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 74,
+                            "end_line": 260,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 35,
+                                    "end_line": 21,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 29,
+                                            "end_line": 265,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 265
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 20,
+                                    "start_line": 21
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 44,
+                            "start_line": 260
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 73
+                }
+            },
+            "267": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 545
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 265,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 265
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "268": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 546
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 265,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 19,
+                            "start_line": 265
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "269": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 547
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 148,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 265,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 265
+                }
+            },
+            "271": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 550
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 151,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 260,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 266,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 266
+                        },
+                        "While expanding the reference 'quotient_mod00' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 260
+                }
+            },
+            "272": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 551
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 151,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 260,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 266,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 266
+                        },
+                        "While expanding the reference 'quotient_mod00' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 260
+                }
+            },
+            "273": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 552
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 151,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 61,
+                            "end_line": 266,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 266
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "274": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 553
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 151,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 61,
+                            "end_line": 266,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 266
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "275": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 554
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 151,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 62,
+                    "end_line": 266,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 266
+                }
+            },
+            "277": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 267,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 267
+                }
+            },
+            "278": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 267,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 267
+                }
+            },
+            "279": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 62,
+                            "end_line": 266,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 33,
+                                    "end_line": 31,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 67,
+                                            "end_line": 269,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 24,
+                                            "start_line": 269
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 31
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 266
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 31
+                }
+            },
+            "280": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 575
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 260,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 269,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 269
+                        },
+                        "While expanding the reference 'quotient_mod01' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 260
+                }
+            },
+            "281": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 576
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 260,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 269,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 269
+                        },
+                        "While expanding the reference 'quotient_mod01' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 260
+                }
+            },
+            "282": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 577
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 258,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 66,
+                            "end_line": 269,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 269
+                        },
+                        "While expanding the reference 'quotient_mod10' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 258
+                }
+            },
+            "283": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 578
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 258,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 66,
+                            "end_line": 269,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 269
+                        },
+                        "While expanding the reference 'quotient_mod10' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 258
+                }
+            },
+            "284": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 579
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 152,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 67,
+                    "end_line": 269,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 269
+                }
+            },
+            "286": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 599
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 270,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 270
+                }
+            },
+            "288": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 599
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 67,
+                            "end_line": 269,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 33,
+                                    "end_line": 31,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 68,
+                                            "end_line": 271,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 24,
+                                            "start_line": 271
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 31
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 269
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 31
+                }
+            },
+            "289": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 600
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 269,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 271,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 271
+                        },
+                        "While expanding the reference 'x1' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 269
+                }
+            },
+            "290": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 601
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 269,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 271,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 36,
+                            "start_line": 271
+                        },
+                        "While expanding the reference 'x1' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 269
+                }
+            },
+            "291": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 602
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 266,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 58,
+                            "end_line": 271,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 271
+                        },
+                        "While expanding the reference 'carry0' in:"
+                    ],
+                    "start_col": 14,
+                    "start_line": 266
+                }
+            },
+            "292": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 603
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 271,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 65,
+                    "start_line": 271
+                }
+            },
+            "294": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 604
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 155,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 156
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 68,
+                    "end_line": 271,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 271
+                }
+            },
+            "296": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 272,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 272
+                }
+            },
+            "298": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 274,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 274
+                }
+            },
+            "299": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 274,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 274
+                }
+            },
+            "300": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 68,
+                            "end_line": 271,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 32,
+                                    "end_line": 133,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 48,
+                                            "end_line": 277,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 22,
+                                            "start_line": 277
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 17,
+                                    "start_line": 133
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 271
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 31
+                }
+            },
+            "301": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 625
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 277,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 33,
+                            "start_line": 277
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "302": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 626
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 277,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 33,
+                            "start_line": 277
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "303": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 627
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 277,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 44,
+                            "start_line": 277
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "304": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 628
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 277,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 44,
+                            "start_line": 277
+                        },
+                        "While expanding the reference 'div' in:"
+                    ],
+                    "start_col": 67,
+                    "start_line": 229
+                }
+            },
+            "305": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 629
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 158,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 48,
+                    "end_line": 277,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 277
+                }
+            },
+            "307": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 664
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 278,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 278
+                }
+            },
+            "309": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 664
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 133,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 48,
+                            "end_line": 277,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 41,
+                                    "end_line": 229,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 90,
+                                            "end_line": 280,
+                                            "input_file": {
+                                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 280
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 26,
+                                    "start_line": 229
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 22,
+                            "start_line": 277
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 133
+                }
+            },
+            "310": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 665
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 26,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "311": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 666
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 238,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 26,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'quotient_low' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 238
+                }
+            },
+            "312": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 667
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 67,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 54,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "313": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 668
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 239,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 67,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 54,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'quotient_high' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 239
+                }
+            },
+            "314": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 669
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 88,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 79,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "315": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 670
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 240,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 88,
+                            "end_line": 280,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "start_col": 79,
+                            "start_line": 280
+                        },
+                        "While expanding the reference 'remainder' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 240
+                }
+            },
+            "316": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 671
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": 154,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": 157,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": 160,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": 162,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": 149,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": 150,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": 145,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": 146,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 161,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": 153,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": 159
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 90,
+                    "end_line": 280,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 280
+                }
+            },
+            "317": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 164,
+                        "starkware.cairo.common.serialize.serialize_word.word": 163
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "318": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 165,
+                        "starkware.cairo.common.serialize.serialize_word.word": 163
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "320": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 165,
+                        "starkware.cairo.common.serialize.serialize_word.word": 163
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "321": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 229,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 14,
+                                    "input_file": {
+                                        "filename": "test_256.cairo"
+                                    },
+                                    "start_col": 58,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 26,
+                            "start_line": 229
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 30,
+                    "start_line": 9
+                }
+            },
+            "322": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 11
+                }
+            },
+            "324": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 97,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 58,
+                    "start_line": 11
+                }
+            },
+            "326": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 12,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 12
+                }
+            },
+            "328": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 12,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 44,
+                    "start_line": 12
+                }
+            },
+            "330": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 13
+                }
+            },
+            "332": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 21,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 13
+                }
+            },
+            "334": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 167
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 58,
+                    "start_line": 10
+                }
+            },
+            "336": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 680
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 39,
+                                    "end_line": 16,
+                                    "input_file": {
+                                        "filename": "test_256.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 16
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 9
+                }
+            },
+            "337": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 681
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 16
+                }
+            },
+            "338": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 682
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 166,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 16
+                }
+            },
+            "340": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 685
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 172,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 17
+                }
+            },
+            "341": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 686
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 172,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 17
+                }
+            },
+            "343": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 689
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 173,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 18
+                }
+            },
+            "344": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 690
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 173,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                }
+            },
+            "346": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 693
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 174,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 19
+                }
+            },
+            "347": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 694
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 174,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 19
+                }
+            },
+            "349": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 697
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 175,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 20
+                }
+            },
+            "350": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 698
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 175,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 20
+                }
+            },
+            "352": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 701
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 176,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 21,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 21
+                }
+            },
+            "353": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 702
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 176,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 21,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 21
+                }
+            },
+            "355": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 705
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 177,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 229,
+                    "input_file": {
+                        "filename": "/Users/lambda/Desktop/cairo-rs/cairo-vm-env/lib/python3.9/site-packages/starkware/cairo/common/uint256.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 14,
+                            "input_file": {
+                                "filename": "test_256.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 51,
+                                    "end_line": 9,
+                                    "input_file": {
+                                        "filename": "test_256.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 15,
+                                            "end_line": 23,
+                                            "input_file": {
+                                                "filename": "test_256.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 23
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 30,
+                                    "start_line": 9
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 58,
+                            "start_line": 10
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 229
+                }
+            },
+            "356": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 706
+                    },
+                    "reference_ids": {
+                        "__main__.main.c_quotient_high": 170,
+                        "__main__.main.c_quotient_low": 169,
+                        "__main__.main.c_remainder": 171,
+                        "__main__.main.output_ptr": 177,
+                        "__main__.main.range_check_ptr": 168
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "test_256.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 23
+                }
+            }
+        }
+    },
+    "hints": {
+        "0": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "import itertools\n\nfrom starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\n# Find an arc less than PRIME / 3, and another less than PRIME / 2.\nlengths_and_indices = [(a, 0), (b - a, 1), (PRIME - 1 - b, 2)]\nlengths_and_indices.sort()\nassert lengths_and_indices[0][0] <= PRIME // 3 and lengths_and_indices[1][0] <= PRIME // 2\nexcluded = lengths_and_indices[2][1]\n\nmemory[ids.range_check_ptr + 1], memory[ids.range_check_ptr + 0] = (\n    divmod(lengths_and_indices[0][0], ids.PRIME_OVER_3_HIGH))\nmemory[ids.range_check_ptr + 3], memory[ids.range_check_ptr + 2] = (\n    divmod(lengths_and_indices[1][0], ids.PRIME_OVER_2_HIGH))",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 2
+                    }
+                }
+            }
+        ],
+        "10": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "memory[ap] = 1 if excluded != 0 else 0",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                }
+            }
+        ],
+        "24": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "memory[ap] = 1 if excluded != 1 else 0",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                }
+            }
+        ],
+        "36": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "assert excluded == 2",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp0": 3,
+                        "starkware.cairo.common.math.assert_le_felt.__temp1": 4,
+                        "starkware.cairo.common.math.assert_le_felt.__temp2": 5,
+                        "starkware.cairo.common.math.assert_le_felt.__temp3": 7,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 8,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 9,
+                        "starkware.cairo.common.math.assert_le_felt.a": 0,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 10,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 13,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 6,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 12,
+                        "starkware.cairo.common.math.assert_le_felt.b": 1,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 11
+                    }
+                }
+            }
+        ],
+        "45": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "code": "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                }
+            }
+        ],
+        "55": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math_cmp",
+                    "starkware.cairo.common.math_cmp.is_nn"
+                ],
+                "code": "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math_cmp.is_nn.a": 25,
+                        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": 26
+                    }
+                }
+            }
+        ],
+        "90": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_add"
+                ],
+                "code": "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_add.a": 39,
+                        "starkware.cairo.common.uint256.uint256_add.b": 40,
+                        "starkware.cairo.common.uint256.uint256_add.carry_high": 44,
+                        "starkware.cairo.common.uint256.uint256_add.carry_low": 43,
+                        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": 41,
+                        "starkware.cairo.common.uint256.uint256_add.res": 42
+                    }
+                }
+            }
+        ],
+        "112": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.split_64"
+                ],
+                "code": "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.split_64.a": 51,
+                        "starkware.cairo.common.uint256.split_64.high": 54,
+                        "starkware.cairo.common.uint256.split_64.low": 53,
+                        "starkware.cairo.common.uint256.split_64.range_check_ptr": 52
+                    }
+                }
+            }
+        ],
+        "240": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.uint256",
+                    "starkware.cairo.common.uint256.uint256_mul_div_mod"
+                ],
+                "code": "a = (ids.a.high << 128) + ids.a.low\nb = (ids.b.high << 128) + ids.b.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a * b, div)\n\nids.quotient_low.low = quotient & ((1 << 128) - 1)\nids.quotient_low.high = (quotient >> 128) & ((1 << 128) - 1)\nids.quotient_high.low = (quotient >> 256) & ((1 << 128) - 1)\nids.quotient_high.high = quotient >> 384\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": 133,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": 139,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": 138,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": 134,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": 135,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": 141,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": 140,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": 137,
+                        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": 142
+                    }
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.Uint256": {
+            "destination": "starkware.cairo.common.uint256.Uint256",
+            "type": "alias"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 321,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.c_quotient_high": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "__main__.main.c_quotient_high",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 680
+                    },
+                    "pc": 336,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.c_quotient_low": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "__main__.main.c_quotient_low",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 680
+                    },
+                    "pc": 336,
+                    "value": "[cast(ap + (-6), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.c_remainder": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "__main__.main.c_remainder",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 680
+                    },
+                    "pc": 336,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 321,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 685
+                    },
+                    "pc": 340,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 689
+                    },
+                    "pc": 343,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 693
+                    },
+                    "pc": 346,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 697
+                    },
+                    "pc": 349,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 701
+                    },
+                    "pc": 352,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 705
+                    },
+                    "pc": 355,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 321,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 680
+                    },
+                    "pc": 336,
+                    "value": "[cast(ap + (-7), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "__main__.uint256_mul_div_mod": {
+            "destination": "starkware.cairo.common.uint256.uint256_mul_div_mod",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.ALL_ONES": {
+            "type": "const",
+            "value": -106710729501573572985208420194530329073740042555888586719234
+        },
+        "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bool.FALSE": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bool.TRUE": {
+            "type": "const",
+            "value": 1
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+            "members": {
+                "input": {
+                    "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                    "offset": 0
+                },
+                "output": {
+                    "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                    "offset": 8
+                }
+            },
+            "size": 16,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+            "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.PoseidonBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.PoseidonBuiltin",
+            "members": {
+                "input": {
+                    "cairo_type": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+                    "offset": 0
+                },
+                "output": {
+                    "cairo_type": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+                    "offset": 3
+                }
+            },
+            "size": 6,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.PoseidonBuiltinState": {
+            "destination": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+            "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "members": {
+                "s0": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "s1": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "s2": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "s3": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "s4": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "s5": {
+                    "cairo_type": "felt",
+                    "offset": 5
+                },
+                "s6": {
+                    "cairo_type": "felt",
+                    "offset": 6
+                },
+                "s7": {
+                    "cairo_type": "felt",
+                    "offset": 7
+                }
+            },
+            "size": 8,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.FALSE": {
+            "destination": "starkware.cairo.common.bool.FALSE",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math.TRUE": {
+            "destination": "starkware.cairo.common.bool.TRUE",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math.assert_le_felt": {
+            "decorators": [
+                "known_ap_change"
+            ],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.math.assert_le_felt.Args": {
+            "full_name": "starkware.cairo.common.math.assert_le_felt.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_le_felt.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.math.assert_le_felt.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_2_HIGH": {
+            "type": "const",
+            "value": 5316911983139663648412552867652567041
+        },
+        "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_3_HIGH": {
+            "type": "const",
+            "value": 3544607988759775765608368578435044694
+        },
+        "starkware.cairo.common.math.assert_le_felt.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.math.assert_le_felt.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "pc": 1,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "pc": 2,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp10": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp10",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "pc": 20,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp11": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp11",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "pc": 28,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp12": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp12",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 13
+                    },
+                    "pc": 30,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp13": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp13",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 14
+                    },
+                    "pc": 32,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp14": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp14",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "pc": 38,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp15": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp15",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "pc": 39,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "pc": 4,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp3": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 5
+                    },
+                    "pc": 6,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp4": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp4",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 6
+                    },
+                    "pc": 7,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp5": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp5",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 7
+                    },
+                    "pc": 9,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp6": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp6",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 10
+                    },
+                    "pc": 14,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp7": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp7",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 11
+                    },
+                    "pc": 15,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp8": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp8",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "pc": 17,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp9": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp9",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 13
+                    },
+                    "pc": 19,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_long": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_long",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "pc": 10,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_prod": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_prod",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "pc": 10,
+                    "value": "cast([ap + (-5)] * [ap + (-1)], felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_short": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_short",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 4
+                    },
+                    "pc": 5,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_sum": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_sum",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "pc": 10,
+                    "value": "cast([ap + (-5)] + [ap + (-1)], felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.b": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.m1mb": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.m1mb",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 12
+                    },
+                    "pc": 29,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 8
+                    },
+                    "pc": 10,
+                    "value": "cast([fp + (-5)] + 4, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.skip_exclude_a": {
+            "pc": 24,
+            "type": "label"
+        },
+        "starkware.cairo.common.math.assert_le_felt.skip_exclude_b_minus_a": {
+            "pc": 36,
+            "type": "label"
+        },
+        "starkware.cairo.common.math_cmp.RC_BOUND": {
+            "type": "const",
+            "value": 340282366920938463463374607431768211456
+        },
+        "starkware.cairo.common.math_cmp.assert_le_felt": {
+            "destination": "starkware.cairo.common.math.assert_le_felt",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math_cmp.assert_lt_felt": {
+            "destination": "starkware.cairo.common.math.assert_lt_felt",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math_cmp.is_le": {
+            "decorators": [
+                "known_ap_change"
+            ],
+            "pc": 78,
+            "type": "function"
+        },
+        "starkware.cairo.common.math_cmp.is_le.Args": {
+            "full_name": "starkware.cairo.common.math_cmp.is_le.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math_cmp.is_le.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.math_cmp.is_le.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math_cmp.is_le.Return": {
+            "cairo_type": "felt",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.math_cmp.is_le.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.math_cmp.is_le.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_le.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 78,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_le.b": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_le.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 78,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_le.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_le.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 78,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 27
+                    },
+                    "pc": 82,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_nn": {
+            "decorators": [
+                "known_ap_change"
+            ],
+            "pc": 45,
+            "type": "function"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.Args": {
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.Return": {
+            "cairo_type": "felt",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.math_cmp.is_nn.__temp16": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.__temp16",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 3
+                    },
+                    "pc": 59,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.__temp17": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.__temp17",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 4
+                    },
+                    "pc": 61,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 45,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.need_felt_comparison": {
+            "pc": 69,
+            "type": "label"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.out_of_range": {
+            "pc": 55,
+            "type": "label"
+        },
+        "starkware.cairo.common.math_cmp.is_nn.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math_cmp.is_nn.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 45,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 21
+                    },
+                    "pc": 50,
+                    "value": "cast([fp + (-4)] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 21
+                    },
+                    "pc": 64,
+                    "value": "cast([fp + (-4)] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 22
+                    },
+                    "pc": 75,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.poseidon_state.PoseidonBuiltinState": {
+            "full_name": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+            "members": {
+                "s0": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "s1": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "s2": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.pow.assert_le": {
+            "destination": "starkware.cairo.common.math.assert_le",
+            "type": "alias"
+        },
+        "starkware.cairo.common.pow.get_ap": {
+            "destination": "starkware.cairo.common.registers.get_ap",
+            "type": "alias"
+        },
+        "starkware.cairo.common.pow.get_fp_and_pc": {
+            "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "starkware.cairo.common.registers.get_ap": {
+            "destination": "starkware.cairo.lang.compiler.lib.registers.get_ap",
+            "type": "alias"
+        },
+        "starkware.cairo.common.registers.get_fp_and_pc": {
+            "destination": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 317,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 317,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 318,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 317,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.ALL_ONES": {
+            "type": "const",
+            "value": 340282366920938463463374607431768211455
+        },
+        "starkware.cairo.common.uint256.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.HALF_SHIFT": {
+            "type": "const",
+            "value": 18446744073709551616
+        },
+        "starkware.cairo.common.uint256.SHIFT": {
+            "type": "const",
+            "value": 340282366920938463463374607431768211456
+        },
+        "starkware.cairo.common.uint256.Uint256": {
+            "full_name": "starkware.cairo.common.uint256.Uint256",
+            "members": {
+                "high": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "low": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.assert_in_range": {
+            "destination": "starkware.cairo.common.math.assert_in_range",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.assert_le": {
+            "destination": "starkware.cairo.common.math.assert_le",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.assert_nn_le": {
+            "destination": "starkware.cairo.common.math.assert_nn_le",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.assert_not_zero": {
+            "destination": "starkware.cairo.common.math.assert_not_zero",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.bitwise_and": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_and",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.bitwise_or": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_or",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.bitwise_xor": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.get_ap": {
+            "destination": "starkware.cairo.common.registers.get_ap",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.get_fp_and_pc": {
+            "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.is_le": {
+            "destination": "starkware.cairo.common.math_cmp.is_le",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.pow": {
+            "destination": "starkware.cairo.common.pow.pow",
+            "type": "alias"
+        },
+        "starkware.cairo.common.uint256.split_64": {
+            "decorators": [],
+            "pc": 110,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.split_64.Args": {
+            "full_name": "starkware.cairo.common.uint256.split_64.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.split_64.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.split_64.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.split_64.Return": {
+            "cairo_type": "(low: felt, high: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.split_64.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 2
+        },
+        "starkware.cairo.common.uint256.split_64.__temp23": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.__temp23",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "pc": 114,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.__temp24": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.__temp24",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 4
+                    },
+                    "pc": 118,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.__temp25": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.__temp25",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "pc": 119,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 110,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.high": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.high",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "pc": 112,
+                    "value": "[cast(fp + 1, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.low": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.low",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "pc": 112,
+                    "value": "[cast(fp, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.split_64.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.split_64.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 110,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "pc": 121,
+                    "value": "cast([fp + (-4)] + 3, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add": {
+            "decorators": [],
+            "pc": 88,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.uint256_add.Args": {
+            "full_name": "starkware.cairo.common.uint256.uint256_add.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 2
+                }
+            },
+            "size": 4,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_add.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.uint256_add.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_add.Return": {
+            "cairo_type": "(res: starkware.cairo.common.uint256.Uint256, carry: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.uint256_add.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 4
+        },
+        "starkware.cairo.common.uint256.uint256_add.__temp18": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.__temp18",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "pc": 93,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.__temp19": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.__temp19",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "pc": 95,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.__temp20": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.__temp20",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "pc": 97,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.__temp21": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.__temp21",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 8
+                    },
+                    "pc": 98,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.__temp22": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.__temp22",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "pc": 100,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.a": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 88,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.b": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 88,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.carry_high": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.carry_high",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "pc": 90,
+                    "value": "[cast(fp + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.carry_low": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.carry_low",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "pc": 90,
+                    "value": "[cast(fp + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 88,
+                    "value": "[cast(fp + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 15
+                    },
+                    "pc": 106,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_add.res": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_add.res",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "pc": 90,
+                    "value": "[cast(fp, starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_check": {
+            "decorators": [],
+            "pc": 83,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.uint256_check.Args": {
+            "full_name": "starkware.cairo.common.uint256.uint256_check.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_check.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.uint256_check.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_check.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.uint256_check.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.uint256.uint256_check.a": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_check.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 83,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_check.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_check.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 83,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 85,
+                    "value": "cast([fp + (-5)] + 2, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_lt": {
+            "decorators": [],
+            "pc": 214,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.Args": {
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 2
+                }
+            },
+            "size": 4,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.Return": {
+            "cairo_type": "(res: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.uint256.uint256_lt.__temp58": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.__temp58",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "pc": 215,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.a": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 214,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.b": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 214,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_lt.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_lt.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 214,
+                    "value": "[cast(fp + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 33
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 33
+                    },
+                    "pc": 230,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul": {
+            "decorators": [],
+            "pc": 126,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.Args": {
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 2
+                }
+            },
+            "size": 4,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.Return": {
+            "cairo_type": "(low: starkware.cairo.common.uint256.Uint256, high: starkware.cairo.common.uint256.Uint256)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp26": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp26",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 61
+                    },
+                    "pc": 149,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp27": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp27",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 62
+                    },
+                    "pc": 150,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp28": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp28",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 63
+                    },
+                    "pc": 151,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp29": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp29",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 76
+                    },
+                    "pc": 156,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp30": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp30",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 77
+                    },
+                    "pc": 157,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp31": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp31",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 78
+                    },
+                    "pc": 158,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp32": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp32",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 79
+                    },
+                    "pc": 159,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp33": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp33",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 80
+                    },
+                    "pc": 160,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp34": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp34",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 93
+                    },
+                    "pc": 165,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp35": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp35",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 94
+                    },
+                    "pc": 166,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp36": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp36",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 95
+                    },
+                    "pc": 167,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp37": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp37",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 96
+                    },
+                    "pc": 168,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp38": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp38",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 97
+                    },
+                    "pc": 169,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp39": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp39",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 98
+                    },
+                    "pc": 170,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp40": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp40",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 99
+                    },
+                    "pc": 171,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp41": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp41",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 112
+                    },
+                    "pc": 176,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp42": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp42",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 113
+                    },
+                    "pc": 177,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp43": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp43",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 114
+                    },
+                    "pc": 178,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp44": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp44",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 115
+                    },
+                    "pc": 179,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp45": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp45",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 116
+                    },
+                    "pc": 180,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp46": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp46",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 129
+                    },
+                    "pc": 185,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp47": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp47",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 130
+                    },
+                    "pc": 186,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp48": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp48",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 131
+                    },
+                    "pc": 187,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp49": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp49",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 144
+                    },
+                    "pc": 192,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp50": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp50",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 157
+                    },
+                    "pc": 198,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp51": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp51",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 158
+                    },
+                    "pc": 199,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp52": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp52",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 159
+                    },
+                    "pc": 201,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp53": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp53",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 160
+                    },
+                    "pc": 202,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp54": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp54",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 161
+                    },
+                    "pc": 204,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp55": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp55",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 162
+                    },
+                    "pc": 205,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp56": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp56",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 163
+                    },
+                    "pc": 207,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.__temp57": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.__temp57",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 164
+                    },
+                    "pc": 208,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.a": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 126,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.a0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.a0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 12
+                    },
+                    "pc": 132,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.a1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.a1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 12
+                    },
+                    "pc": 132,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.a2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.a2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 24
+                    },
+                    "pc": 136,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.a3": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.a3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 24
+                    },
+                    "pc": 136,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.b": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 126,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.b0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.b0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 36
+                    },
+                    "pc": 140,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.b1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.b1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 36
+                    },
+                    "pc": 140,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.b2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.b2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 48
+                    },
+                    "pc": 144,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.b3": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.b3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 48
+                    },
+                    "pc": 144,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.carry": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.carry",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 60
+                    },
+                    "pc": 148,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 75
+                    },
+                    "pc": 155,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 92
+                    },
+                    "pc": 164,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 111
+                    },
+                    "pc": 175,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 128
+                    },
+                    "pc": 184,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 143
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 156
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 126,
+                    "value": "[cast(fp + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 12
+                    },
+                    "pc": 132,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 24
+                    },
+                    "pc": 136,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 36
+                    },
+                    "pc": 140,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 48
+                    },
+                    "pc": 144,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 60
+                    },
+                    "pc": 148,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 75
+                    },
+                    "pc": 155,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 92
+                    },
+                    "pc": 164,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 111
+                    },
+                    "pc": 175,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 128
+                    },
+                    "pc": 184,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 143
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 156
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 60
+                    },
+                    "pc": 148,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 75
+                    },
+                    "pc": 155,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 92
+                    },
+                    "pc": 164,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res3": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 111
+                    },
+                    "pc": 175,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res4": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res4",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 128
+                    },
+                    "pc": 184,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res5": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res5",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 143
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul.res6": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul.res6",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 156
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod": {
+            "decorators": [],
+            "pc": 231,
+            "type": "function"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.Args": {
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 2
+                },
+                "div": {
+                    "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                    "offset": 4
+                }
+            },
+            "size": 6,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.Return": {
+            "cairo_type": "(quotient_low: starkware.cairo.common.uint256.Uint256, quotient_high: starkware.cairo.common.uint256.Uint256, remainder: starkware.cairo.common.uint256.Uint256)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 6
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.a": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 231,
+                    "value": "[cast(fp + (-8), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_high",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.ab_low",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.b": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 231,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.carry0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "pc": 277,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.carry1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 599
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.carry2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "pc": 296,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.div": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.div",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 231,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.is_valid",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 664
+                    },
+                    "pc": 307,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_high",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(fp + 2, starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_low",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(fp, starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod00",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "pc": 262,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod01",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "pc": 262,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod10",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 363
+                    },
+                    "pc": 251,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.quotient_mod11",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 363
+                    },
+                    "pc": 251,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 231,
+                    "value": "[cast(fp + (-9), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(ap + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 188
+                    },
+                    "pc": 245,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 363
+                    },
+                    "pc": 251,
+                    "value": "[cast(ap + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 369
+                    },
+                    "pc": 256,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 544
+                    },
+                    "pc": 262,
+                    "value": "[cast(ap + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 550
+                    },
+                    "pc": 271,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "pc": 277,
+                    "value": "[cast(ap + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 599
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "pc": 296,
+                    "value": "[cast(ap + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 664
+                    },
+                    "pc": 307,
+                    "value": "[cast(ap + (-2), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.remainder",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 182
+                    },
+                    "pc": 240,
+                    "value": "[cast(fp + 4, starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.x0": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.x0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 574
+                    },
+                    "pc": 277,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.uint256.uint256_mul_div_mod.x1": {
+            "cairo_type": "starkware.cairo.common.uint256.Uint256",
+            "full_name": "starkware.cairo.common.uint256.uint256_mul_div_mod.x1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 599
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 624
+                    },
+                    "pc": 296,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 1
+                },
+                "pc": 1,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 2
+                },
+                "pc": 2,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 3
+                },
+                "pc": 4,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 4
+                },
+                "pc": 5,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 5
+                },
+                "pc": 6,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 6
+                },
+                "pc": 7,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 7
+                },
+                "pc": 9,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 8
+                },
+                "pc": 10,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 8
+                },
+                "pc": 10,
+                "value": "cast([fp + (-5)] + 4, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 8
+                },
+                "pc": 10,
+                "value": "cast([ap + (-5)] + [ap + (-1)], felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 8
+                },
+                "pc": 10,
+                "value": "cast([ap + (-5)] * [ap + (-1)], felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 10
+                },
+                "pc": 14,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 11
+                },
+                "pc": 15,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 12
+                },
+                "pc": 17,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 13
+                },
+                "pc": 19,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 14
+                },
+                "pc": 20,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 11
+                },
+                "pc": 28,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 12
+                },
+                "pc": 29,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 13
+                },
+                "pc": 30,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 14
+                },
+                "pc": 32,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 11
+                },
+                "pc": 38,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 12
+                },
+                "pc": 39,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 45,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 45,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 21
+                },
+                "pc": 50,
+                "value": "cast([fp + (-4)] + 1, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 3
+                },
+                "pc": 59,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 4
+                },
+                "pc": 61,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 21
+                },
+                "pc": 64,
+                "value": "cast([fp + (-4)] + 1, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 22
+                },
+                "pc": 75,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 78,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 78,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 78,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 27
+                },
+                "pc": 82,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 83,
+                "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 83,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 85,
+                "value": "cast([fp + (-5)] + 2, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 88,
+                "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 88,
+                "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 88,
+                "value": "[cast(fp + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 4
+                },
+                "pc": 90,
+                "value": "[cast(fp, starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 4
+                },
+                "pc": 90,
+                "value": "[cast(fp + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 4
+                },
+                "pc": 90,
+                "value": "[cast(fp + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 5
+                },
+                "pc": 93,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 6
+                },
+                "pc": 95,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 7
+                },
+                "pc": 97,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 8
+                },
+                "pc": 98,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 9
+                },
+                "pc": 100,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 15
+                },
+                "pc": 106,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 110,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 110,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 2
+                },
+                "pc": 112,
+                "value": "[cast(fp, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 2
+                },
+                "pc": 112,
+                "value": "[cast(fp + 1, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 3
+                },
+                "pc": 114,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 4
+                },
+                "pc": 118,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 5
+                },
+                "pc": 119,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 5
+                },
+                "pc": 121,
+                "value": "cast([fp + (-4)] + 3, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 126,
+                "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 126,
+                "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 126,
+                "value": "[cast(fp + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 12
+                },
+                "pc": 132,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 12
+                },
+                "pc": 132,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 12
+                },
+                "pc": 132,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 24
+                },
+                "pc": 136,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 24
+                },
+                "pc": 136,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 24
+                },
+                "pc": 136,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 36
+                },
+                "pc": 140,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 36
+                },
+                "pc": 140,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 36
+                },
+                "pc": 140,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 48
+                },
+                "pc": 144,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 48
+                },
+                "pc": 144,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 48
+                },
+                "pc": 144,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 60
+                },
+                "pc": 148,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 60
+                },
+                "pc": 148,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 60
+                },
+                "pc": 148,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 61
+                },
+                "pc": 149,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 62
+                },
+                "pc": 150,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 63
+                },
+                "pc": 151,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 75
+                },
+                "pc": 155,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 75
+                },
+                "pc": 155,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 75
+                },
+                "pc": 155,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 76
+                },
+                "pc": 156,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 77
+                },
+                "pc": 157,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 78
+                },
+                "pc": 158,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 79
+                },
+                "pc": 159,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 80
+                },
+                "pc": 160,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 92
+                },
+                "pc": 164,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 92
+                },
+                "pc": 164,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 92
+                },
+                "pc": 164,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 93
+                },
+                "pc": 165,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 94
+                },
+                "pc": 166,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 95
+                },
+                "pc": 167,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 96
+                },
+                "pc": 168,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 97
+                },
+                "pc": 169,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 98
+                },
+                "pc": 170,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 99
+                },
+                "pc": 171,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 111
+                },
+                "pc": 175,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 111
+                },
+                "pc": 175,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 111
+                },
+                "pc": 175,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 112
+                },
+                "pc": 176,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 113
+                },
+                "pc": 177,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 114
+                },
+                "pc": 178,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 115
+                },
+                "pc": 179,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 116
+                },
+                "pc": 180,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 128
+                },
+                "pc": 184,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 128
+                },
+                "pc": 184,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 128
+                },
+                "pc": 184,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 129
+                },
+                "pc": 185,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 130
+                },
+                "pc": 186,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 131
+                },
+                "pc": 187,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 143
+                },
+                "pc": 191,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 143
+                },
+                "pc": 191,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 143
+                },
+                "pc": 191,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 144
+                },
+                "pc": 192,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 156
+                },
+                "pc": 196,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 156
+                },
+                "pc": 196,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 156
+                },
+                "pc": 196,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 157
+                },
+                "pc": 198,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 158
+                },
+                "pc": 199,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 159
+                },
+                "pc": 201,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 160
+                },
+                "pc": 202,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 161
+                },
+                "pc": 204,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 162
+                },
+                "pc": 205,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 163
+                },
+                "pc": 207,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 164
+                },
+                "pc": 208,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 214,
+                "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 214,
+                "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 214,
+                "value": "[cast(fp + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 1
+                },
+                "pc": 215,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 33
+                },
+                "pc": 223,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 33
+                },
+                "pc": 230,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 231,
+                "value": "[cast(fp + (-8), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 231,
+                "value": "[cast(fp + (-6), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 231,
+                "value": "[cast(fp + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 231,
+                "value": "[cast(fp + (-9), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(ap + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(fp, starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(fp + 2, starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 182
+                },
+                "pc": 240,
+                "value": "[cast(fp + 4, starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 188
+                },
+                "pc": 245,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 363
+                },
+                "pc": 251,
+                "value": "[cast(ap + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 363
+                },
+                "pc": 251,
+                "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 363
+                },
+                "pc": 251,
+                "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 369
+                },
+                "pc": 256,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 544
+                },
+                "pc": 262,
+                "value": "[cast(ap + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 544
+                },
+                "pc": 262,
+                "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 544
+                },
+                "pc": 262,
+                "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 550
+                },
+                "pc": 271,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 574
+                },
+                "pc": 277,
+                "value": "[cast(ap + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 574
+                },
+                "pc": 277,
+                "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 574
+                },
+                "pc": 277,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 599
+                },
+                "pc": 286,
+                "value": "[cast(ap + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 599
+                },
+                "pc": 286,
+                "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 599
+                },
+                "pc": 286,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 624
+                },
+                "pc": 296,
+                "value": "[cast(ap + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 624
+                },
+                "pc": 296,
+                "value": "[cast(ap + (-3), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 624
+                },
+                "pc": 296,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 664
+                },
+                "pc": 307,
+                "value": "[cast(ap + (-2), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 664
+                },
+                "pc": 307,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 317,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 317,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 318,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 0
+                },
+                "pc": 321,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 0
+                },
+                "pc": 321,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 680
+                },
+                "pc": 336,
+                "value": "[cast(ap + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 680
+                },
+                "pc": 336,
+                "value": "[cast(ap + (-6), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 680
+                },
+                "pc": 336,
+                "value": "[cast(ap + (-4), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 680
+                },
+                "pc": 336,
+                "value": "[cast(ap + (-2), starkware.cairo.common.uint256.Uint256*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 685
+                },
+                "pc": 340,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 689
+                },
+                "pc": 343,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 693
+                },
+                "pc": 346,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 697
+                },
+                "pc": 349,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 701
+                },
+                "pc": 352,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 705
+                },
+                "pc": 355,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Create diff fuzzer for vm for `uint256_mul_div_mod` hint 

## Description

This PR creates a python script that runs a differential fuzzer that compares rust vs py vm implementation of `uint256_mul_div_mod` hint.
Does this by taking a .json  of a cairo program that uses the `uint256_mul_div_mod` hint and randomize the values of the uint256, runs the programs with both implementations and compares them.


