### PR TITLE
Use `ProjectivePoint` from types-rs in ec_op builtin impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: Use `ProjectivePoint` from types-rs in ec_op builtin impl [#1532](https://github.com/lambdaclass/cairo-vm/pull/1532)
+
 * feat(BREAKING): Replace `cairo-felt` crate with `starknet-types-core` (0.0.5) [#1408](https://github.com/lambdaclass/cairo-vm/pull/1408)
 
 * feat(BREAKING): Add Cairo 1 proof mode compilation and execution [#1517] (https://github.com/lambdaclass/cairo-vm/pull/1517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat(BREAKING): Replace `cairo-felt` crate with `starknet-types-core` [#1408](https://github.com/lambdaclass/cairo-vm/pull/1408)
+* feat(BREAKING): Replace `cairo-felt` crate with `starknet-types-core` (0.0.5) [#1408](https://github.com/lambdaclass/cairo-vm/pull/1408)
 
 * feat(BREAKING): Add Cairo 1 proof mode compilation and execution [#1517] (https://github.com/lambdaclass/cairo-vm/pull/1517)
     * In the cairo1-run crate, now the Cairo 1 Programs are compiled and executed in proof-mode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b4af540664e3dec02f36a47b79ba4df825a7752bf0941954f69753a98a397e"
+checksum = "b2441eb61d91a6bae832fda48e50b6ff09faa6cf63bfadd22dc16798d2cc024d"
 dependencies = [
  "arbitrary",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,8 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.3.0"
-source = "git+https://github.com/lambdaclass/lambdaworks.git?rev=55731492f8d919523a692265b1c34e7ca6387a0d#55731492f8d919523a692265b1c34e7ca6387a0d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6c4d0ddd1fcd235be5196b1bcc404f89ad3e911f4c190fa01459e05dbf40f8"
 dependencies = [
  "thiserror",
 ]
@@ -2452,8 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.5"
-source = "git+https://github.com/lambdaclass/types-rs.git?rev=2cdd735eda7d225ce801e8fa62cdf534f960fc04#2cdd735eda7d225ce801e8fa62cdf534f960fc04"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6b868f545d43b474c2c00e9349c489fdeb7ff17eb00cdf339744ac4cae0930"
 dependencies = [
  "arbitrary",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,8 +1506,10 @@ dependencies = [
 [[package]]
 name = "lambdaworks-math"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540c0715d7da472edc421ceca702d3f3a716b3b9168b6211f2e3939cb14c863c"
+source = "git+https://github.com/lambdaclass/lambdaworks.git?rev=55731492f8d919523a692265b1c34e7ca6387a0d#55731492f8d919523a692265b1c34e7ca6387a0d"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2451,8 +2453,6 @@ dependencies = [
 [[package]]
 name = "starknet-types-core"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2441eb61d91a6bae832fda48e50b6ff09faa6cf63bfadd22dc16798d2cc024d"
 dependencies = [
  "arbitrary",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
 [[package]]
 name = "starknet-types-core"
 version = "0.0.5"
+source = "git+https://github.com/lambdaclass/types-rs.git?rev=2cdd735eda7d225ce801e8fa62cdf534f960fc04#2cdd735eda7d225ce801e8fa62cdf534f960fc04"
 dependencies = [
  "arbitrary",
  "bitvec",

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -412,8 +412,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.3.0"
-source = "git+https://github.com/lambdaclass/lambdaworks.git?rev=55731492f8d919523a692265b1c34e7ca6387a0d#55731492f8d919523a692265b1c34e7ca6387a0d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6c4d0ddd1fcd235be5196b1bcc404f89ad3e911f4c190fa01459e05dbf40f8"
 dependencies = [
  "thiserror",
 ]
@@ -906,8 +907,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.5"
-source = "git+https://github.com/lambdaclass/types-rs.git?rev=2cdd735eda7d225ce801e8fa62cdf534f960fc04#2cdd735eda7d225ce801e8fa62cdf534f960fc04"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6b868f545d43b474c2c00e9349c489fdeb7ff17eb00cdf339744ac4cae0930"
 dependencies = [
  "arbitrary",
  "bitvec",

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -413,8 +413,10 @@ dependencies = [
 [[package]]
 name = "lambdaworks-math"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540c0715d7da472edc421ceca702d3f3a716b3b9168b6211f2e3939cb14c863c"
+source = "git+https://github.com/lambdaclass/lambdaworks.git?rev=55731492f8d919523a692265b1c34e7ca6387a0d#55731492f8d919523a692265b1c34e7ca6387a0d"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "lazy_static"
@@ -904,9 +906,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b4af540664e3dec02f36a47b79ba4df825a7752bf0941954f69753a98a397e"
+version = "0.0.5"
+source = "git+https://github.com/lambdaclass/types-rs.git?rev=2cdd735eda7d225ce801e8fa62cdf534f960fc04#2cdd735eda7d225ce801e8fa62cdf534f960fc04"
 dependencies = [
  "arbitrary",
  "bitvec",
@@ -957,6 +958,26 @@ name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "thiserror-impl-no-std"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -62,7 +62,7 @@ hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
 # FIXME: Update after release
-starknet-types-core = { git = "https://github.com/lambdaclass/types-rs.git", rev = "2cdd735eda7d225ce801e8fa62cdf534f960fc04", default-features = false, features = ["serde", "curve", "num-traits"] }
+starknet-types-core = { version = "0.0.6", default-features = false, features = ["serde", "curve", "num-traits"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -61,7 +61,6 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
-# FIXME: Update after release
 starknet-types-core = { version = "0.0.6", default-features = false, features = ["serde", "curve", "num-traits"] }
 
 # only for std

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -61,7 +61,7 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
-starknet-types-core = { version = "0.0.4", default-features = false, features = ["serde"] }
+starknet-types-core = { version = "0.0.5", default-features = false, features = ["serde"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -61,7 +61,7 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
-starknet-types-core = { path = "../../types-rs/crates/starknet-types-core", default-features = false, features = ["serde", "curve"] }
+starknet-types-core = { path = "../../types-rs/crates/starknet-types-core", default-features = false, features = ["serde", "curve", "num-traits"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -61,7 +61,7 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
-starknet-types-core = { version = "0.0.5", default-features = false, features = ["serde"] }
+starknet-types-core = { path = "../../types-rs/crates/starknet-types-core", default-features = false, features = ["serde", "curve"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -62,7 +62,7 @@ hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
 # FIXME: Update after release
-starknet-types-core = { git = "https://github.com/lambdaclass/types-rs.git", rev "2cdd735eda7d225ce801e8fa62cdf534f960fc04", default-features = false, features = ["serde", "curve", "num-traits"] }
+starknet-types-core = { git = "https://github.com/lambdaclass/types-rs.git", rev = "2cdd735eda7d225ce801e8fa62cdf534f960fc04", default-features = false, features = ["serde", "curve", "num-traits"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -61,7 +61,8 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror-no-std = { workspace = true }
-starknet-types-core = { path = "../../types-rs/crates/starknet-types-core", default-features = false, features = ["serde", "curve", "num-traits"] }
+# FIXME: Update after release
+starknet-types-core = { git = "https://github.com/lambdaclass/types-rs.git", rev "2cdd735eda7d225ce801e8fa62cdf534f960fc04", default-features = false, features = ["serde", "curve", "num-traits"] }
 
 # only for std
 num-prime = { version = "0.4.3", features = ["big-int"], optional = true }

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -50,10 +50,10 @@ pub fn pow2_const_nz(n: u32) -> &'static NonZeroFelt {
 /// ```
 /// # use cairo_vm::{Felt252, math_utils::signed_felt};
 /// # use num_bigint::BigInt;
-/// let positive = Felt252::new(5);
+/// let positive = Felt252::from(5);
 /// assert_eq!(signed_felt(positive), BigInt::from(5));
 ///
-/// let negative = Felt252::max_value();
+/// let negative = Felt252::MAX;
 /// assert_eq!(signed_felt(negative), BigInt::from(-1));
 /// ```
 

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -48,12 +48,13 @@ pub fn pow2_const_nz(n: u32) -> &'static NonZeroFelt {
 /// # Examples
 ///
 /// ```
-/// # use crate::Felt252;
+/// # use cairo_vm::{Felt252, math_utils::signed_felt};
+/// # use num_bigint::BigInt;
 /// let positive = Felt252::new(5);
-/// assert_eq!(signed_felt(positive), Felt252::from(5));
+/// assert_eq!(signed_felt(positive), BigInt::from(5));
 ///
 /// let negative = Felt252::max_value();
-/// assert_eq!(signed_felt(negative), Felt252::from(-1));
+/// assert_eq!(signed_felt(negative), BigInt::from(-1));
 /// ```
 
 pub fn signed_felt(felt: Felt252) -> BigInt {

--- a/vm/src/vm/errors/runner_errors.rs
+++ b/vm/src/vm/errors/runner_errors.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::explicit_auto_deref)]
 
 use crate::stdlib::{collections::HashSet, prelude::*};
-
 use thiserror_no_std::Error;
 
 use super::{memory_errors::MemoryError, trace_errors::TraceError};
@@ -101,6 +100,8 @@ pub enum RunnerError {
     StrippedProgramNoMain,
     #[error(transparent)]
     Trace(#[from] TraceError),
+    #[error("EcOp builtin: Invalid Point")]
+    InvalidPoint,
 }
 
 #[cfg(test)]

--- a/vm/src/vm/runners/builtin_runner/ec_op.rs
+++ b/vm/src/vm/runners/builtin_runner/ec_op.rs
@@ -66,9 +66,9 @@ impl EcOpBuiltinRunner {
     ) -> Result<(Felt252, Felt252), RunnerError> {
         let mut slope = felt_to_bigint(*m);
         let mut partial_sum_b = ProjectivePoint::from_affine(partial_sum.0, partial_sum.1)
-            .map_err(|_| RunnerError::InvalidPoint)?;
+            .map_err(|_| RunnerError::PointNotOnCurve(Box::new(partial_sum)))?;
         let mut doubled_point_b = ProjectivePoint::from_affine(doubled_point.0, doubled_point.1)
-            .map_err(|_| RunnerError::InvalidPoint)?;
+            .map_err(|_| RunnerError::PointNotOnCurve(Box::new(doubled_point)))?;
         for _ in 0..height {
             if partial_sum_b.x() * doubled_point_b.z() == partial_sum_b.z() * doubled_point_b.x() {
                 #[allow(deprecated)]

--- a/vm/src/vm/runners/builtin_runner/ec_op.rs
+++ b/vm/src/vm/runners/builtin_runner/ec_op.rs
@@ -65,7 +65,7 @@ impl EcOpBuiltinRunner {
             .map_err(|_| RunnerError::PointNotOnCurve(Box::new(partial_sum)))?;
         let mut doubled_point_b = ProjectivePoint::from_affine(doubled_point.0, doubled_point.1)
             .map_err(|_| RunnerError::PointNotOnCurve(Box::new(doubled_point)))?;
-        for i in 0..(Into::<u64>::into(height)).min(slope.bits()) {
+        for i in 0..(height as u64).min(slope.bits()) {
             if partial_sum_b.x() * doubled_point_b.z() == partial_sum_b.z() * doubled_point_b.x() {
                 return Err(RunnerError::EcOpSameXCoordinate(
                     Self::format_ec_op_error(partial_sum_b, slope, doubled_point_b)


### PR DESCRIPTION
Use types-rs `ProjectivePoint` implementation (aka lambdaworks implementation) for ec_op builtin operations
Pending:

- [x] Merge [lambdaworks PR](https://github.com/lambdaclass/lambdaworks/pull/737)
- [x] Create [PR in types-rs](https://github.com/starknet-io/types-rs/pull/32)
- [x] Merge PR in types-rs
- [x] Update `starknet-core-types` version
