### PR TITLE
chore: bump starknet-crypto to v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* chore: bump starknet-crypto to v0.6.1 [#1469](https://github.com/lambdaclass/cairo-vm/pull/1469)
+
 * feat: Implement the Serialize and Deserialize methods for the Program struct [#1458](https://github.com/lambdaclass/cairo-vm/pull/1458)
 
 * feat: Use only program builtins when running cairo 1 programs [#1457](https://github.com/lambdaclass/cairo-vm/pull/1457)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,9 +2471,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693e6362f150f9276e429a910481fb7f3bcb8d6aa643743f587cfece0b374874"
+checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -2484,7 +2484,7 @@ dependencies = [
  "rfc6979",
  "sha2",
  "starknet-crypto-codegen",
- "starknet-curve 0.3.0",
+ "starknet-curve",
  "starknet-ff",
  "zeroize",
 ]
@@ -2495,18 +2495,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
- "starknet-curve 0.4.0",
+ "starknet-curve",
  "starknet-ff",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
-dependencies = [
- "starknet-ff",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ hex = { version = "0.4.3", default-features = false }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = [
     "serde",
 ] }
-starknet-crypto = { version = "0.5.0", default-features = false, features = [
+starknet-crypto = { version = "0.6.1", default-features = false, features = [
     "signature-display",
     "alloc",
 ] }


### PR DESCRIPTION
# Update `starknet-crypto`

## Description

The new version contains a bug fix on ECDSA signature verification. Previously, the `s` range was incorrectly enforced to be lower than EC order instead of element bound. While this did not allow invalid signatures to be used, it was theoretically possible (1 in 2^48 signatures) to have a signature that passes `verify` yet cannot be proven (due to being out of element bound).

This wouldn't be an issue though, as long as other parts of the VM already enforce the range, but I'm not sure if it's the case. But in any case it wouldn't be a bad thing to upgrade anyways.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.