### PR TITLE
Update hint accountant for tracking unimplemented hints

### DIFF
--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -3,6 +3,8 @@ name: Update missing hints tracking issue
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -3,8 +3,6 @@ name: Update missing hints tracking issue
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ '**' ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -17,6 +17,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Check Build
+      run: cargo build -p hint_accountant
     - name: Run the hint accounting script
       run: cargo r -p hint_accountant | tee comment.md
     - name: Update comment in tracking issue

--- a/hint_accountant/src/main.rs
+++ b/hint_accountant/src/main.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 #![forbid(unsafe_code)]
-use cairo_vm::stdlib::collections::{HashMap, HashSet};
 use cairo_vm::{
     hint_processor::{
         builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
@@ -9,8 +8,8 @@ use cairo_vm::{
     serde::deserialize_program::ApTracking,
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
+    with_std::collections::{HashMap, HashSet},
 };
-
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/hint_accountant/src/main.rs
+++ b/hint_accountant/src/main.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 #![forbid(unsafe_code)]
+use cairo_vm::stdlib::collections::{HashMap, HashSet};
 use cairo_vm::{
     hint_processor::{
         builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
@@ -8,8 +9,8 @@ use cairo_vm::{
     serde::deserialize_program::ApTracking,
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
-    with_std::collections::{HashMap, HashSet},
 };
+
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/hint_accountant/whitelists/cairo_secp.json
+++ b/hint_accountant/whitelists/cairo_secp.json
@@ -90,6 +90,13 @@
         {
             "allowed_expressions": [],
             "hint_lines": [
+                "from starkware.cairo.common.cairo_secp.secp_utils import pack",
+                "value = pack(ids.x, PRIME) % SECP_P"
+            ]
+        },
+        {
+            "allowed_expressions": [],
+            "hint_lines": [
                 "from starkware.python.math_utils import div_mod",
                 "",
                 "value = x_inv = div_mod(1, x, SECP_P)"

--- a/hint_accountant/whitelists/latest.json
+++ b/hint_accountant/whitelists/latest.json
@@ -279,18 +279,6 @@
         {
             "allowed_expressions": [],
             "hint_lines": [
-                "from starkware.cairo.common.keccak_utils.keccak_utils import keccak_func",
-                "_keccak_state_size_felts = int(ids.KECCAK_STATE_SIZE_FELTS)",
-                "assert 0 <= _keccak_state_size_felts < 100",
-                "",
-                "output_values = keccak_func(memory.get_range(",
-                "    ids.keccak_ptr - _keccak_state_size_felts, _keccak_state_size_felts))",
-                "segments.write_arg(ids.keccak_ptr, output_values)"
-            ]
-        },
-        {
-            "allowed_expressions": [],
-            "hint_lines": [
                 "from starkware.cairo.common.cairo_secp.secp_utils import N, pack",
                 "from starkware.python.math_utils import div_mod, safe_div",
                 "",
@@ -417,6 +405,18 @@
                 "from starkware.cairo.common.cairo_secp.secp_utils import split",
                 "",
                 "segments.write_arg(ids.res.address_, split(value))"
+            ]
+        },
+        {
+            "allowed_expressions": [],
+            "hint_lines": [
+                "from starkware.cairo.common.keccak_utils.keccak_utils import keccak_func",
+                "_keccak_state_size_felts = int(ids.KECCAK_STATE_SIZE_FELTS)",
+                "assert 0 <= _keccak_state_size_felts < 100",
+                "",
+                "output_values = keccak_func(memory.get_range(",
+                "    ids.keccak_ptr - _keccak_state_size_felts, _keccak_state_size_felts))",
+                "segments.write_arg(ids.keccak_ptr, output_values)"
             ]
         },
         {
@@ -887,13 +887,13 @@
         {
             "allowed_expressions": [],
             "hint_lines": [
-                "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)"
+                "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)"
             ]
         },
         {
             "allowed_expressions": [],
             "hint_lines": [
-                "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)"
+                "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)"
             ]
         },
         {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -20,7 +20,7 @@ include!("./with_std.rs");
 #[cfg(not(feature = "std"))]
 include!("./without_std.rs");
 
-mod stdlib {
+pub mod stdlib {
     pub mod collections {
         #[cfg(feature = "std")]
         pub use crate::with_std::collections::*;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -20,7 +20,7 @@ include!("./with_std.rs");
 #[cfg(not(feature = "std"))]
 include!("./without_std.rs");
 
-pub mod stdlib {
+mod stdlib {
     pub mod collections {
         #[cfg(feature = "std")]
         pub use crate::with_std::collections::*;


### PR DESCRIPTION
# Update hint accountant for tracking unimplemented hints

## Description

The hint_accountant crate was failing in the build and the whitelisted hints files were not updated.
Changes made:
* Update the whitelisted hints from the master branch in cairo-lang
* Fix the error in the hint_accountant build and add a build check in the CI
* Make the `mod stdlib` public

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

