### PR TITLE
Fix `cairo1` & `cairo2` builds in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,24 +152,22 @@ $(CAIRO_2_CONTRACTS_TEST_DIR)/%.casm: $(CAIRO_2_CONTRACTS_TEST_DIR)/%.sierra
 # Setup Cairo 2 Compiler
 # ======================
 
-cairo-repo-2-dir = cairo2
-cairo-repo-2-dir-macos = cairo2-macos
+CAIRO_2_REPO_DIR = cairo2
+CAIRO_2_VERSION = 2.1.0-rc1
 
-build-cairo-2-compiler-macos: | $(cairo-repo-2-dir-macos)
+build-cairo-2-compiler-macos:
+	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+        curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-aarch64-apple-darwin.tar \
+	 	&& tar -xzvf cairo-${CAIRO_2_VERSION}.tar \
+	 	&& mv cairo/ cairo2/; \
+    fi
 
-CAIRO_2_VERSION=2.1.0-rc1
-
-$(cairo-repo-2-dir-macos):
-	curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-aarch64-apple-darwin.tar \
-	&& tar -xzvf cairo-${CAIRO_2_VERSION}.tar \
-	&& mv cairo/ cairo2/
-
-build-cairo-2-compiler: | $(cairo-repo-2-dir)
-
-$(cairo-repo-2-dir):
-	curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-x86_64-unknown-linux-musl.tar.gz \
-	&& tar -xzvf cairo-${CAIRO_2_VERSION}.tar \
-	&& mv cairo/ cairo2/
+build-cairo-2-compiler:
+	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+		curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-x86_64-unknown-linux-musl.tar.gz \
+		&& tar -xzvf cairo-${CAIRO_2_VERSION}.tar \
+		&& mv cairo/ cairo2/; \
+	fi
 
 cargo-deps:
 	cargo install --version 0.3.1 iai-callgrind-runner

--- a/Makefile
+++ b/Makefile
@@ -120,16 +120,16 @@ CAIRO_1_VERSION = 1.1.1
 
 build-cairo-1-compiler-macos:
 	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
-        curl -L -o cairo-$(CAIRO_1_VERSION).tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
+        	curl -L -o cairo-$(CAIRO_1_VERSION).tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
 		&& tar -xzvf cairo-$(CAIRO_1_VERSION).tar \
 		&& mv cairo/ cairo1/; \
-    fi
+    	fi
 
 build-cairo-1-compiler:
 	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
 		curl -L -o cairo-$(CAIRO_1_VERSION).tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-x86_64-unknown-linux-musl.tar.gz \
 		&& tar -xzvf cairo-$(CAIRO_1_VERSION).tar \
-		&& mv cairo/ cairo1/
+		&& mv cairo/ cairo1/; \
 	fi
 
 # ======================
@@ -157,10 +157,10 @@ CAIRO_2_VERSION = 2.1.0-rc1
 
 build-cairo-2-compiler-macos:
 	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
-        curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-aarch64-apple-darwin.tar \
+        	curl -L -o cairo-${CAIRO_2_VERSION}.tar https://github.com/starkware-libs/cairo/releases/download/v${CAIRO_2_VERSION}/release-aarch64-apple-darwin.tar \
 	 	&& tar -xzvf cairo-${CAIRO_2_VERSION}.tar \
 	 	&& mv cairo/ cairo2/; \
-    fi
+	fi
 
 build-cairo-2-compiler:
 	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,14 @@ CAIRO_2_REPO_DIR = cairo1
 CAIRO_1_VERSION = 1.1.1
 
 build-cairo-1-compiler-macos:
-	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
         curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
 		&& tar -xzvf cairo-1.1.1.tar \
 		&& mv cairo/ cairo1/; \
     fi
 
 build-cairo-1-compiler:
-	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
 		curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-x86_64-unknown-linux-musl.tar.gz \
 		&& tar -xzvf cairo-1.1.1.tar \
 		&& mv cairo/ cairo1/

--- a/Makefile
+++ b/Makefile
@@ -120,15 +120,15 @@ CAIRO_1_VERSION = 1.1.1
 
 build-cairo-1-compiler-macos:
 	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
-        curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
-		&& tar -xzvf cairo-1.1.1.tar \
+        curl -L -o cairo-$(CAIRO_1_VERSION).tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
+		&& tar -xzvf cairo-$(CAIRO_1_VERSION).tar \
 		&& mv cairo/ cairo1/; \
     fi
 
 build-cairo-1-compiler:
 	@if [ ! -d "$(CAIRO_1_REPO_DIR)" ]; then \
-		curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-x86_64-unknown-linux-musl.tar.gz \
-		&& tar -xzvf cairo-1.1.1.tar \
+		curl -L -o cairo-$(CAIRO_1_VERSION).tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-x86_64-unknown-linux-musl.tar.gz \
+		&& tar -xzvf cairo-$(CAIRO_1_VERSION).tar \
 		&& mv cairo/ cairo1/
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -115,22 +115,22 @@ $(CAIRO_1_CONTRACTS_TEST_DIR)/%.casm: $(CAIRO_1_CONTRACTS_TEST_DIR)/%.sierra
 # Setup Cairo 1 Compiler
 # ======================
 
-cairo-repo-1-dir = cairo1
-cairo-repo-1-dir-macos = cairo1-macos
+CAIRO_2_REPO_DIR = cairo1
+CAIRO_1_VERSION = 1.1.1
 
-build-cairo-1-compiler-macos: | $(cairo-repo-1-dir-macos)
+build-cairo-1-compiler-macos:
+	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+        curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-aarch64-apple-darwin.tar \
+		&& tar -xzvf cairo-1.1.1.tar \
+		&& mv cairo/ cairo1/; \
+    fi
 
-$(cairo-repo-1-dir-macos):
-	curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v1.1.1/release-aarch64-apple-darwin.tar \
-	&& tar -xzvf cairo-1.1.1.tar \
-	&& mv cairo/ cairo1/
-
-build-cairo-1-compiler: | $(cairo-repo-1-dir)
-
-$(cairo-repo-1-dir):
-	curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v1.1.1/release-x86_64-unknown-linux-musl.tar.gz \
-	&& tar -xzvf cairo-1.1.1.tar \
-	&& mv cairo/ cairo1/
+build-cairo-1-compiler:
+	@if [ ! -d "$(CAIRO_2_REPO_DIR)" ]; then \
+		curl -L -o cairo-1.1.1.tar https://github.com/starkware-libs/cairo/releases/download/v$(CAIRO_1_VERSION)/release-x86_64-unknown-linux-musl.tar.gz \
+		&& tar -xzvf cairo-1.1.1.tar \
+		&& mv cairo/ cairo1/
+	fi
 
 # ======================
 # Test Cairo 2 Contracts

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(CAIRO_1_CONTRACTS_TEST_DIR)/%.casm: $(CAIRO_1_CONTRACTS_TEST_DIR)/%.sierra
 # Setup Cairo 1 Compiler
 # ======================
 
-CAIRO_2_REPO_DIR = cairo1
+CAIRO_1_REPO_DIR = cairo1
 CAIRO_1_VERSION = 1.1.1
 
 build-cairo-1-compiler-macos:

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,8 @@ clean:
 	rm -rf cairo-vm-env
 	rm -rf cairo-vm-pypy-env
 	rm -rf cairo
+	rm -rf cairo1
+	rm -rf cairo2
 
 fuzzer-deps: 
 	cargo +nightly install cargo-fuzz


### PR DESCRIPTION
In order to install versions 1 & 2 of the cairo compiler for both macos and not macos systems, a rule was used to check weather the directory existed and build it. As two different behaviours where expected when building for macos and not for macos, two rules were added, one for the `cairoX` directory and one for `cairoX-macos` directory, but both of them built the `cairoX` directory. This lead to makefile erros when building for macos, as the rule would check for the `cairoX-macos` directory which didn't exist and then fail when the `cairoX` directory did exist. 
This PR uses conditionals to check weather the directory `cairoX` exists, solving this issue.
Closes #1389 
Also contains fix from #1388 

