### PR TITLE
Fix air parsing

### DIFF
--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -31,7 +31,7 @@ mod mem_value_serde {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         if let Some(value) = value {
-            serializer.serialize_str(&format!("{:x}", value))
+            serializer.serialize_str(&format!("0x{}", value.to_str_radix(16)))
         } else {
             serializer.serialize_none()
         }

--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -31,7 +31,7 @@ mod mem_value_serde {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         if let Some(value) = value {
-            serializer.serialize_str(&format!("0x{}", value.to_str_radix(16)))
+            serializer.serialize_str(&format!("{:x}", value))
         } else {
             serializer.serialize_none()
         }
@@ -57,12 +57,13 @@ impl From<(usize, usize)> for MemorySegmentAddresses {
 #[derive(Serialize, Debug)]
 pub struct PublicInput<'a> {
     layout: &'a str,
-    layout_params: Option<&'a CairoLayout>,
     rc_min: isize,
     rc_max: isize,
     n_steps: usize,
     memory_segments: HashMap<&'a str, MemorySegmentAddresses>,
     public_memory: Vec<PublicMemoryEntry>,
+    #[serde(rename = "dynamic_params")]
+    layout_params: Option<&'a CairoLayout>,
 }
 
 impl<'a> PublicInput<'a> {


### PR DESCRIPTION
# Fix air parsing

## Description

Change the `PublicInput` serde parsing to match cairo-lang 0.12.2 output. This can be checked by running `make compare_air_public_input`, remember to clean any `*.air_public_input` inside `cairo_programs/proof_mode`
Must be merged into #1408 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

