### PR TITLE
Fix `VirtualMachineError::JumpRelNotInt` Display message

### DIFF
--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -53,7 +53,7 @@ pub enum VirtualMachineError {
     UnconstrainedResJumpRel,
     #[error("Res.UNCONSTRAINED cannot be used with Opcode.ASSERT_EQ")]
     UnconstrainedResAssertEq,
-    #[error("An integer value as Res cannot be used with PcUpdate.JUMP_REL")]
+    #[error("A relocatable value as Res cannot be used with PcUpdate.JUMP_REL")]
     JumpRelNotInt,
     #[error(
         "Failed to compute Res.MUL: Could not complete computation of non pure values {} * {}", (*.0).0, (*.0).1


### PR DESCRIPTION
Message says that Res can't be integer instead of Res can't be relocatable
Note: coverage label added as this change doesn't merit a changelog entry
