### PR TITLE
bugfix: Fix string code of `BLAKE2S_ADD_UINT256` hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Fix string code of `BLAKE2S_ADD_UINT256` hint [#1454](https://github.com/lambdaclass/cairo-vm/pull/1454)
+
 #### [0.9.0] - 2023-10-03
 
 * fix: Default to empty attributes vector when the field is missing from the program JSON [#1450](https://github.com/lambdaclass/cairo-vm/pull/1450)

--- a/cairo_programs/blake2s_felts.cairo
+++ b/cairo_programs/blake2s_felts.cairo
@@ -1,6 +1,6 @@
 %builtins range_check bitwise
 
-from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_blake2s.blake2s import blake2s_felts
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
@@ -26,10 +26,19 @@ func main{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     assert inputs[15] = 74256930;
     let (local blake2s_ptr_start) = alloc();
     let blake2s_ptr = blake2s_ptr_start;
+    // Big endian
     let (result) = blake2s_felts{range_check_ptr=range_check_ptr, blake2s_ptr=blake2s_ptr}(
         16, inputs, TRUE
     );
     assert result.low = 23022179997536219430502258022509199703;
     assert result.high = 136831746058902715979837770794974289597;
+
+    // Little endian
+    let (result) = blake2s_felts{range_check_ptr=range_check_ptr, blake2s_ptr=blake2s_ptr}(
+        16, inputs, FALSE
+    );
+    assert result.low = 315510691254085211243916597439546947220;
+    assert result.high = 42237338665522721102428636006748876126;
+
     return ();
 }

--- a/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -522,7 +522,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_valid_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)])";
         //Create vm
         let mut vm = vm!();
         //Initialize fp
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn blake2s_add_uint256_valid_non_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)])";
         //Create vm
         let mut vm = vm!();
         //Initialize fp

--- a/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -478,7 +478,7 @@ segments.write_arg(ids.blake2s_ptr_end, padding)"#;
 pub const BLAKE2S_ADD_UINT256: &str = r#"B = 32
 MASK = 2 ** 32 - 1
 segments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])
-segments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]"#;
+segments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)])"#;
 
 pub const BLAKE2S_ADD_UINT256_BIGEND: &str = r#"B = 32
 MASK = 2 ** 32 - 1

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -442,7 +442,7 @@ fn unsafe_keccak() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_felts() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_felts.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 139);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 278);
 }
 
 #[test]


### PR DESCRIPTION
Fixes small bug in the hint string that causes the match to fail when calling the common library function that uses the hint

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

