### PR TITLE
Fix rvm typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cd cairo-vm-cli; cargo build --release -F lambdaworks-felt; cd ..
 
 The `-F lambdaworks-felt` part adds usage of [`lambdaworks-math`](https://github.com/lambdaclass/lambdaworks) as the backend for `Felt252`. This improves performance by more than 20%, and will be the default in the future.
 
-Once the binary is built, it can be found in `target/release/` under the name `cairo-rvm-cli`.
+Once the binary is built, it can be found in `target/release/` under the name `cairo-vm-cli`.
 
 To compile a program, use `cairo-compile [path_to_the_.cairo_file] --output [desired_path_of_the_compiled_.json_file]`. For example:
 


### PR DESCRIPTION
# Fix README typo

## Description

cairo-rvm-cli -> cairo-vm-cli

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

