### PR TITLE
Remove duplicated code is dst deduction

### DIFF
--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -318,9 +318,9 @@ impl VirtualMachine {
         instruction: &Instruction,
         res: &Option<MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, VirtualMachineError> {
-        let dst = match instruction.opcode {
-            Opcode::AssertEq if res.is_some() => res.clone().unwrap(),
-            Opcode::Call => MaybeRelocatable::from(self.run_context.get_fp()),
+        let dst = match (instruction.opcode, res) {
+            (Opcode::AssertEq, Some(res)) => res.clone(),
+            (Opcode::Call, _) => MaybeRelocatable::from(self.run_context.get_fp()),
             _ => return Err(VirtualMachineError::NoDst),
         };
         Ok(dst)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -316,13 +316,14 @@ impl VirtualMachine {
     fn deduce_dst(
         &self,
         instruction: &Instruction,
-        res: Option<&MaybeRelocatable>,
-    ) -> Option<MaybeRelocatable> {
-        match instruction.opcode {
-            Opcode::AssertEq => res.cloned(),
-            Opcode::Call => Some(self.get_fp().into()),
-            _ => None,
-        }
+        res: &Option<MaybeRelocatable>,
+    ) -> Result<MaybeRelocatable, VirtualMachineError> {
+        let dst = match instruction.opcode {
+            Opcode::AssertEq if res.is_some() => res.clone().unwrap(),
+            Opcode::Call => MaybeRelocatable::from(self.run_context.get_fp()),
+            _ => return Err(VirtualMachineError::NoDst),
+        };
+        Ok(dst)
     }
 
     fn opcode_assertions(
@@ -545,20 +546,6 @@ impl VirtualMachine {
         Ok(op1)
     }
 
-    fn compute_dst_deductions(
-        &self,
-        instruction: &Instruction,
-        res: &Option<MaybeRelocatable>,
-    ) -> Result<MaybeRelocatable, VirtualMachineError> {
-        let dst_op = match instruction.opcode {
-            Opcode::AssertEq if res.is_some() => Option::clone(res),
-            Opcode::Call => Some(MaybeRelocatable::from(self.run_context.get_fp())),
-            _ => self.deduce_dst(instruction, res.as_ref()),
-        };
-        let dst = dst_op.ok_or(VirtualMachineError::NoDst)?;
-        Ok(dst)
-    }
-
     /// Compute operands and result, trying to deduce them if normal memory access returns a None
     /// value.
     pub fn compute_operands(
@@ -609,7 +596,7 @@ impl VirtualMachine {
             Some(dst) => dst,
             None => {
                 deduced_operands.set_dst(true);
-                self.compute_dst_deductions(instruction, &res)?
+                self.deduce_dst(instruction, &res)?
             }
         };
         let accessed_addresses = OperandsAddresses {
@@ -2451,8 +2438,8 @@ mod tests {
 
         let res = MaybeRelocatable::Int(Felt252::new(7));
         assert_eq!(
-            Some(MaybeRelocatable::Int(Felt252::new(7))),
-            vm.deduce_dst(&instruction, Some(&res))
+            MaybeRelocatable::Int(Felt252::new(7)),
+            vm.deduce_dst(&instruction, &Some(res)).unwrap()
         );
     }
 
@@ -2475,7 +2462,7 @@ mod tests {
 
         let vm = vm!();
 
-        assert_eq!(None, vm.deduce_dst(&instruction, None));
+        assert!(vm.deduce_dst(&instruction, &None).is_err());
     }
 
     #[test]
@@ -2498,8 +2485,8 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            Some(MaybeRelocatable::from((1, 0))),
-            vm.deduce_dst(&instruction, None)
+            MaybeRelocatable::from((1, 0)),
+            vm.deduce_dst(&instruction, &None).unwrap()
         );
     }
 
@@ -2522,7 +2509,7 @@ mod tests {
 
         let vm = vm!();
 
-        assert_eq!(None, vm.deduce_dst(&instruction, None));
+        assert!(vm.deduce_dst(&instruction, &None).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Combines `compute_dst_deductions` & `deduce_dst` into `deduce_dst`
Solves #1364 
No changelog update needed as this is an internal refactor

