### PR TITLE
Remove redundant memory_hole checks from cairo_run_tests module

### DIFF
--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -84,7 +84,7 @@ fn jmp() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn jmp_if_condition() {
     let program_data = include_bytes!("../../../cairo_programs/jmp_if_condition.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -190,21 +190,21 @@ fn compare_arrays() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_greater_array() {
     let program_data = include_bytes!("../../../cairo_programs/compare_greater_array.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 170);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_lesser_array() {
     let program_data = include_bytes!("../../../cairo_programs/compare_lesser_array.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 200);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_felt_hint() {
     let program_data = include_bytes!("../../../cairo_programs/assert_le_felt_hint.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn split_felt() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_cmp() {
     let program_data = include_bytes!("../../../cairo_programs/math_cmp.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 372);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn signed_div_rem() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_lt_felt() {
     let program_data = include_bytes!("../../../cairo_programs/assert_lt_felt.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 8);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -316,28 +316,28 @@ fn memset() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn pow() {
     let program_data = include_bytes!("../../../cairo_programs/pow.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 6);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict() {
     let program_data = include_bytes!("../../../cairo_programs/dict.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 4);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_update() {
     let program_data = include_bytes!("../../../cairo_programs/dict_update.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256() {
     let program_data = include_bytes!("../../../cairo_programs/uint256.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 3554);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -351,14 +351,14 @@ fn find_element() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn search_sorted_lower() {
     let program_data = include_bytes!("../../../cairo_programs/search_sorted_lower.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 4);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn usort() {
     let program_data = include_bytes!("../../../cairo_programs/usort.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 3);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn dict_squash() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_add() {
     let program_data = include_bytes!("../../../cairo_programs/set_add.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -393,7 +393,7 @@ fn secp() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_ec() {
     let program_data = include_bytes!("../../../cairo_programs/secp_ec.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1752);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -407,28 +407,28 @@ fn signature() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_hello_world_hash() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_hello_world_hash.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn example_blake2s() {
     let program_data = include_bytes!("../../../cairo_programs/example_blake2s.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn finalize_blake2s() {
     let program_data = include_bytes!("../../../cairo_programs/finalize_blake2s.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn finalize_blake2s_v2_hint() {
     let program_data = include_bytes!("../../../cairo_programs/finalize_blake2s_v2_hint.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -442,7 +442,7 @@ fn unsafe_keccak() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_felts() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_felts.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 278);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -463,7 +463,7 @@ fn keccak_add_uint256() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak() {
     let program_data = include_bytes!("../../../cairo_programs/_keccak.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 21);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -477,7 +477,7 @@ fn keccak_copy_inputs() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_finalize_keccak_v1() {
     let program_data = include_bytes!("../../../cairo_programs/cairo_finalize_keccak.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 50);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn cairo_finalize_keccak_v1() {
 fn cairo_finalize_keccak_v2() {
     let program_data =
         include_bytes!("../../../cairo_programs/cairo_finalize_keccak_block_size_1000.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 50);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -493,14 +493,14 @@ fn cairo_finalize_keccak_v2() {
 fn operations_with_data_structures() {
     let program_data =
         include_bytes!("../../../cairo_programs/operations_with_data_structures.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 72);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn packed_sha256() {
     let program_data = include_bytes!("../../../cairo_programs/packed_sha256_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -508,56 +508,56 @@ fn packed_sha256() {
 fn math_cmp_and_pow_integration_tests() {
     let program_data =
         include_bytes!("../../../cairo_programs/math_cmp_and_pow_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1213);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/uint256_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1027);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/set_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memory_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/memory_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 5);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/dict_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 32);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/secp_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 4626);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/keccak_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 507);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_integration_tests() {
     let program_data = include_bytes!("../../../cairo_programs/blake2s_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 409);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -571,14 +571,14 @@ fn relocate_segments() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments_with_offset() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments_with_offset.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 5);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_store_cast_ptr() {
     let program_data = include_bytes!("../../../cairo_programs/dict_store_cast_ptr.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -712,14 +712,14 @@ fn recover_y() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_integration() {
     let program_data = include_bytes!("../../../cairo_programs/math_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 109);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn is_quad_residue_test() {
     let program_data = include_bytes!("../../../cairo_programs/is_quad_residue_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 6);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -733,28 +733,28 @@ fn mul_s_inv() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_alternative_hint() {
     let program_data = include_bytes!("../../../cairo_programs/_keccak_alternative_hint.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 24);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint384() {
     let program_data = include_bytes!("../../../cairo_programs/uint384_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 54);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint384_extension() {
     let program_data = include_bytes!("../../../cairo_programs/uint384_extension_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 40);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn field_arithmetic() {
     let program_data = include_bytes!("../../../cairo_programs/field_arithmetic.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 507);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -845,14 +845,14 @@ fn highest_bitlen() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_improvements() {
     let program_data = include_bytes!("../../../cairo_programs/uint256_improvements.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 128);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memory_holes() {
     let program_data = include_bytes!("../../../cairo_programs/memory_holes.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 5)
+    run_program_simple(program_data.as_slice())
 }
 
 #[test]
@@ -880,14 +880,14 @@ fn bitand_hint() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_felt_old() {
     let program_data = include_bytes!("../../../cairo_programs/assert_le_felt_old.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 35);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_fq_test() {
     let program_data = include_bytes!("../../../cairo_programs/fq_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 120);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -971,14 +971,14 @@ fn cairo_run_ec_double_slope() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_normalize_address() {
     let program_data = include_bytes!("../../../cairo_programs/normalize_address.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 110);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_sha256_test() {
     let program_data = include_bytes!("../../../cairo_programs/sha256_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 923);
+    run_program_simple(program_data.as_slice());
 }
 
 #[test]
@@ -991,7 +991,7 @@ fn cairo_run_reduce() {
 #[test]
 fn cairo_run_if_reloc_equal() {
     let program_data = include_bytes!("../../../cairo_programs/if_reloc_equal.json");
-    run_program_simple_with_memory_holes(program_data, 4);
+    run_program_simple(program_data);
 }
 
 #[test]
@@ -1051,7 +1051,7 @@ fn cairo_run_print_array() {
 #[cfg(feature = "print")]
 fn cairo_run_print_dict_felt() {
     let program_data = include_bytes!("../../../cairo_programs/print_feature/print_dict_felt.json");
-    run_program_simple_with_memory_holes(program_data, 5);
+    run_program_simple(program_data);
 }
 
 #[test]
@@ -1059,5 +1059,5 @@ fn cairo_run_print_dict_felt() {
 fn cairo_run_print_dict_array() {
     let program_data =
         include_bytes!("../../../cairo_programs/print_feature/print_dict_array.json");
-    run_program_simple_with_memory_holes(program_data, 4);
+    run_program_simple(program_data);
 }

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -48,26 +48,20 @@ mod skip_instruction_test;
 //For simple programs that should just succeed and have no special needs.
 //Checks memory holes == 0
 pub(self) fn run_program_simple(data: &[u8]) {
-    run_program(data, Some("all_cairo"), None, None, Some(0))
-}
-
-//For simple programs that should just succeed and have no special needs.
-//Checks memory holes
-pub(self) fn run_program_simple_with_memory_holes(data: &[u8], holes: usize) {
-    run_program(data, Some("all_cairo"), None, None, Some(holes))
+    run_program(data, Some("all_cairo"), None, None)
 }
 
 //For simple programs that should just succeed but using small layout.
 pub(self) fn run_program_small(data: &[u8]) {
-    run_program(data, Some("small"), None, None, None)
+    run_program(data, Some("small"), None, None)
 }
 
 pub(self) fn run_program_with_trace(data: &[u8], trace: &[(usize, usize, usize)]) {
-    run_program(data, Some("all_cairo"), Some(trace), None, None)
+    run_program(data, Some("all_cairo"), Some(trace), None)
 }
 
 pub(self) fn run_program_with_error(data: &[u8], error: &str) {
-    run_program(data, Some("all_cairo"), None, Some(error), None)
+    run_program(data, Some("all_cairo"), None, Some(error))
 }
 
 pub(self) fn run_program(
@@ -75,7 +69,6 @@ pub(self) fn run_program(
     layout: Option<&str>,
     trace: Option<&[(usize, usize, usize)]>,
     error: Option<&str>,
-    memory_holes: Option<usize>,
 ) {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
     let cairo_run_config = CairoRunConfig {
@@ -90,7 +83,7 @@ pub(self) fn run_program(
         assert!(res.err().unwrap().to_string().contains(error));
         return;
     }
-    let (runner, vm) = res.expect("Execution failed");
+    let (runner, _) = res.expect("Execution failed");
     if let Some(trace) = trace {
         let expected_trace: Vec<_> = trace
             .iter()
@@ -102,9 +95,6 @@ pub(self) fn run_program(
         for (entry, expected) in trace.iter().zip(expected_trace.iter()) {
             assert_eq!(entry, expected);
         }
-    }
-    if let Some(holes) = memory_holes {
-        assert_eq!(runner.get_memory_holes(&vm).unwrap(), holes);
     }
 }
 


### PR DESCRIPTION
Closes #1584 
Preferrably merge after #1578, as checks are replaced by cairo pie output comparison

