### PR TITLE
Handle error in hint `UINT256_MUL_DIV_MOD` when divides by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Handle error in hint `UINT256_MUL_DIV_MOD` when divides by zero [#1367](https://github.com/lambdaclass/cairo-vm/pull/1367)
+
 * feat: make *arbitrary* feature also enable a `proptest::arbitrary::Arbitrary` implementation for `Felt252` [#1355](https://github.com/lambdaclass/cairo-vm/pull/1355)
 
 * fix: correctly display invalid signature error message [#1361](https://github.com/lambdaclass/cairo-vm/pull/1361)

--- a/cairo_programs/bad_programs/div_by_zero.cairo
+++ b/cairo_programs/bad_programs/div_by_zero.cairo
@@ -1,0 +1,31 @@
+struct MyStruct0 {
+	low: felt,
+	high: felt,
+}
+func main() {
+	let a = MyStruct0(low=0, high=0);
+	let b = MyStruct0(low=0, high=0);
+	let div = MyStruct0(low=0, high=0);
+	hint_func(a, b, div);
+	return();
+}
+func hint_func(a: MyStruct0, b: MyStruct0, div: MyStruct0) -> (MyStruct0, MyStruct0, MyStruct0) {
+	alloc_locals;
+	local quotient_low: MyStruct0;
+	local quotient_high: MyStruct0;
+	local remainder: MyStruct0;
+    %{
+        a = (ids.a.high << 128) + ids.a.low
+        b = (ids.b.high << 128) + ids.b.low
+        div = (ids.div.high << 128) + ids.div.low
+        quotient, remainder = divmod(a * b, div)
+
+        ids.quotient_low.low = quotient & ((1 << 128) - 1)
+        ids.quotient_low.high = (quotient >> 128) & ((1 << 128) - 1)
+        ids.quotient_high.low = (quotient >> 256) & ((1 << 128) - 1)
+        ids.quotient_high.high = quotient >> 384
+        ids.remainder.low = remainder & ((1 << 128) - 1)
+        ids.remainder.high = remainder >> 128
+    %}
+	return(quotient_low, quotient_high, remainder);
+}

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -148,9 +148,6 @@ pub fn assert_le_felt(
     let excluded = lengths_and_indices[2].1;
     exec_scopes.assign_or_update_variable("excluded", any_box!(Felt252::new(excluded)));
 
-    if prime_over_3_high.is_zero() || prime_over_2_high.is_zero() {
-        return Err(MathError::DividedByZero.into());
-    }
     let (q_0, r_0) = (lengths_and_indices[0].0).div_mod_floor(&prime_over_3_high.to_biguint());
     let (q_1, r_1) = (lengths_and_indices[1].0).div_mod_floor(&prime_over_2_high.to_biguint());
 

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -6,6 +6,7 @@ use crate::{
         ops::{Shl, Shr},
         prelude::*,
     },
+    types::errors::math_errors::MathError,
 };
 use lazy_static::lazy_static;
 use num_traits::{Bounded, Pow};
@@ -147,6 +148,9 @@ pub fn assert_le_felt(
     let excluded = lengths_and_indices[2].1;
     exec_scopes.assign_or_update_variable("excluded", any_box!(Felt252::new(excluded)));
 
+    if prime_over_3_high.is_zero() || prime_over_2_high.is_zero() {
+        return Err(MathError::DividedByZero.into());
+    }
     let (q_0, r_0) = (lengths_and_indices[0].0).div_mod_floor(&prime_over_3_high.to_biguint());
     let (q_1, r_1) = (lengths_and_indices[1].0).div_mod_floor(&prime_over_2_high.to_biguint());
 
@@ -486,6 +490,10 @@ pub fn signed_div_rem(
             ))));
         }
         _ => {}
+    }
+
+    if div.is_zero() {
+        return Err(MathError::DividedByZero.into());
     }
 
     let int_value = value.to_signed_felt();

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -6,7 +6,6 @@ use crate::{
         ops::{Shl, Shr},
         prelude::*,
     },
-    types::errors::math_errors::MathError,
 };
 use lazy_static::lazy_static;
 use num_traits::{Bounded, Pow};

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -492,10 +492,6 @@ pub fn signed_div_rem(
         _ => {}
     }
 
-    if div.is_zero() {
-        return Err(MathError::DividedByZero.into());
-    }
-
     let int_value = value.to_signed_felt();
     let int_div = div.to_bigint();
     let int_bound = bound.to_bigint();

--- a/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -13,7 +13,7 @@ use crate::{
         ops::{Shl, Shr},
         prelude::*,
     },
-    types::relocatable::Relocatable,
+    types::{errors::math_errors::MathError, relocatable::Relocatable},
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
 use felt::Felt252;
@@ -434,6 +434,9 @@ pub fn uint256_mul_div_mod(
     let a = a_high.to_biguint().shl(128_usize) + a_low.to_biguint();
     let b = b_high.to_biguint().shl(128_usize) + b_low.to_biguint();
     let div = div_high.to_biguint().shl(128_usize) + div_low.to_biguint();
+    if div.is_zero() {
+        return Err(MathError::DividedByZero.into());
+    }
     let (quotient, remainder) = (a * b).div_mod_floor(&div);
 
     // ids.quotient_low.low

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -640,6 +640,13 @@ fn error_msg_attr_struct() {
     let error_msg = "Error message: Cats cannot have more than nine lives: {cat} (Cannot evaluate ap-based or complex references: ['cat'])";
     run_program_with_error(program_data.as_slice(), error_msg);
 }
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn error_msg_attr_div_by_zero() {
+    let program_data = include_bytes!("../../../cairo_programs/bad_programs/div_by_zero.json");
+    let error_msg = "Got an exception while executing a hint: Attempted to divide by zero";
+    run_program_with_error(program_data.as_slice(), error_msg);
+}
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]


### PR DESCRIPTION
# Handle error in hint `UINT256_MUL_DIV_MOD` when divides by zero

## Description
* Handle error in hint `UINT256_MUL_DIV_MOD` when divides by zero
* Also, checks possible zeros before `div_mod_floor` with `BigUints`


## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

