### PR TITLE
Feature: deserialize AIR private input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   * Add instructions to the proof_mode header to copy return values to the output segment before initiating the infinite loop
   * Output builtin is now always included when running cairo 1 programs in proof_mode
 
+* feat: deserialize AIR private input [#1589](https://github.com/lambdaclass/cairo-vm/pull/1589)
+
 * feat(BREAKING): Remove unecessary conversion functions between `Felt` & `BigUint`/`BigInt` [#1562](https://github.com/lambdaclass/cairo-vm/pull/1562)
   * Remove the following functions:
     * felt_from_biguint

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -157,14 +157,18 @@ impl AirPrivateInputSerializable {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::air_private_input::{AirPrivateInput, AirPrivateInputSerializable};
-    use crate::vm::runners::builtin_runner::{
-        BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME, KECCAK_BUILTIN_NAME,
-        POSEIDON_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
+    #[cfg(feature = "std")]
+    use {
+        super::*,
+        crate::air_private_input::{AirPrivateInput, AirPrivateInputSerializable},
+        crate::vm::runners::builtin_runner::{
+            BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME, KECCAK_BUILTIN_NAME,
+            POSEIDON_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
+        },
+        assert_matches::assert_matches,
     };
-    use assert_matches::assert_matches;
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_from_serializable() {
         let serializable_private_input = AirPrivateInputSerializable {

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -135,6 +135,20 @@ impl AirPrivateInput {
     }
 }
 
+impl From<AirPrivateInputSerializable> for AirPrivateInput {
+    fn from(private_input: AirPrivateInputSerializable) -> Self {
+        Self(HashMap::from([
+            (HASH_BUILTIN_NAME, private_input.pedersen),
+            (RANGE_CHECK_BUILTIN_NAME, private_input.range_check),
+            (SIGNATURE_BUILTIN_NAME, private_input.ecdsa),
+            (BITWISE_BUILTIN_NAME, private_input.bitwise),
+            (EC_OP_BUILTIN_NAME, private_input.ec_op),
+            (KECCAK_BUILTIN_NAME, private_input.keccak),
+            (POSEIDON_BUILTIN_NAME, private_input.poseidon),
+        ]))
+    }
+}
+
 impl AirPrivateInputSerializable {
     pub fn serialize_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string_pretty(&self)


### PR DESCRIPTION
Added an implementation of `From<AirPrivateInputSerializable>` for AirPrivateInput, making it easier to interact with already generated private inputs.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

