### PR TITLE
Fix signature error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: correctly display invalid signature error message [#1361](https://github.com/lambdaclass/cairo-vm/pull/1361)
+
 #### [0.8.5] - 2023-7-31
 
 * fix: `Program` comparison depending on `hints_ranges` ordering [#1351](https://github.com/lambdaclass/cairo-rs/pull/1351)

--- a/vm/src/vm/runners/builtin_runner/signature.rs
+++ b/vm/src/vm/runners/builtin_runner/signature.rs
@@ -137,7 +137,7 @@ impl SignatureBuiltinRunner {
                 match verify(&public_key, &message, &r, &s) {
                     Ok(true) => Ok(vec![]),
                     _ => Err(MemoryError::InvalidSignature(Box::new((
-                        signature.to_string(),
+                        format!("({}, {})", signature.r, signature.s),
                         pubkey.into_owned(),
                         msg.into_owned(),
                     )))),


### PR DESCRIPTION
## Description
In Pythonic cairo-vm, invalid signature was reported like this:
```
Error at pc=0:124:
Signature (1193313242338130160318297312666865822293235647311047835298033290753491994440, 155691799158656286221600221734062249357606752541106292108852403284952061129),
is invalid, with respect to the public key 3571077580641057962019375980836964323430604474979724507958294224671833227961,
and the message hash 1308364852790706196451346173687342589479412849559424395391024201449978019648.
Cairo traceback (most recent call last):
Unknown location (pc=0:577)
Unknown location (pc=0:541)
Unknown location (pc=0:245)
```

And in Rust cairo-vm, it's reported like this:
```
Error at pc=0:124:
Signature 03e4c994748ab4c6a0374e7aa6ae938b6c880a58ff2938ddfdd569bc694351990128cf025da10fcc6742f5c242922fb251c0852c7f68c70e1923fcc74f9454fb,
is invalid, with respect to the public key 2554664058264077495144519976141551974382939217789466639725771495363739387604,
and the message hash 3232999915494270110450164060897339602579794848593724915613880343018894519633.
Cairo traceback (most recent call last):
Unknown location (pc=0:615)
Unknown location (pc=0:600)
Unknown location (pc=0:245)
```

Notice how the signature is currently two concatenated hexadecimal representations (difficult to separate manually/visually), whereas it used to be two separated decimal representations (consistent with public key and message hash). This PR aims to address this.

I removed the checklist because I don't think it's needed for this small PR.

<!-- ## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.
-->