### PR TITLE
Fix wasm and hint accountant imports

### DIFF
--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -25,12 +25,13 @@ pub struct PublicMemoryEntry {
 mod mem_value_serde {
     use super::*;
     use serde::Serializer;
+    use crate::stdlib::string::ToString;
 
     pub(crate) fn serialize<S: Serializer>(
         value: &Option<Felt252>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        if let Some(value) = value {
+        if let Some(ref value) = value {
             serializer.serialize_str(&format!("{}", value.to_string()))
         } else {
             serializer.serialize_none()

--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -31,7 +31,7 @@ mod mem_value_serde {
         value: &Option<Felt252>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        if let Some(ref value) = value {
+        if let Some(value) = value {
             serializer.serialize_str(&format!("{}", value.to_string()))
         } else {
             serializer.serialize_none()

--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -24,8 +24,8 @@ pub struct PublicMemoryEntry {
 
 mod mem_value_serde {
     use super::*;
-    use serde::Serializer;
     use crate::stdlib::string::ToString;
+    use serde::Serializer;
 
     pub(crate) fn serialize<S: Serializer>(
         value: &Option<Felt252>,


### PR DESCRIPTION
# Fix wasm and hint accountant imports

## Description

This PR fixes imports that were broken with the felt to lambdaworks-felt swap.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

