### PR TITLE
Pin `genco-macros` dependency to last working minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ bitvec = { version = "1", default-features = false, features = ["alloc"] }
 
 # Dependencies for cairo-1-hints feature
 # TODO: Remove this dependency once fixed in cairo-lang crates
-genco-macros = "=1.17.6"
+genco-macros = "=0.17.6"
 
 cairo-lang-starknet = { version = "2.2.0", default-features = false }
 cairo-lang-casm = { version = "2.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ thiserror-no-std = { version = "2.0.2", default-features = false }
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 
 # Dependencies for cairo-1-hints feature
+# TODO: Remove this dependency once fixed in cairo-lang crates
+genco-macros = "=1.17.6"
+
 cairo-lang-starknet = { version = "2.2.0", default-features = false }
 cairo-lang-casm = { version = "2.2.0", default-features = false }
 


### PR DESCRIPTION
The latest minor version update of the crate `genco-macros` used by cairo-lang crates is broken, and we therefore need to pin it to the previous version for cairo-vm to build propperly. This is a temporary fix until this issue is solved

