### PR TITLE
Use lambdawork's `UnsignedInteger.div_rem` instead of converting to `BigInt` in `Felt252.div_rem`

### DIFF
--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -761,8 +761,18 @@ impl Integer for Felt252 {
     }
 
     fn div_rem(&self, other: &Self) -> (Self, Self) {
-        let (div, rem) = self.to_biguint().div_mod_floor(&other.to_biguint());
-        (Self::from(div), Self::from(rem))
+        let (div, rem) = self
+            .value
+            .representative()
+            .div_rem(&other.value.representative());
+        (
+            Self {
+                value: FieldElement::from(&div),
+            },
+            Self {
+                value: FieldElement::from(&rem),
+            },
+        )
     }
 
     // NOTE: we overload because the default impl calls div_floor AND mod_floor.


### PR DESCRIPTION
This change requires no new tests / changelog
Closes #1321 

