### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In order to compile programs you need to install the cairo-lang package.
 
 Running the  `make deps` (or the `make deps-macos`  if you are runnning in MacOS) command will create a virtual environment with all the required dependencies.
 
-You can then activate this enviroment by running
+You can then activate this environment by running
  ```bash
 . cairo-vm-env/bin/activate
 ```

--- a/docs/hint_processor/builtin_hint_processor/README.md
+++ b/docs/hint_processor/builtin_hint_processor/README.md
@@ -90,7 +90,7 @@ In order to code your custom hints you need to take into account the accessible 
 
 ### Data which can be accessed by hint functions:
 * Hint function arguments:
-  * `exec_scopes` is the way to interact with the execution scopes in the VM and share data bewteen hints without inserting them into the Cairo execution. It provides methods to create and remove scopes and to modify the current scope, along with several helper methods to allow inserting and retrieving variables of specific types.
+  * `exec_scopes` is the way to interact with the execution scopes in the VM and share data between hints without inserting them into the Cairo execution. It provides methods to create and remove scopes and to modify the current scope, along with several helper methods to allow inserting and retrieving variables of specific types.
   * `vm` is passed in order to give access to the internal state of the VM. It provides mutable references to the memory, memory segment manager and the run context, and immutable references to the builtin runners and the program's prime.
   * `constants`: A dictionary mapping constant's paths to its values. Used to access constants defined in Cairo code.
   * `ap_tracking`: Ap-tracking data of the hint.
@@ -109,7 +109,7 @@ There are many helper functions available [here](../../../src/hint_processor/bui
 
 These methods take the name of the ids variable along with vm, ids_data and ap_tracking.
 
-Note: When handling pointer type variables, computing the address and using it to get the variable from memory might not lead to the correct value (as the variable refrence may contain an immediate value that has to be added to the ptr itself), so using the functiom `get_ptr_from_var_name` is strongly recomended.
+Note: When handling pointer type variables, computing the address and using it to get the variable from memory might not lead to the correct value (as the variable reference may contain an immediate value that has to be added to the ptr itself), so using the functiom `get_ptr_from_var_name` is strongly recommended.
 
 Note: Cairo's memory is write-once, read-only, so when using `insert_value_from_var_name` its important to first make sure that the variable doesnt contain any value (for example, it may be defined as local but never written) to avoid inconsistent memory errors.
 

--- a/docs/python_vm/README.md
+++ b/docs/python_vm/README.md
@@ -194,7 +194,7 @@ First it will try to obtain dst, op0 and op1 by computing their addresses (`comp
 ## How does [decode_instruction](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/vm/vm_core.py#L371) work?
 </a>
 
-This function calls decode_instruction at comiler/encode.py, where `flags`, and the encoded offsets are obtained from calling decode_instruction_values (this function is defined under the Instruction class) on the encoded instruction (an int). This encoded offsets will then become the instruction's offsets after substracting a constant value, and all other values of the Instruction will be determined by "reading" `flags`, by checking specific bits (ie: `flags >> OPCODE_CALL_BIT) & 1` will determine if opcode will be set Instruction.Opcode.CALL).
+This function calls decode_instruction at comiler/encode.py, where `flags`, and the encoded offsets are obtained from calling decode_instruction_values (this function is defined under the Instruction class) on the encoded instruction (an int). This encoded offsets will then become the instruction's offsets after subtracting a constant value, and all other values of the Instruction will be determined by "reading" `flags`, by checking specific bits (ie: `flags >> OPCODE_CALL_BIT) & 1` will determine if opcode will be set Instruction.Opcode.CALL).
 Some register updates will also be assigned based on the determined opcode: ap_update will be set to ADD2 if the opcode is CALL (ADD2 won't be assigned by reading `flag`, instead, this will be REGULAR), and the fp_update will be determined solely based on the opcode (without using `flag`). `imm` will be set to None unless op1_addr is IMM.
 
 # What is an Operands?
@@ -279,7 +279,7 @@ Functions:
 * `size()` 2 if it has immediate, 1 if not
 * [`decode_instruction_values(encoded_instruction)`](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/compiler/instruction.py#L117) returns tuple with flags, off0, off1, off2
 
-These values will then be used by decode_instruction (at compiler/encode).`flag` will be used to determine the enums of the Instruction (Some register updates will be then changed based on the Opcode). off0, off1 and off2 will become the instruction's off0, off1 and off2 after substracting a constant offset value.
+These values will then be used by decode_instruction (at compiler/encode).`flag` will be used to determine the enums of the Instruction (Some register updates will be then changed based on the Opcode). off0, off1 and off2 will become the instruction's off0, off1 and off2 after subtracting a constant offset value.
 
 # What happens before and after step()?
 *Left side of flow diagram analysis*
@@ -389,7 +389,7 @@ The following is a broad analysis of how hints are processed from the compiled j
 
 On the compiled json file, there is a hint section that includes each hint's code, accesible scopes (includes main, current function, builtins, and import path if inside an imported function) flow-tracking data, and the reference_ids which would be the variables it can interact with (the ones available on the scope the moment the hint is "called").
 Once we load the json file and create a [Program](https://github.com/starkware-libs/cairo-lang/blob/2abd303e1808612b724bc1412b2b5babd04bb4e7/src/starkware/cairo/lang/compiler/program.py#L83) object, it will have a field called hints, which will be a dictionary containing this same information we saw on the json file.
-When the vm is initialized, and the program’s data is loaded through `load_program`, [`load_hints`](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/vm/virtual_machine_base.py#L202) is called, which creates a dictionary that maps an address to a list of compiled hints (there may be more than one hint for an adress) this is called hints, and also creates a map from an id (the hint’s id) to a pc (address) and an index (in case there is more than one hint on a particular address), this is called hint_pc_and_index.
+When the vm is initialized, and the program’s data is loaded through `load_program`, [`load_hints`](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/vm/virtual_machine_base.py#L202) is called, which creates a dictionary that maps an address to a list of compiled hints (there may be more than one hint for an address) this is called hints, and also creates a map from an id (the hint’s id) to a pc (address) and an index (in case there is more than one hint on a particular address), this is called hint_pc_and_index.
 The compiled hints are obtained by using python's [`compile`](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/vm/virtual_machine_base.py#L278) function in exec mode using the hint's code.
 
 ### During execution phase (with each step iteration)


### PR DESCRIPTION
fix some typos in docs