### PR TITLE
ci: run tests with optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ ark-std = { version = "0.4.0", default-features = false }
 # For fuzzing
 arbitrary = { version = "1.3.0", features = ["derive"] }
 
+[profile.test]
+opt-level = 2
+
 [profile.release]
 lto = "fat"
 


### PR DESCRIPTION
This saves a lot of execution time and, in the case of coverage builds, disk space.
O2 seems to give good results, so I'm going with it.
Local tests on a development machine:

| PROFILE | BUILD TIME | RUN TIME | COV ARTIFACTS |
|---------|------------|----------|---------------|
| NONE    | 61s        | 112s     | N/A           |
| O1      | 193s       | 16s      | N/A           |
| O2      | 190s       | 13s      | N/A           |
| O3      | 192s       | 12s      | N/A           |
| Os      | 126s       | 14s      | N/A           |
| Oz      | 138s       | 21s      | N/A           |
| COV     | 68s        | 451s     | 90GB          |
| COV+O1  | 182s       | 130s     | 93GB          |
| COV+O2  | 204s       | 95s      | 69GB          |
| COV+O3  | 208s       | 98s      | 69GB          |
| COV+Os  | 180s       | 131s     | 93GB          |
| COV+Oz  | 157s       | 140s     | 93GB          |

On CI first run (invalidated cache) tests take about 9-10 minutes per shard. This seems stable too afterwards, which makes sense since most time seems to be spent linking the binaries rather than compiling dependencies, and artifacts local to the project aren't cached by `rust-cache`.