### PR TITLE
Allow running instructions from `pc`s outside the program segement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 #### Upcoming Changes
 
+* feat: Partially Revert `Optimize trace relocation #906` [#492](https://github.com/lambdaclass/cairo-vm/pull/492)
+
+  * Remove methods `VirtualMachine::get_relocated_trace`& `VirtualMachine::relocate_trace`
+  * Add `relocated_trace` field to `CairoRunner`
+
 * feat: add debugging capabilities behind `print` feature flag. [#1476](https://github.com/lambdaclass/cairo-vm/pull/1476)
 
 #### [0.9.1] - 2023-11-16
-
 
 * chore: bump `cairo-lang-` dependencies to 2.3.1 [#1482](https://github.com/lambdaclass/cairo-vm/pull/1482), [#1483](https://github.com/lambdaclass/cairo-vm/pull/1483)
 

--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -149,7 +149,10 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
     }
 
     if let Some(trace_path) = args.trace_file {
-        let relocated_trace = vm.get_relocated_trace()?;
+        let relocated_trace = cairo_runner
+            .relocated_trace
+            .as_ref()
+            .ok_or(Error::Trace(TraceError::TraceNotRelocated))?;
 
         let trace_file = std::fs::File::create(trace_path)?;
         let mut trace_writer =

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -294,12 +294,14 @@ fn run(args: impl Iterator<Item = String>) -> Result<Vec<MaybeRelocatable>, Erro
     runner.relocate(&mut vm, true)?;
 
     if let Some(trace_path) = args.trace_file {
-        let relocated_trace = vm.get_relocated_trace()?;
+        let relocated_trace = runner
+            .relocated_trace
+            .ok_or(Error::Trace(TraceError::TraceNotRelocated))?;
         let trace_file = std::fs::File::create(trace_path)?;
         let mut trace_writer =
             FileWriter::new(io::BufWriter::with_capacity(3 * 1024 * 1024, trace_file));
 
-        cairo_run::write_encoded_trace(relocated_trace, &mut trace_writer)?;
+        cairo_run::write_encoded_trace(&relocated_trace, &mut trace_writer)?;
         trace_writer.flush()?;
     }
     if let Some(memory_path) = args.memory_file {

--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -10,7 +10,7 @@ use crate::{
     types::layout::CairoLayout,
     vm::{
         errors::{trace_errors::TraceError, vm_errors::VirtualMachineError},
-        trace::trace_entry::TraceEntry,
+        trace::trace_entry::RelocatedTraceEntry,
     },
 };
 
@@ -73,7 +73,7 @@ impl<'a> PublicInput<'a> {
         dyn_layout_params: Option<&'a CairoLayout>,
         public_memory_addresses: &[(usize, usize)],
         memory_segment_addresses: HashMap<&'static str, (usize, usize)>,
-        trace: &[TraceEntry],
+        trace: &[RelocatedTraceEntry],
         rc_limits: (isize, isize),
     ) -> Result<Self, PublicInputError> {
         let memory_entry =

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -158,7 +158,7 @@ pub struct EncodeTraceError(usize, bincode::error::EncodeError);
 /// Bincode encodes to little endian by default and each trace entry is composed of
 /// 3 usize values that are padded to always reach 64 bit size.
 pub fn write_encoded_trace(
-    relocated_trace: &[crate::vm::trace::trace_entry::TraceEntry],
+    relocated_trace: &[crate::vm::trace::trace_entry::RelocatedTraceEntry],
     dest: &mut impl Writer,
 ) -> Result<(), EncodeTraceError> {
     for (i, entry) in relocated_trace.iter().enumerate() {
@@ -318,11 +318,11 @@ mod tests {
         // relocate memory so we can dump it to file
         assert!(cairo_runner.relocate(&mut vm, false).is_ok());
 
-        let trace_entries = vm.get_relocated_trace().unwrap();
+        let trace_entries = cairo_runner.relocated_trace.unwrap();
         let mut buffer = [0; 24];
         let mut buff_writer = SliceWriter::new(&mut buffer);
         // write cairo_rs vm trace file
-        write_encoded_trace(trace_entries, &mut buff_writer).unwrap();
+        write_encoded_trace(&trace_entries, &mut buff_writer).unwrap();
 
         // compare that the original cairo vm trace file and cairo_rs vm trace files are equal
         assert_eq!(buffer, *expected_encoded_trace);
@@ -369,6 +369,6 @@ mod tests {
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
         assert!(cairo_runner.relocate(&mut vm, false).is_ok());
-        assert!(vm.get_relocated_trace().is_err());
+        assert!(cairo_runner.relocated_trace.is_none());
     }
 }

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -2,6 +2,7 @@
 use crate::vm::errors::cairo_run_errors::CairoRunError;
 #[cfg(feature = "cairo-1-hints")]
 use crate::vm::runners::cairo_runner::RunResources;
+use crate::vm::trace::trace_entry::RelocatedTraceEntry;
 #[cfg(feature = "cairo-1-hints")]
 use crate::{
     hint_processor::cairo_1_hint_processor::hint_processor::Cairo1HintProcessor,
@@ -22,7 +23,6 @@ use crate::stdlib::prelude::*;
 use crate::{
     cairo_run::{cairo_run, CairoRunConfig},
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
-    vm::trace::trace_entry::TraceEntry,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -93,9 +93,9 @@ pub(self) fn run_program(
         let expected_trace: Vec<_> = trace
             .iter()
             .copied()
-            .map(|(pc, ap, fp)| TraceEntry { pc, ap, fp })
+            .map(|(pc, ap, fp)| RelocatedTraceEntry { pc, ap, fp })
             .collect();
-        let trace = vm.get_relocated_trace().unwrap();
+        let trace = runner.relocated_trace.as_ref().unwrap();
         assert_eq!(trace.len(), expected_trace.len());
         for (entry, expected) in trace.iter().zip(expected_trace.iter()) {
             assert_eq!(entry, expected);

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -413,7 +413,10 @@ pub mod test_utils {
     pub(crate) use non_continuous_ids_data;
 
     #[track_caller]
-    pub(crate) fn trace_check(actual: &[TraceEntry], expected: &[(usize, usize, usize)]) {
+    pub(crate) fn trace_check(
+        actual: &[TraceEntry],
+        expected: &[(crate::utils::Relocatable, usize, usize)],
+    ) {
         assert_eq!(actual.len(), expected.len());
         for (entry, expected) in actual.iter().zip(expected.iter()) {
             assert_eq!(&(entry.pc, entry.ap, entry.fp), expected);
@@ -704,22 +707,29 @@ mod test {
     fn assert_trace() {
         let trace = vec![
             TraceEntry {
-                pc: 2,
+                pc: (0, 2).into(),
                 ap: 7,
                 fp: 1,
             },
             TraceEntry {
-                pc: 5,
+                pc: (0, 5).into(),
                 ap: 1,
                 fp: 0,
             },
             TraceEntry {
-                pc: 9,
+                pc: (0, 9).into(),
                 ap: 5,
                 fp: 7,
             },
         ];
-        trace_check(&trace, &[(2, 7, 1), (5, 1, 0), (9, 5, 7)]);
+        trace_check(
+            &trace,
+            &[
+                ((0, 2).into(), 7, 1),
+                ((0, 5).into(), 1, 0),
+                ((0, 9).into(), 5, 7),
+            ],
+        );
     }
 
     #[test]

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -7,7 +7,10 @@ use crate::{
         prelude::*,
     },
     types::instance_definitions::keccak_instance_def::KeccakInstanceDef,
-    vm::runners::builtin_runner::SegmentArenaBuiltinRunner,
+    vm::{
+        runners::builtin_runner::SegmentArenaBuiltinRunner,
+        trace::trace_entry::{relocate_trace_register, RelocatedTraceEntry},
+    },
 };
 
 use crate::{
@@ -143,6 +146,7 @@ pub struct CairoRunner {
     pub original_steps: Option<usize>,
     pub relocated_memory: Vec<Option<Felt252>>,
     pub exec_scopes: ExecutionScopes,
+    pub relocated_trace: Option<Vec<RelocatedTraceEntry>>,
 }
 
 impl CairoRunner {
@@ -184,6 +188,7 @@ impl CairoRunner {
             relocated_memory: Vec::new(),
             exec_scopes: ExecutionScopes::new(),
             execution_public_memory: if proof_mode { Some(Vec::new()) } else { None },
+            relocated_trace: None,
         })
     }
 
@@ -756,12 +761,39 @@ impl CairoRunner {
         Ok(())
     }
 
+    ///Relocates the VM's trace, turning relocatable registers to numbered ones
+    fn relocate_trace(
+        &mut self,
+        vm: &VirtualMachine,
+        relocation_table: &Vec<usize>,
+    ) -> Result<(), TraceError> {
+        if self.relocated_trace.is_some() {
+            return Err(TraceError::AlreadyRelocated);
+        }
+
+        let trace = vm.trace.as_ref().ok_or(TraceError::TraceNotEnabled)?.iter();
+        let mut relocated_trace = Vec::<RelocatedTraceEntry>::with_capacity(trace.len());
+        let segment_1_base = relocation_table
+            .get(1)
+            .ok_or(TraceError::NoRelocationFound)?;
+
+        for entry in trace {
+            relocated_trace.push(RelocatedTraceEntry {
+                pc: relocate_trace_register(entry.pc, relocation_table)?,
+                ap: entry.ap + segment_1_base,
+                fp: entry.fp + segment_1_base,
+            })
+        }
+        self.relocated_trace = Some(relocated_trace);
+        Ok(())
+    }
+
     /// Relocates the VM's memory, turning bidimensional indexes into contiguous numbers, and values
     /// into Felt252s. Uses the relocation_table to asign each index a number according to the value
     /// on its segment number.
     fn relocate_memory(
         &mut self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         relocation_table: &Vec<usize>,
     ) -> Result<(), MemoryError> {
         if !(self.relocated_memory.is_empty()) {
@@ -811,8 +843,9 @@ impl CairoRunner {
                 return Err(TraceError::MemoryError(memory_error));
             }
         }
-
-        vm.relocate_trace(&relocation_table)?;
+        if vm.trace.is_some() {
+            self.relocate_trace(vm, &relocation_table)?;
+        }
         vm.relocation_table = Some(relocation_table);
         Ok(())
     }
@@ -1276,7 +1309,9 @@ impl CairoRunner {
             dyn_layout,
             &vm.get_public_memory_addresses()?,
             vm.get_memory_segment_addresses()?,
-            vm.get_relocated_trace()?,
+            self.relocated_trace
+                .as_ref()
+                .ok_or(PublicInputError::EmptyTrace)?,
             self.get_perm_range_check_limits(vm)
                 .ok_or(PublicInputError::NoRangeCheckLimits)?,
         )
@@ -2109,7 +2144,13 @@ mod tests {
         assert_eq!(trace.len(), 5);
         trace_check(
             &trace,
-            &[(3, 2, 2), (5, 3, 2), (0, 5, 5), (2, 6, 5), (7, 6, 2)],
+            &[
+                ((0, 3).into(), 2, 2),
+                ((0, 5).into(), 3, 2),
+                ((0, 0).into(), 5, 5),
+                ((0, 2).into(), 6, 5),
+                ((0, 7).into(), 6, 2),
+            ],
         );
     }
 
@@ -2186,16 +2227,16 @@ mod tests {
         trace_check(
             &trace,
             &[
-                (8, 3, 3),
-                (9, 4, 3),
-                (11, 5, 3),
-                (0, 7, 7),
-                (1, 7, 7),
-                (3, 8, 7),
-                (4, 9, 7),
-                (5, 9, 7),
-                (7, 10, 7),
-                (13, 10, 3),
+                ((0, 8).into(), 3, 3),
+                ((0, 9).into(), 4, 3),
+                ((0, 11).into(), 5, 3),
+                ((0, 0).into(), 7, 7),
+                ((0, 1).into(), 7, 7),
+                ((0, 3).into(), 8, 7),
+                ((0, 4).into(), 9, 7),
+                ((0, 5).into(), 9, 7),
+                ((0, 7).into(), 10, 7),
+                ((0, 13).into(), 10, 3),
             ],
         );
         //Check the range_check builtin segment
@@ -2302,18 +2343,18 @@ mod tests {
         trace_check(
             &trace,
             &[
-                (4, 3, 3),
-                (5, 4, 3),
-                (7, 5, 3),
-                (0, 7, 7),
-                (1, 7, 7),
-                (3, 8, 7),
-                (9, 8, 3),
-                (11, 9, 3),
-                (0, 11, 11),
-                (1, 11, 11),
-                (3, 12, 11),
-                (13, 12, 3),
+                ((0, 4).into(), 3, 3),
+                ((0, 5).into(), 4, 3),
+                ((0, 7).into(), 5, 3),
+                ((0, 0).into(), 7, 7),
+                ((0, 1).into(), 7, 7),
+                ((0, 3).into(), 8, 7),
+                ((0, 9).into(), 8, 3),
+                ((0, 11).into(), 9, 3),
+                ((0, 0).into(), 11, 11),
+                ((0, 1).into(), 11, 11),
+                ((0, 3).into(), 12, 11),
+                ((0, 13).into(), 12, 3),
             ],
         );
         //Check that the output to be printed is correct
@@ -2440,24 +2481,24 @@ mod tests {
         trace_check(
             &trace,
             &[
-                (13, 4, 4),
-                (14, 5, 4),
-                (16, 6, 4),
-                (4, 8, 8),
-                (5, 8, 8),
-                (7, 9, 8),
-                (8, 10, 8),
-                (9, 10, 8),
-                (11, 11, 8),
-                (12, 12, 8),
-                (18, 12, 4),
-                (19, 13, 4),
-                (20, 14, 4),
-                (0, 16, 16),
-                (1, 16, 16),
-                (3, 17, 16),
-                (22, 17, 4),
-                (23, 18, 4),
+                ((0, 13).into(), 4, 4),
+                ((0, 14).into(), 5, 4),
+                ((0, 16).into(), 6, 4),
+                ((0, 4).into(), 8, 8),
+                ((0, 5).into(), 8, 8),
+                ((0, 7).into(), 9, 8),
+                ((0, 8).into(), 10, 8),
+                ((0, 9).into(), 10, 8),
+                ((0, 11).into(), 11, 8),
+                ((0, 12).into(), 12, 8),
+                ((0, 18).into(), 12, 4),
+                ((0, 19).into(), 13, 4),
+                ((0, 20).into(), 14, 4),
+                ((0, 0).into(), 16, 16),
+                ((0, 1).into(), 16, 16),
+                ((0, 3).into(), 17, 16),
+                ((0, 22).into(), 17, 4),
+                ((0, 23).into(), 18, 4),
             ],
         );
         //Check the range_check builtin segment
@@ -2562,7 +2603,7 @@ mod tests {
             .segments
             .relocate_segments()
             .expect("Couldn't relocate after compute effective sizes");
-        assert_eq!(cairo_runner.relocate_memory(&mut vm, &rel_table), Ok(()));
+        assert_eq!(cairo_runner.relocate_memory(&vm, &rel_table), Ok(()));
         assert_eq!(cairo_runner.relocated_memory[0], None);
         assert_eq!(
             cairo_runner.relocated_memory[1],
@@ -2668,7 +2709,7 @@ mod tests {
             .segments
             .relocate_segments()
             .expect("Couldn't relocate after compute effective sizes");
-        assert_eq!(cairo_runner.relocate_memory(&mut vm, &rel_table), Ok(()));
+        assert_eq!(cairo_runner.relocate_memory(&vm, &rel_table), Ok(()));
         assert_eq!(cairo_runner.relocated_memory[0], None);
         assert_eq!(
             cairo_runner.relocated_memory[1],
@@ -2807,12 +2848,12 @@ mod tests {
             .segments
             .relocate_segments()
             .expect("Couldn't relocate after compute effective sizes");
-        vm.relocate_trace(&rel_table).unwrap();
-        let relocated_trace = vm.trace.unwrap();
+        cairo_runner.relocate_trace(&vm, &rel_table).unwrap();
+        let relocated_trace = cairo_runner.relocated_trace.unwrap();
         assert_eq!(relocated_trace.len(), 12);
         assert_eq!(
             relocated_trace[0],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 5,
                 ap: 18,
                 fp: 18
@@ -2820,7 +2861,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[1],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 6,
                 ap: 19,
                 fp: 18
@@ -2828,7 +2869,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[2],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 8,
                 ap: 20,
                 fp: 18
@@ -2836,7 +2877,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[3],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 1,
                 ap: 22,
                 fp: 22
@@ -2844,7 +2885,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[4],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 2,
                 ap: 22,
                 fp: 22
@@ -2852,7 +2893,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[5],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 4,
                 ap: 23,
                 fp: 22
@@ -2860,7 +2901,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[6],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 10,
                 ap: 23,
                 fp: 18
@@ -2868,7 +2909,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[7],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 12,
                 ap: 24,
                 fp: 18
@@ -2876,7 +2917,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[8],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 1,
                 ap: 26,
                 fp: 26
@@ -2884,7 +2925,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[9],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 2,
                 ap: 26,
                 fp: 26
@@ -2892,7 +2933,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[10],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 4,
                 ap: 27,
                 fp: 26
@@ -2900,7 +2941,7 @@ mod tests {
         );
         assert_eq!(
             relocated_trace[11],
-            TraceEntry {
+            RelocatedTraceEntry {
                 pc: 14,
                 ap: 27,
                 fp: 18
@@ -3972,7 +4013,7 @@ mod tests {
             0x80FF_8000_0530u64
         )))]];
         vm.trace = Some(vec![TraceEntry {
-            pc: 0,
+            pc: (0, 0).into(),
             ap: 0,
             fp: 0,
         }]);
@@ -3994,7 +4035,7 @@ mod tests {
             0x80FF_8000_0530u64
         )))]];
         vm.trace = Some(vec![TraceEntry {
-            pc: 0,
+            pc: (0, 0).into(),
             ap: 0,
             fp: 0,
         }]);
@@ -4062,7 +4103,7 @@ mod tests {
             0x80FF_8000_0530u64
         )))]];
         vm.trace = Some(vec![TraceEntry {
-            pc: 0,
+            pc: (0, 0).into(),
             ap: 0,
             fp: 0,
         }]);

--- a/vm/src/vm/trace/mod.rs
+++ b/vm/src/vm/trace/mod.rs
@@ -1,16 +1,42 @@
 pub mod trace_entry {
     use serde::{Deserialize, Serialize};
 
+    use crate::{
+        stdlib::prelude::*,
+        types::relocatable::Relocatable,
+        vm::errors::{memory_errors::MemoryError, trace_errors::TraceError},
+    };
+
     ///A trace entry for every instruction that was executed.
     ///Holds the register values before the instruction was executed.
-    /// Before relocation:
-    ///     Register values are represented as their offsets, as their indexes will always be 0,1,1 respectively
-    ///     The index of the last pc will not be equal to 0, but it is not appended to the trace
-    /// After relocation the value of each register will be a single integer
+    ///Register values for ap & fp are represented as their offsets, as their indexes will always be 1
     #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
     pub struct TraceEntry {
+        pub pc: Relocatable,
+        pub ap: usize,
+        pub fp: usize,
+    }
+
+    /// A trace entry for every instruction that was executed.
+    /// Holds the register values before the instruction was executed, after going through the relocation process
+    #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+    pub struct RelocatedTraceEntry {
         pub pc: usize,
         pub ap: usize,
         pub fp: usize,
+    }
+
+    pub fn relocate_trace_register(
+        value: Relocatable,
+        relocation_table: &Vec<usize>,
+    ) -> Result<usize, TraceError> {
+        let segment_index: usize = value.segment_index.try_into().map_err(|_| {
+            TraceError::MemoryError(MemoryError::AddressInTemporarySegment(value.segment_index))
+        })?;
+
+        if relocation_table.len() <= segment_index {
+            return Err(TraceError::NoRelocationFound);
+        }
+        Ok(relocation_table[segment_index] + value.offset)
     }
 }

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -4326,7 +4326,7 @@ mod tests {
             Ok(())
         );
         let trace = vm.trace.unwrap();
-        trace_check(&trace, &[(0, 2, 2)]);
+        trace_check(&trace, &[((2,0).into(), 2, 2)]);
 
         assert_eq!(vm.run_context.pc, Relocatable::from((3, 0)));
         assert_eq!(vm.run_context.ap, 2);

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -28,7 +28,6 @@ use felt::Felt252;
 use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
-use super::errors::trace_errors::TraceError;
 use super::runners::builtin_runner::OUTPUT_BUILTIN_NAME;
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
@@ -80,7 +79,6 @@ pub struct VirtualMachine {
     pub(crate) trace: Option<Vec<TraceEntry>>,
     pub(crate) current_step: usize,
     pub(crate) rc_limits: Option<(isize, isize)>,
-    trace_relocated: bool,
     skip_instruction_execution: bool,
     run_finished: bool,
     instruction_cache: Vec<Option<Instruction>>,
@@ -112,7 +110,6 @@ impl VirtualMachine {
             segments: MemorySegmentManager::new(),
             rc_limits: None,
             run_finished: false,
-            trace_relocated: false,
             instruction_cache: Vec::new(),
             #[cfg(feature = "hooks")]
             hooks: Default::default(),
@@ -396,7 +393,7 @@ impl VirtualMachine {
 
         if let Some(ref mut trace) = &mut self.trace {
             trace.push(TraceEntry {
-                pc: self.run_context.pc.offset,
+                pc: self.run_context.pc,
                 ap: self.run_context.ap,
                 fp: self.run_context.fp,
             });
@@ -979,34 +976,6 @@ impl VirtualMachine {
         Ok(())
     }
 
-    ///Relocates the VM's trace, turning relocatable registers to numbered ones
-    pub fn relocate_trace(&mut self, relocation_table: &[usize]) -> Result<(), TraceError> {
-        if let Some(ref mut trace) = self.trace {
-            if self.trace_relocated {
-                return Err(TraceError::AlreadyRelocated);
-            }
-            let segment_1_base = relocation_table
-                .get(1)
-                .ok_or(TraceError::NoRelocationFound)?;
-
-            trace.iter_mut().for_each(|entry| {
-                entry.pc += 1;
-                entry.ap += segment_1_base;
-                entry.fp += segment_1_base;
-            });
-            self.trace_relocated = true;
-        }
-        Ok(())
-    }
-
-    pub fn get_relocated_trace(&self) -> Result<&Vec<TraceEntry>, TraceError> {
-        if self.trace_relocated {
-            self.trace.as_ref().ok_or(TraceError::TraceNotEnabled)
-        } else {
-            Err(TraceError::TraceNotRelocated)
-        }
-    }
-
     /// Returns a list of addresses of memory cells that constitute the public memory.
     pub fn get_public_memory_addresses(&self) -> Result<Vec<(usize, usize)>, VirtualMachineError> {
         if let Some(relocation_table) = &self.relocation_table {
@@ -1142,7 +1111,6 @@ impl VirtualMachineBuilder {
             segments: self.segments,
             rc_limits: None,
             run_finished: self.run_finished,
-            trace_relocated: false,
             instruction_cache: Vec::new(),
             #[cfg(feature = "hooks")]
             hooks: self.hooks,
@@ -2930,7 +2898,7 @@ mod tests {
             Ok(())
         );
         let trace = vm.trace.unwrap();
-        trace_check(&trace, &[(0, 2, 2)]);
+        trace_check(&trace, &[((0, 0).into(), 2, 2)]);
 
         assert_eq!(vm.run_context.pc, Relocatable::from((3, 0)));
         assert_eq!(vm.run_context.ap, 2);
@@ -3024,7 +2992,13 @@ mod tests {
         assert_eq!(trace.len(), 5);
         trace_check(
             &trace,
-            &[(3, 2, 2), (5, 3, 2), (0, 5, 5), (2, 6, 5), (7, 6, 2)],
+            &[
+                ((0, 3).into(), 2, 2),
+                ((0, 5).into(), 3, 2),
+                ((0, 0).into(), 5, 5),
+                ((0, 2).into(), 6, 5),
+                ((0, 7).into(), 6, 2),
+            ],
         );
         //Check that the following addresses have been accessed:
         // Addresses have been copied from python execution:
@@ -3723,12 +3697,12 @@ mod tests {
         trace_check(
             &trace,
             &[
-                (3, 2, 2),
-                (0, 4, 4),
-                (2, 5, 4),
-                (5, 5, 2),
-                (7, 6, 2),
-                (8, 6, 2),
+                ((0, 3).into(), 2, 2),
+                ((0, 0).into(), 4, 4),
+                ((0, 2).into(), 5, 4),
+                ((0, 5).into(), 5, 2),
+                ((0, 7).into(), 6, 2),
+                ((0, 8).into(), 6, 2),
             ],
         );
 
@@ -4243,7 +4217,7 @@ mod tests {
             })
             .skip_instruction_execution(true)
             .trace(Some(vec![TraceEntry {
-                pc: 1,
+                pc: (0, 1).into(),
                 ap: 1,
                 fp: 1,
             }]));
@@ -4285,7 +4259,7 @@ mod tests {
         assert_eq!(
             virtual_machine_from_builder.trace,
             Some(vec![TraceEntry {
-                pc: 1,
+                pc: (0, 1).into(),
                 ap: 1,
                 fp: 1,
             }])


### PR DESCRIPTION
In order to run the os, we need to load programs into new segments and run them by setting the pc to their starting location. In order to achieve this, we must handle pc's with an index different from 0 in `step_instruction`.

