### PR TITLE
Add cairo1-run dependencies to `deps` & `deps-macos` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,10 @@ cargo-deps:
 	cargo install --version 0.5.9 cargo-llvm-cov
 	cargo install --version 0.11.0 wasm-pack
 
-deps: cargo-deps build-cairo-1-compiler build-cairo-2-compiler
+cairo1-run-deps:
+	cd cairo1-run; make deps
+
+deps: cargo-deps build-cairo-1-compiler build-cairo-2-compiler cairo1-run-deps
 	pyenv install -s pypy3.9-7.3.9
 	PYENV_VERSION=pypy3.9-7.3.9 python -m venv cairo-vm-pypy-env
 	. cairo-vm-pypy-env/bin/activate ; \
@@ -193,7 +196,7 @@ deps: cargo-deps build-cairo-1-compiler build-cairo-2-compiler
 	. cairo-vm-env/bin/activate ; \
 	pip install -r requirements.txt ; \
 
-deps-macos: cargo-deps build-cairo-1-compiler-macos build-cairo-2-compiler-macos
+deps-macos: cargo-deps build-cairo-1-compiler-macos build-cairo-2-compiler-macos cairo1-run-deps
 	arch -x86_64 pyenv install -s pypy3.9-7.3.9
 	PYENV_VERSION=pypy3.9-7.3.9 python -m venv cairo-vm-pypy-env
 	. cairo-vm-pypy-env/bin/activate ; \
@@ -310,6 +313,7 @@ clean:
 	rm -rf cairo1
 	rm -rf cairo2
 	rm -rf cairo-lang
+	cd cairo1-run; make clean
 
 fuzzer-deps: build
 	cargo +nightly install cargo-fuzz


### PR DESCRIPTION
Currently, the fresh-run workflow is failing when`make test` is ran. This is due to cairo1-run crate tests having their own dependencies (aka the corelib setup), and them not being installed when running make deps(-macos).
This PR adds these dependencies to the deps(-macos) targets, solving this problem
Closes #1465 #1464 #1463 #1462 

