### PR TITLE
fix: Fix python build condition in `build_programs` job CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,9 @@ jobs:
       uses: chetan/git-restore-mtime-action@v1
 
     - name: Python3 Build
-      if: steps.cache-programs.outputs.cache-hit != 'true' && matrix.program-target != 'cairo_1_test_contracts'
+      if: steps.cache-programs.outputs.cache-hit != 'true'
+        && matrix.program-target != 'cairo_1_test_contracts'
+        && matrix.program-target != 'cairo_2_test_contracts'
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'


### PR DESCRIPTION
The `build_programs` job checks for cache hits & program-target to decide if it shoud setup python. This job  currently checks that the cache hasn't been hit and the program-target is not `cairo_1_test_contracts`, it should also check that the program-target is not cairo_2_test_contracts either
