### PR TITLE
add HintError::CustomHintEx and trait HintProcessorError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Upcoming Changes
 
+* feat: Add HintError::CustomHintEx [#1540](https://github.com/lambdaclass/cairo-vm/pull/1540)
+    * Add trait `HintProcessorError`.
+    * Add `HintError::CustomHintEx(Box<dyn HintProcessorError>)` that allows wrapping non-string errors.
+
 * feat(BREAKING): Replace `cairo-felt` crate with `starknet-types-core` (0.0.5) [#1408](https://github.com/lambdaclass/cairo-vm/pull/1408)
 
 * feat(BREAKING): Add Cairo 1 proof mode compilation and execution [#1517] (https://github.com/lambdaclass/cairo-vm/pull/1517)

--- a/vm/src/hint_processor/hint_processor_definition.rs
+++ b/vm/src/hint_processor/hint_processor_definition.rs
@@ -14,9 +14,14 @@ use crate::vm::vm_core::VirtualMachine;
 
 use super::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
 use crate::Felt252;
+use std::fmt::{Debug, Display};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+
+pub trait HintProcessorError: Debug + Display {
+    fn as_any(&self) -> &dyn Any;
+}
 
 pub trait HintProcessorLogic {
     // Executes the hint which's data is provided by a dynamic structure previously created by compile_hint

--- a/vm/src/vm/errors/hint_errors.rs
+++ b/vm/src/vm/errors/hint_errors.rs
@@ -8,6 +8,7 @@ use thiserror_no_std::Error;
 use crate::Felt252;
 use num_bigint::{BigInt, BigUint};
 
+use crate::hint_processor::hint_processor_definition::HintProcessorError;
 use crate::types::{
     errors::math_errors::MathError,
     relocatable::{MaybeRelocatable, Relocatable},
@@ -44,6 +45,8 @@ pub enum HintError {
     WrongIdentifierTypeInternal(Box<Relocatable>),
     #[error("Hint Error: {0}")]
     CustomHint(Box<str>),
+    #[error("Hint Error: {0}")]
+    CustomHintEx(Box<dyn HintProcessorError>),
     #[error("Missing constant: {0}")]
     MissingConstant(Box<&'static str>),
     #[error("Fail to get constants for hint execution")]


### PR DESCRIPTION
Add `trait HintProcessorError` and  a `CustomHintEx` variant to `HintError` that uses the trait.
The extended custom hint error is to be used by the hint processor in Starknet 's Blockifier to improve error handling.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

