### PR TITLE
[Cairo1] Append return values to the output segment when running in proof_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Upcoming Changes
 
+* feat: Append return values to the output segment when running cairo1-run in proof_mode [#1597](https://github.com/lambdaclass/cairo-vm/pull/1597)
+  * Add instructions to the proof_mode header to copy return values to the output segment before initiating the infinite loop
+  * Output builtin is always included when running cairo 1 programs in proof_mode
+
 * perf: optimize instruction cache allocations by using `VirtualMachine::load_data` [#1441](https://github.com/lambdaclass/cairo-vm/pull/1441)
 
 * feat: Add `print_output` flag to `cairo-1` crate [#1575] (https://github.com/lambdaclass/cairo-vm/pull/1575)

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -337,25 +337,6 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         casm! {}.instructions
     };
 
-    //let proof_mode_footer = if args.proof_mode {
-    // TODO: If the Output builtin is ever added to cairo 1 execution use the logic commented below to fetch the output ptr
-    // // Find where the output builtin's stop_ptr is located
-    // // For this we need to search for the output builtin in the main function's return types
-    // // All of these return values will be placed next to each other before the final ap value
-    // // The location of the output builtin's final pointer will be ap - offset, with offset being the size of
-    // // each return type that comes after the output builtin in the ret_types vector.
-    // let mut offset = 1;
-    // for ret_type in main_func.signature.ret_types.iter() {
-    //     match ret_type.debug_name {
-    //         Some(ref name) if name == "Output" => break,
-    //         _ => offset += type_sizes.get(ret_type).unwrap(),
-    //     }
-    // }
-    // As the Output builtin is not currently used during cairo 1 execution, we can asume it is empty by the end of the run
-    // So we can use it's base as stop_ptr, we can find it relative to fp where it is first created
-
-    // This is the program we are actually running/proving
-    // With (embedded proof mode), cairo1 header and the libfunc footer
     let instructions = chain!(
         proof_mode_header.iter(),
         entry_code.iter(),

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -317,7 +317,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         // And also appending the return values to the output builtin's memory segment
 
         // As the output builtin is not used by cairo 1 (we forced it for this purpose), it's segment is always empty
-        // so we can start writing values directly from its base, which is located relative to the fp before the other builtin's bases
+        // so we can start writing values directly from it's base, which is located relative to the fp before the other builtin's bases
         let output_fp_offset: i16 = -(builtins.len() as i16 + 2); // The 2 here represents the return_fp & end segments
 
         // The pc offset where the original program should start
@@ -945,7 +945,7 @@ fn get_function_builtins(
         builtin_offset.insert(PedersenType::ID, current_offset);
         current_offset += 1;
     }
-    // Force an output builtin so that we can write the program output into its segment
+    // Force an output builtin so that we can write the program output into it's segment
     if proof_mode {
         builtins.push(BuiltinName::output);
         builtin_offset.insert(OutputType::ID, current_offset);

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -301,12 +301,11 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         println!("Builtins used: {:?}", builtins);
 
         // Prepare "canonical" proof mode instructions. These are usually added by the compiler in cairo 0
-
-        //let output_fp_offset: i16 = -(builtins.len() as i16 + 2); // builtin bases + end segment + return fp segment
+        let output_fp_offset: i16 = -(builtins.len() as i16 + 2); // builtin bases + end segment + return fp segment
         let mut ctx = casm! {};
         casm_extend! {ctx,
-            call rel 6; // Begin program execution
-            [ap] = 6969; // Append return values to output
+            call rel 5; // Begin program execution
+            [ap - 1] = [[fp + output_fp_offset]]; // Append last return value to output
             jmp rel 0; // Infinite loop
         };
         ctx.instructions

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -924,11 +924,7 @@ fn get_function_builtins(
         current_offset += 1;
     }
     // Force an output builtin so that we can write the program output into its segment
-    if entry_params
-        .iter()
-        .any(|ti| ti.debug_name == Some("Output".into()))
-        || proof_mode
-    {
+    if proof_mode {
         builtins.push(BuiltinName::output);
         builtin_offset.insert(OutputType::ID, current_offset);
     }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -312,17 +312,19 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         println!("Builtins used: {:?}", builtins);
 
         // Create proof_mode specific instructions
-        // Including the "cannonical" proof mode instructions (the ones added by the compiler in cairo 0)
-        // wich call the firts program instruction and the initiate an infinite loop
+        // Including the "canonical" proof mode instructions (the ones added by the compiler in cairo 0)
+        // wich call the firt program instruction and then initiate an infinite loop.
         // And also appending the return values to the output builtin's memory segment
 
-        // As the output builtin is not used by cairo 1 (we forced it for this purpose), its segment is always empty
+        // As the output builtin is not used by cairo 1 (we forced it for this purpose), it's segment is always empty
         // so we can start writing values directly from its base, which is located relative to the fp before the other builtin's bases
         let output_fp_offset: i16 = -(builtins.len() as i16 + 2); // The 2 here represents the return_fp & end segments
-                                                                  // The pc offset where the original program should start
-                                                                  // Without this header it should start at 0, but we add 2 for each call and jump instruction (as both of them use immediate values)
-                                                                  // and also 1 for each instruction added to copy each return value into the output segment
+
+        // The pc offset where the original program should start
+        // Without this header it should start at 0, but we add 2 for each call and jump instruction (as both of them use immediate values)
+        // and also 1 for each instruction added to copy each return value into the output segment
         let program_start_offset: i16 = 4 + return_type_size;
+
         let mut ctx = casm! {};
         casm_extend! {ctx,
             call rel program_start_offset; // Begin program execution by calling the first instruction in the original program
@@ -410,7 +412,9 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
     if args.proof_mode {
         // As we will be inserting the return values into the output segment after running the main program (right before the infinite loop) the computed size for the output builtin will be 0
         // We need to manually set the segment size for the output builtin's segment so memory hole counting doesn't fail due to having a higher accessed address count than the segment's size
-        vm.segments.segment_sizes.insert(2, return_type_size as usize);
+        vm.segments
+            .segment_sizes
+            .insert(2, return_type_size as usize);
     }
     runner.end_run(false, false, &mut vm, &mut hint_processor)?;
 
@@ -510,7 +514,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         // Set stop pointer for each builtin
         vm.builtins_final_stack_from_stack_pointer_dict(
             &builtin_name_to_stack_pointer,
-            args.proof_mode
+            args.proof_mode,
         )?;
 
         // Build execution public memory

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -511,7 +511,9 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         // Build execution public memory
         if args.proof_mode {
             // As the output builtin is not used by the program we need to compute it's stop ptr manually
-            vm.set_output_stop_ptr_offset(main_func.signature.ret_types.len());
+            vm.set_output_stop_ptr_offset(return_type_size as usize);
+            // We also manually set the segment size for the output builtin's segment so memory hole counting doesn't fail
+            vm.segments.segment_sizes.insert(2, return_type_size as usize);
 
             runner.finalize_segments(&mut vm)?;
         }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -345,6 +345,8 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         casm! {}.instructions
     };
 
+    // This is the program we are actually running/proving
+    // With (embedded proof mode), cairo1 header and the libfunc footer
     let instructions = chain!(
         proof_mode_header.iter(),
         entry_code.iter(),

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -1161,6 +1161,14 @@ mod tests {
     }
 
     #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/struct_span_return.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/struct_span_return.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_struct_span_return(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Ok(Some(res)) if res == "[[4 3] [2 1]]");
+    }
+
+    #[rstest]
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
     fn test_tensor(#[case] args: &[&str]) {

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -3,23 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aes"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,12 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,33 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cairo-vm"
 version = "1.0.0-rc0"
 dependencies = [
@@ -235,7 +185,6 @@ dependencies = [
  "starknet-crypto",
  "starknet-types-core",
  "thiserror-no-std",
- "zip",
 ]
 
 [[package]]
@@ -255,22 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,21 +211,6 @@ checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-bigint"
@@ -313,15 +231,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -362,16 +271,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "funty"
@@ -468,15 +367,6 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "itertools"
@@ -630,15 +520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,12 +541,6 @@ dependencies = [
  "rand",
  "serde",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -743,45 +618,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -981,17 +821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,25 +1000,6 @@ checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
 dependencies = [
  "thiserror-impl-no-std",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "typenum"
@@ -1379,53 +1189,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/vm/src/vm/runners/builtin_runner/output.rs
+++ b/vm/src/vm/runners/builtin_runner/output.rs
@@ -114,6 +114,10 @@ impl OutputBuiltinRunner {
             attributes: HashMap::default(),
         })
     }
+
+    pub(crate) fn set_stop_ptr_offset(&mut self, offset: usize) {
+        self.stop_ptr = Some(offset)
+    }
 }
 
 impl Default for OutputBuiltinRunner {

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1094,6 +1094,16 @@ impl VirtualMachine {
         }
         Ok(())
     }
+
+    #[doc(hidden)]
+    pub fn set_output_stop_ptr_offset(
+        &mut self,
+        offset: usize,
+    ) {
+        if let Some(BuiltinRunner::Output(builtin)) = self.builtin_runners.first_mut() {
+            builtin.set_stop_ptr_offset(offset)
+        }
+    }
 }
 
 pub struct VirtualMachineBuilder {

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1082,8 +1082,12 @@ impl VirtualMachine {
     pub fn builtins_final_stack_from_stack_pointer_dict(
         &mut self,
         builtin_name_to_stack_pointer: &HashMap<&'static str, Relocatable>,
+        skip_output: bool,
     ) -> Result<(), RunnerError> {
         for builtin in self.builtin_runners.iter_mut() {
+            if matches!(builtin, BuiltinRunner::Output(_)) && skip_output {
+                continue;
+            }
             builtin.final_stack(
                 &self.segments,
                 builtin_name_to_stack_pointer


### PR DESCRIPTION
This involves:

- Forcing the output builtin to be included when running cairo 1 programs in proof_mode (And manually setting it's stop_ptr and segment_size)
- Adding extra instructions in the proof_mode_header (after calling the first program instruction and before initiating the infinite loop) to copy the return values into the output builtin segment

Testing:

- This new behaviour was tested manually by printing out the memory when running the available test programs to ensure that it behaves correctly with one or more return values and all flags enabled.

- There is currently no way to create a test for this behaviour without some code refactors that escape the scope of the PR.

Also in this PR:

- Restored a test that was accidentally removed when solving merge conflicts in a previous PR
