### PR TITLE
Add div by zero error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: ec_recover hints no longer panic when divisor is 0 [#1433](https://github.com/lambdaclass/cairo-vm/pull/1433)
+
 * fix: Using UINT256_HINT no longer panics when b is greater than 2^256 [#1430](https://github.com/lambdaclass/cairo-vm/pull/1430)
 
 * feat: Added a differential fuzzer for programs with whitelisted hints [#1358](https://github.com/lambdaclass/cairo-vm/pull/1358)

--- a/cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo
+++ b/cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo
@@ -1,0 +1,26 @@
+struct BigInt3 {
+    d0: felt,
+    d1: felt,
+    d2: felt,
+}
+
+func main() {
+    let x = BigInt3(d0=0, d1=0, d2=1);
+    let s = BigInt3(d0=0, d1=0, d2=1);
+    let n = BigInt3(d0=0, d1=0, d2=0);
+    ec_recover_product(x, s, n);
+    return();
+}
+
+func ec_recover_product(x:BigInt3, s:BigInt3, n:BigInt3) {
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import div_mod, safe_div
+
+        N = pack(ids.n, PRIME)
+        x = pack(ids.x, PRIME) % N
+        s = pack(ids.s, PRIME) % N
+        value = res = div_mod(x, s, N)
+    %}
+    return();
+}

--- a/cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo
+++ b/cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo
@@ -1,0 +1,28 @@
+struct BigInt3 {
+    d0: felt,
+    d1: felt,
+    d2: felt,
+}
+
+func main() {
+    let a = BigInt3(d0=0, d1=0, d2=1);
+    let b = BigInt3(d0=0, d1=0, d2=1);
+    let m = BigInt3(d0=0, d1=0, d2=0);
+    ec_recover_product(a, b, m);
+    return();
+}
+
+func ec_recover_product(a:BigInt3, b:BigInt3, m:BigInt3) {
+    %{
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import div_mod, safe_div
+
+        a = pack(ids.a, PRIME)
+        b = pack(ids.b, PRIME)
+        product = a * b
+        m = pack(ids.m, PRIME)
+
+        value = res = product % m
+    %}
+    return();
+}

--- a/cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo
+++ b/cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo
@@ -1,0 +1,57 @@
+
+struct MyStruct1 {
+	d0: felt,
+	d1: felt,
+	d2: felt,
+	d3: felt,
+}
+struct MyStruct0 {
+	low: felt,
+	high: felt,
+}
+func main() {
+	let x =MyStruct1(d0=1, d1=1, d2=1, d3=1);
+	let div = MyStruct0(low=0, high=0);
+	hint_func(x, div);
+	return();
+}
+
+func hint_func(x: MyStruct1, div: MyStruct0) {
+	alloc_locals;
+    local quotient: MyStruct1;
+    local remainder: MyStruct0;
+
+%{
+def split(num: int, num_bits_shift: int, length: int):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+    limbs = (z.low, z.high)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+def pack_extended(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2, z.d3)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+x = pack_extended(ids.x, num_bits_shift = 128)
+div = pack(ids.div, num_bits_shift = 128)
+
+quotient, remainder = divmod(x, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=4)
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+ids.quotient.d3 = quotient_split[3]
+
+remainder_split = split(remainder, num_bits_shift=128, length=2)
+ids.remainder.low = remainder_split[0]
+ids.remainder.high = remainder_split[1]
+%}
+	return();
+}

--- a/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
@@ -209,12 +209,14 @@ mod tests {
             ((1, 8), 0)
         ];
 
-        assert_matches!(run_hint!(
-            vm,
-            ids_data,
-            hint_code::EC_RECOVER_DIV_MOD_N_PACKED,
-            &mut exec_scopes
-        ), Err(HintError::Math(MathError::DividedByZero))
+        assert_matches!(
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code::EC_RECOVER_DIV_MOD_N_PACKED,
+                &mut exec_scopes
+            ),
+            Err(HintError::Math(MathError::DividedByZero))
         );
     }
 
@@ -319,12 +321,14 @@ mod tests {
             ((1, 8), 0)
         ];
 
-        assert_matches!(run_hint!(
-            vm,
-            ids_data,
-            hint_code::EC_RECOVER_PRODUCT_MOD,
-            &mut exec_scopes
-        ), Err(HintError::Math(MathError::DividedByZero))
+        assert_matches!(
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code::EC_RECOVER_PRODUCT_MOD,
+                &mut exec_scopes
+            ),
+            Err(HintError::Math(MathError::DividedByZero))
         );
     }
 
@@ -362,12 +366,14 @@ mod tests {
 
         let ids_data = ids_data!["none"];
 
-        assert_matches!(run_hint!(
-            vm,
-            ids_data,
-            hint_code::EC_RECOVER_PRODUCT_DIV_M,
-            &mut exec_scopes
-        ), Err(HintError::Math(MathError::DividedByZero))
+        assert_matches!(
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code::EC_RECOVER_PRODUCT_DIV_M,
+                &mut exec_scopes
+            ),
+            Err(HintError::Math(MathError::DividedByZero))
         );
     }
 }

--- a/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/ec_recover.rs
@@ -6,10 +6,11 @@ use crate::{
     hint_processor::hint_processor_definition::HintReference,
     math_utils::div_mod,
     serde::deserialize_program::ApTracking,
-    types::exec_scope::ExecutionScopes,
+    types::{errors::math_errors::MathError, exec_scope::ExecutionScopes},
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
 use num_bigint::BigInt;
+use num_traits::Zero;
 
 /* Implements Hint:
 %{
@@ -29,6 +30,9 @@ pub fn ec_recover_divmod_n_packed(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let n = BigInt3::from_var_name("n", vm, ids_data, ap_tracking)?.pack86();
+    if n.is_zero() {
+        return Err(MathError::DividedByZero.into());
+    }
     let x = BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?
         .pack86()
         .mod_floor(&n);
@@ -89,6 +93,9 @@ pub fn ec_recover_product_mod(
     let a = BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
     let b = BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
     let m = BigInt3::from_var_name("m", vm, ids_data, ap_tracking)?.pack86();
+    if m.is_zero() {
+        return Err(MathError::DividedByZero.into());
+    }
 
     let product = a * b;
     let value = product.mod_floor(&m);
@@ -107,6 +114,9 @@ pub fn ec_recover_product_mod(
 pub fn ec_recover_product_div_m(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
     let product: &BigInt = exec_scopes.get_ref("product")?;
     let m: &BigInt = exec_scopes.get_ref("m")?;
+    if m.is_zero() {
+        return Err(MathError::DividedByZero.into());
+    }
     let value = product.div_floor(m);
     exec_scopes.insert_value("k", value.clone());
     exec_scopes.insert_value("value", value);

--- a/vm/src/hint_processor/builtin_hint_processor/vrf/fq.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/vrf/fq.rs
@@ -8,8 +8,8 @@ use crate::{
     },
     math_utils::div_mod,
     serde::deserialize_program::ApTracking,
-    types::errors::math_errors::MathError,
     stdlib::{collections::HashMap, prelude::*},
+    types::errors::math_errors::MathError,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
 use num_bigint::{BigInt, ToBigInt};

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -947,6 +947,42 @@ cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:11:5: (pc=0:18)
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_bad_ec_recover_div_mod_n_packed_n_zero() {
+        #[cfg(feature = "std")]
+        let expected_error_string = r#"cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:16:5: Error at pc=0:21:
+Got an exception while executing a hint: Attempted to divide by zero
+    %{
+    ^^
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0:18)
+    ec_recover_product(x, s, n);
+    ^*************************^
+"#;
+        #[cfg(not(feature = "std"))]
+        let expected_error_string = r#"Got an exception while executing a hint: Attempted to divide by zero
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0:18)
+"#;
+        let program = Program::from_bytes(
+            include_bytes!("../../../../cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.json"),
+            Some("main"),
+        )
+        .unwrap();
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let error = cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .unwrap_err();
+        let vm_excepction = VmException::from_vm_error(&cairo_runner, &vm, error);
+        assert_eq!(vm_excepction.to_string(), expected_error_string);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_value_from_simple_reference_ap_based() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_tempvar.json"),

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -961,7 +961,8 @@ cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0
     ^*************************^
 "#;
         #[cfg(not(feature = "std"))]
-        let expected_error_string = r#"Got an exception while executing a hint: Attempted to divide by zero
+        let expected_error_string = r#"cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:16:5: Error at pc=0:21:
+Got an exception while executing a hint: Attempted to divide by zero
 Cairo traceback (most recent call last):
 cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0:18)
 "#;

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -928,7 +928,9 @@ Cairo traceback (most recent call last):
 cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:11:5: (pc=0:18)
 "#;
         let program = Program::from_bytes(
-            include_bytes!("../../../../cairo_programs/bad_programs/ec_recover_product_mod_m_zero.json"),
+            include_bytes!(
+                "../../../../cairo_programs/bad_programs/ec_recover_product_mod_m_zero.json"
+            ),
             Some("main"),
         )
         .unwrap();
@@ -964,7 +966,9 @@ Cairo traceback (most recent call last):
 cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0:18)
 "#;
         let program = Program::from_bytes(
-            include_bytes!("../../../../cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.json"),
+            include_bytes!(
+                "../../../../cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.json"
+            ),
             Some("main"),
         )
         .unwrap();

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -910,6 +910,43 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_bad_ec_recover_product_mod() {
+        #[cfg(feature = "std")]
+        let expected_error_string = r#"cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:16:5: Error at pc=0:21:
+Got an exception while executing a hint: Attempted to divide by zero
+    %{
+    ^^
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:11:5: (pc=0:18)
+    ec_recover_product(a, b, m);
+    ^*************************^
+"#;
+        #[cfg(not(feature = "std"))]
+        let expected_error_string = r#"cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:16:5: Error at pc=0:21:
+Got an exception while executing a hint: Attempted to divide by zero
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:11:5: (pc=0:18)
+"#;
+        let program = Program::from_bytes(
+            include_bytes!("../../../../cairo_programs/bad_programs/ec_recover_product_mod_m_zero.json"),
+            Some("main"),
+        )
+        .unwrap();
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let error = cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .unwrap_err();
+        let vm_excepction = VmException::from_vm_error(&cairo_runner, &vm, error);
+        assert_eq!(vm_excepction.to_string(), expected_error_string);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_value_from_simple_reference_ap_based() {
         let program = Program::from_bytes(
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_attr_tempvar.json"),

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -988,6 +988,45 @@ cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_bad_uint512_unsigned_div_rem() {
+        #[cfg(feature = "std")]
+        let expected_error_string = r#"cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:24:1: Error at pc=0:17:
+Got an exception while executing a hint: Attempted to divide by zero
+%{
+^^
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:15:2: (pc=0:12)
+	hint_func(x, div);
+ ^***************^
+ "#;
+        #[cfg(not(feature = "std"))]
+        let expected_error_string = r#"cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:24:1: Error at pc=0:17:
+Got an exception while executing a hint: Attempted to divide by zero
+Cairo traceback (most recent call last):
+cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:15:2: (pc=0:12)
+ "#;
+        let program = Program::from_bytes(
+            include_bytes!(
+                "../../../../cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.json"
+            ),
+            Some("main"),
+        )
+        .unwrap();
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let error = cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .unwrap_err();
+        let vm_excepction = VmException::from_vm_error(&cairo_runner, &vm, error);
+        assert_eq!(vm_excepction.to_string(), expected_error_string);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_bad_uint256_sub_check_error_displayed() {
         #[cfg(feature = "std")]
         let expected_error_string = r#"cairo_programs/bad_programs/uint256_sub_b_gt_256.cairo:17:1: Error at pc=0:17:

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -998,13 +998,13 @@ Cairo traceback (most recent call last):
 cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:15:2: (pc=0:12)
 	hint_func(x, div);
  ^***************^
- "#;
+"#;
         #[cfg(not(feature = "std"))]
         let expected_error_string = r#"cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:24:1: Error at pc=0:17:
 Got an exception while executing a hint: Attempted to divide by zero
 Cairo traceback (most recent call last):
 cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:15:2: (pc=0:12)
- "#;
+"#;
         let program = Program::from_bytes(
             include_bytes!(
                 "../../../../cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.json"


### PR DESCRIPTION
# Raise error when dividing by zero

## Description

ec_recover and uint512_unsigned_div_rem now raises errors when trying to divide by zero. Fixes #1431

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

