### PR TITLE
perf: share constants between `Program` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* perf: share `constants` field across `Program` instances [#1442](https://github.com/lambdaclass/cairo-vm/pull/1442)
+
 * fix: ec_recover hints no longer panic when divisor is 0 [#1433](https://github.com/lambdaclass/cairo-vm/pull/1433)
 
 * feat: Implement the Serialize and Deserialize traits for the CairoPie struct [#1438](https://github.com/lambdaclass/cairo-vm/pull/1438)

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -500,11 +500,11 @@ pub fn parse_program_json(
             .debug_info
             .map(|debug_info| debug_info.instruction_locations),
         identifiers: program_json.identifiers,
+        constants,
         reference_manager: Program::get_reference_list(&program_json.reference_manager),
     };
     Ok(Program {
         shared_program_data: Arc::new(shared_program_data),
-        constants,
         builtins: program_json.builtins,
     })
 }

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -60,6 +60,7 @@ pub(crate) struct SharedProgramData {
     pub(crate) error_message_attributes: Vec<Attribute>,
     pub(crate) instruction_locations: Option<HashMap<usize, InstructionLocation>>,
     pub(crate) identifiers: HashMap<String, Identifier>,
+    pub(crate) constants: HashMap<String, Felt252>,
     pub(crate) reference_manager: Vec<HintReference>,
 }
 
@@ -160,7 +161,6 @@ type HintRange = Option<(usize, NonZeroUsize)>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
     pub(crate) shared_program_data: Arc<SharedProgramData>,
-    pub(crate) constants: HashMap<String, Felt252>,
     pub(crate) builtins: Vec<BuiltinName>,
 }
 
@@ -197,11 +197,11 @@ impl Program {
             error_message_attributes,
             instruction_locations,
             identifiers,
+            constants,
             reference_manager: Self::get_reference_list(&reference_manager),
         };
         Ok(Self {
             shared_program_data: Arc::new(shared_program_data),
-            constants,
             builtins,
         })
     }
@@ -231,11 +231,11 @@ impl Program {
             error_message_attributes,
             instruction_locations,
             identifiers,
+            constants,
             reference_manager: Self::get_reference_list(&reference_manager),
         };
         Ok(Self {
             shared_program_data: Arc::new(shared_program_data),
-            constants,
             builtins,
         })
     }
@@ -340,7 +340,6 @@ impl Default for Program {
     fn default() -> Self {
         Self {
             shared_program_data: Arc::new(SharedProgramData::default()),
-            constants: HashMap::new(),
             builtins: Vec::new(),
         }
     }
@@ -643,7 +642,7 @@ mod tests {
         assert_eq!(program.shared_program_data.main, None);
         assert_eq!(program.shared_program_data.identifiers, identifiers);
         assert_eq!(
-            program.constants,
+            program.shared_program_data.constants,
             [("__main__.main.SIZEOF_LOCALS", Felt252::zero())]
                 .into_iter()
                 .map(|(key, value)| (key.to_string(), value))
@@ -1212,7 +1211,7 @@ mod tests {
         .map(|(key, value)| (key.to_string(), value))
         .collect::<HashMap<_, _>>();
 
-        assert_eq!(program.constants, constants);
+        assert_eq!(program.shared_program_data.constants, constants);
     }
 
     #[test]
@@ -1232,13 +1231,13 @@ mod tests {
             error_message_attributes: Vec::new(),
             instruction_locations: None,
             identifiers: HashMap::new(),
+            constants: HashMap::new(),
             reference_manager: Program::get_reference_list(&ReferenceManager {
                 references: Vec::new(),
             }),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_program_data),
-            constants: HashMap::new(),
             builtins: Vec::new(),
         };
 

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -266,13 +266,13 @@ pub mod test_utils {
                 error_message_attributes: crate::stdlib::vec::Vec::new(),
                 instruction_locations: None,
                 identifiers: crate::stdlib::collections::HashMap::new(),
+                constants: crate::stdlib::collections::HashMap::new(),
                 reference_manager: Program::get_reference_list(&ReferenceManager {
                     references: crate::stdlib::vec::Vec::new(),
                 }),
             };
             Program {
                 shared_program_data: Arc::new(shared_program_data),
-                constants: crate::stdlib::collections::HashMap::new(),
                 builtins: vec![$( $builtin_name ),*],
             }
         }};
@@ -356,9 +356,9 @@ pub mod test_utils {
                     error_message_attributes: val.error_message_attributes,
                     instruction_locations: val.instruction_locations,
                     identifiers: val.identifiers,
+                    constants: val.constants,
                     reference_manager: Program::get_reference_list(&val.reference_manager),
                 }),
-                constants: val.constants,
                 builtins: val.builtins,
             }
         }
@@ -932,13 +932,13 @@ mod test {
             error_message_attributes: Vec::new(),
             instruction_locations: None,
             identifiers: HashMap::new(),
+            constants: HashMap::new(),
             reference_manager: Program::get_reference_list(&ReferenceManager {
                 references: Vec::new(),
             }),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
-            constants: HashMap::new(),
             builtins: Vec::new(),
         };
         assert_eq!(program, program!())
@@ -956,13 +956,13 @@ mod test {
             error_message_attributes: Vec::new(),
             instruction_locations: None,
             identifiers: HashMap::new(),
+            constants: HashMap::new(),
             reference_manager: Program::get_reference_list(&ReferenceManager {
                 references: Vec::new(),
             }),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
-            constants: HashMap::new(),
             builtins: vec![BuiltinName::range_check],
         };
 
@@ -981,13 +981,13 @@ mod test {
             error_message_attributes: Vec::new(),
             instruction_locations: None,
             identifiers: HashMap::new(),
+            constants: HashMap::new(),
             reference_manager: Program::get_reference_list(&ReferenceManager {
                 references: Vec::new(),
             }),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
-            constants: HashMap::new(),
             builtins: vec![BuiltinName::range_check],
         };
 

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -534,7 +534,7 @@ impl CairoRunner {
     }
 
     pub fn get_constants(&self) -> &HashMap<String, Felt252> {
-        &self.program.constants
+        &self.program.shared_program_data.constants
     }
 
     pub fn get_program_builtins(&self) -> &Vec<BuiltinName> {
@@ -565,7 +565,7 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 hint_data,
-                &self.program.constants,
+                &self.program.shared_program_data.constants,
             )?;
             hint_processor.consume_step();
         }
@@ -605,7 +605,7 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 hint_data,
-                &self.program.constants,
+                &self.program.shared_program_data.constants,
             )?;
         }
 


### PR DESCRIPTION
This reduces `Program` cloning for building the `CairoRunner` by 86%
according to our Criterion benchmarks.
This is a significant cost for running many short-lived programs such
as most Starknet transactions.
No negative impact in runtime was observed.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

