### PR TITLE
Feature: make test_utils macros public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   * Add instructions to the proof_mode header to copy return values to the output segment before initiating the infinite loop
   * Output builtin is now always included when running cairo 1 programs in proof_mode
 
+* feat: Make test_utils macros public [#1599](https://github.com/lambdaclass/cairo-vm/pull/1599).
+
 * feat(BREAKING): Remove unecessary conversion functions between `Felt` & `BigUint`/`BigInt` [#1562](https://github.com/lambdaclass/cairo-vm/pull/1562)
   * Remove the following functions:
     * felt_from_biguint

--- a/vm/src/hint_processor/builtin_hint_processor/bigint.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bigint.rs
@@ -105,6 +105,7 @@ mod test {
     use crate::hint_processor::hint_processor_definition::{HintProcessorLogic, HintReference};
     use crate::stdlib::collections::HashMap;
     use crate::types::exec_scope::ExecutionScopes;
+    use crate::utils::test_utils::bigint::*;
     use crate::utils::test_utils::*;
     use crate::vm::vm_core::VirtualMachine;
     use assert_matches::assert_matches;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -192,6 +192,7 @@ mod tests {
     use crate::{any_box, felt_str};
 
     use crate::types::relocatable::Relocatable;
+    use crate::utils::test_utils::bigint::*;
     use crate::utils::test_utils::*;
 
     use crate::vm::vm_core::VirtualMachine;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -556,6 +556,7 @@ mod tests {
             hint_processor_definition::HintProcessorLogic,
         },
         types::{exec_scope::ExecutionScopes, relocatable::Relocatable},
+        utils::test_utils::bigint::*,
         utils::test_utils::*,
         vm::vm_core::VirtualMachine,
     };

--- a/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -225,6 +225,7 @@ mod tests {
             exec_scope::ExecutionScopes,
             relocatable::{MaybeRelocatable, Relocatable},
         },
+        utils::test_utils::bigint::*,
         utils::test_utils::*,
         vm::errors::memory_errors::MemoryError,
     };

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -92,7 +92,7 @@ mod tests {
     use super::*;
 
     use crate::stdlib::{collections::HashMap, string::ToString};
-    use crate::utils::test_utils::*;
+    use crate::utils::test_utils::bigint::*;
     use assert_matches::assert_matches;
     use num_bigint::BigUint;
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -177,6 +177,7 @@ mod tests {
             hint_processor_definition::HintProcessorLogic,
         },
         types::exec_scope::ExecutionScopes,
+        utils::test_utils::bigint::*,
         utils::test_utils::*,
     };
     use assert_matches::assert_matches;

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -374,6 +374,7 @@ pub(crate) fn is_quad_residue(a: &BigUint, p: &BigUint) -> Result<bool, MathErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::test_utils::bigint::*;
     use crate::utils::test_utils::*;
     use crate::utils::CAIRO_PRIME;
     use assert_matches::assert_matches;

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -232,7 +232,7 @@ pub mod test_utils {
             $crate::types::relocatable::MaybeRelocatable::from(($val1, $val2))
         };
         ($val1 : expr) => {
-            $crate::types::relocatable::MaybeRelocatable::from(crate::Felt252::from($val1 as i128))
+            $crate::types::relocatable::MaybeRelocatable::from($crate::Felt252::from($val1 as i128))
         };
     }
     pub use mayberelocatable;
@@ -240,7 +240,8 @@ pub mod test_utils {
     #[macro_export]
     macro_rules! references {
         ($num: expr) => {{
-            let mut references = crate::stdlib::collections::HashMap::<usize, HintReference>::new();
+            let mut references =
+                $crate::stdlib::collections::HashMap::<usize, HintReference>::new();
             for i in 0..$num {
                 references.insert(i as usize, HintReference::new_simple((i as i32 - $num)));
             }
@@ -295,27 +296,27 @@ pub mod test_utils {
         //Program with builtins
         ( $( $builtin_name: expr ),* ) => {{
             let shared_program_data = SharedProgramData {
-                data: crate::stdlib::vec::Vec::new(),
+                data: $crate::stdlib::vec::Vec::new(),
                 hints_collection: HintsCollection::new(&BTreeMap::new(), 0).unwrap(),
                 main: None,
                 start: None,
                 end: None,
-                error_message_attributes: crate::stdlib::vec::Vec::new(),
+                error_message_attributes: $crate::stdlib::vec::Vec::new(),
                 instruction_locations: None,
-                identifiers: crate::stdlib::collections::HashMap::new(),
+                identifiers: $crate::stdlib::collections::HashMap::new(),
                 reference_manager: Program::get_reference_list(&ReferenceManager {
-                    references: crate::stdlib::vec::Vec::new(),
+                    references: $crate::stdlib::vec::Vec::new(),
                 }),
             };
             Program {
                 shared_program_data: Arc::new(shared_program_data),
-                constants: crate::stdlib::collections::HashMap::new(),
+                constants: $crate::stdlib::collections::HashMap::new(),
                 builtins: vec![$( $builtin_name ),*],
             }
         }};
         ($($field:ident = $value:expr),* $(,)?) => {{
 
-            let program_flat = crate::utils::test_utils::ProgramFlat {
+            let program_flat = $crate::utils::test_utils::ProgramFlat {
                 $(
                     $field: $value,
                 )*
@@ -427,9 +428,9 @@ pub mod test_utils {
             {
                 let ids_names = vec![$( $name ),*];
                 let references = references!(ids_names.len() as i32);
-                let mut ids_data = crate::stdlib::collections::HashMap::<crate::stdlib::string::String, HintReference>::new();
+                let mut ids_data = $crate::stdlib::collections::HashMap::<$crate::stdlib::string::String, HintReference>::new();
                 for (i, name) in ids_names.iter().enumerate() {
-                    ids_data.insert(crate::stdlib::string::ToString::to_string(name), references.get(&i).unwrap().clone());
+                    ids_data.insert($crate::stdlib::string::ToString::to_string(name), references.get(&i).unwrap().clone());
                 }
                 ids_data
             }
@@ -441,9 +442,9 @@ pub mod test_utils {
     macro_rules! non_continuous_ids_data {
         ( $( ($name: expr, $offset:expr) ),* $(,)? ) => {
             {
-                let mut ids_data = crate::stdlib::collections::HashMap::<crate::stdlib::string::String, HintReference>::new();
+                let mut ids_data = $crate::stdlib::collections::HashMap::<$crate::stdlib::string::String, HintReference>::new();
                 $(
-                    ids_data.insert(crate::stdlib::string::String::from($name), HintReference::new_simple($offset));
+                    ids_data.insert($crate::stdlib::string::String::from($name), HintReference::new_simple($offset));
                 )*
                 ids_data
             }
@@ -479,7 +480,7 @@ pub mod test_utils {
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_scopes:expr) => {{
             let hint_data = HintProcessorData::new_default(
-                crate::stdlib::string::ToString::to_string($hint_code),
+                $crate::stdlib::string::ToString::to_string($hint_code),
                 $ids_data,
             );
             let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -487,12 +488,12 @@ pub mod test_utils {
                 &mut $vm,
                 $exec_scopes,
                 &any_box!(hint_data),
-                &crate::stdlib::collections::HashMap::new(),
+                &$crate::stdlib::collections::HashMap::new(),
             )
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr) => {{
             let hint_data = HintProcessorData::new_default(
-                crate::stdlib::string::ToString::to_string($hint_code),
+                $crate::stdlib::string::ToString::to_string($hint_code),
                 $ids_data,
             );
             let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -500,7 +501,7 @@ pub mod test_utils {
                 &mut $vm,
                 exec_scopes_ref!(),
                 &any_box!(hint_data),
-                &crate::stdlib::collections::HashMap::new(),
+                &$crate::stdlib::collections::HashMap::new(),
             )
         }};
     }
@@ -591,13 +592,13 @@ pub mod test_utils {
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
-            $exec_scopes.insert_value("dict_manager", crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
+            $exec_scopes.insert_value("dict_manager", $crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
         };
         ($exec_scopes:expr, $tracker_num:expr) => {
             let  tracker = DictTracker::new_empty(relocatable!($tracker_num, 0));
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
-            $exec_scopes.insert_value("dict_manager", crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
+            $exec_scopes.insert_value("dict_manager", $crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
         };
 
     }
@@ -612,13 +613,13 @@ pub mod test_utils {
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
-            $exec_scopes.insert_value("dict_manager", crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
+            $exec_scopes.insert_value("dict_manager", $crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
         };
         ($exec_scopes:expr, $tracker_num:expr,$default:expr) => {
             let tracker = DictTracker::new_default_dict(relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
-            $exec_scopes.insert_value("dict_manager", crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
+            $exec_scopes.insert_value("dict_manager", $crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
         };
     }
     pub use dict_manager_default;

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -49,7 +49,7 @@ pub fn from_relocatable_to_indexes(relocatable: Relocatable) -> (usize, usize) {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test_utils"))]
 #[macro_use]
 pub mod test_utils {
     use crate::types::exec_scope::ExecutionScopes;
@@ -76,7 +76,7 @@ pub mod test_utils {
             Into::<num_bigint::BigInt>::into($val)
         };
     }
-    pub(crate) use bigint;
+    pub use bigint;
 
     #[macro_export]
     macro_rules! bigint_str {
@@ -87,7 +87,7 @@ pub mod test_utils {
             num_bigint::BigInt::parse_bytes($val.as_bytes(), $opt).expect("Couldn't parse bytes")
         };
     }
-    pub(crate) use bigint_str;
+    pub use bigint_str;
 
     #[macro_export]
     macro_rules! biguint {
@@ -95,7 +95,7 @@ pub mod test_utils {
             Into::<num_bigint::BigUint>::into($val as u128)
         };
     }
-    pub(crate) use biguint;
+    pub use biguint;
 
     #[macro_export]
     macro_rules! biguint_str {
@@ -106,7 +106,7 @@ pub mod test_utils {
             num_bigint::BigUint::parse_bytes($val.as_bytes(), $opt).expect("Couldn't parse bytes")
         };
     }
-    pub(crate) use biguint_str;
+    pub use biguint_str;
 
     impl From<(&str, u8)> for MaybeRelocatable {
         fn from((string, radix): (&str, u8)) -> Self {
@@ -118,6 +118,7 @@ pub mod test_utils {
         }
     }
 
+    #[macro_export]
     macro_rules! segments {
         ($( (($si:expr, $off:expr), $val:tt) ),* $(,)? ) => {
             {
@@ -133,8 +134,9 @@ pub mod test_utils {
 
         };
     }
-    pub(crate) use segments;
+    pub use segments;
 
+    #[macro_export]
     macro_rules! memory {
         ( $( (($si:expr, $off:expr), $val:tt) ),* ) => {
             {
@@ -144,8 +146,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use memory;
+    pub use memory;
 
+    #[macro_export]
     macro_rules! memory_from_memory {
         ($mem: expr, ( $( (($si:expr, $off:expr), $val:tt) ),* )) => {
             {
@@ -155,8 +158,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use memory_from_memory;
+    pub use memory_from_memory;
 
+    #[macro_export]
     macro_rules! memory_inner {
         ($mem:expr, ($si:expr, $off:expr), ($sival:expr, $offval: expr)) => {
             let (k, v) = (($si, $off).into(), &mayberelocatable!($sival, $offval));
@@ -189,8 +193,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use memory_inner;
+    pub use memory_inner;
 
+    #[macro_export]
     macro_rules! check_memory {
         ( $mem: expr, $( (($si:expr, $off:expr), $val:tt) ),* $(,)? ) => {
             $(
@@ -198,8 +203,9 @@ pub mod test_utils {
             )*
         };
     }
-    pub(crate) use check_memory;
+    pub use check_memory;
 
+    #[macro_export]
     macro_rules! check_memory_address {
         ($mem:expr, ($si:expr, $off:expr), ($sival:expr, $offval: expr)) => {
             assert_eq!(
@@ -214,8 +220,9 @@ pub mod test_utils {
             )
         };
     }
-    pub(crate) use check_memory_address;
+    pub use check_memory_address;
 
+    #[macro_export]
     macro_rules! mayberelocatable {
         ($val1 : expr, $val2 : expr) => {
             $crate::types::relocatable::MaybeRelocatable::from(($val1, $val2))
@@ -224,8 +231,9 @@ pub mod test_utils {
             $crate::types::relocatable::MaybeRelocatable::from(crate::Felt252::from($val1 as i128))
         };
     }
-    pub(crate) use mayberelocatable;
+    pub use mayberelocatable;
 
+    #[macro_export]
     macro_rules! references {
         ($num: expr) => {{
             let mut references = crate::stdlib::collections::HashMap::<usize, HintReference>::new();
@@ -235,8 +243,9 @@ pub mod test_utils {
             references
         }};
     }
-    pub(crate) use references;
+    pub use references;
 
+    #[macro_export]
     macro_rules! vm_with_range_check {
         () => {{
             let mut vm = VirtualMachine::new(false);
@@ -247,8 +256,9 @@ pub mod test_utils {
             vm
         }};
     }
-    pub(crate) use vm_with_range_check;
+    pub use vm_with_range_check;
 
+    #[macro_export]
     macro_rules! cairo_runner {
         ($program:expr) => {
             CairoRunner::new(&$program, "all_cairo", false).unwrap()
@@ -263,12 +273,14 @@ pub mod test_utils {
             CairoRunner::new(&program, $layout.to_string(), proof_mode).unwrap()
         };
     }
-    pub(crate) use cairo_runner;
+    pub use cairo_runner;
 
-    pub(crate) use crate::stdlib::{collections::BTreeMap, sync::Arc};
+    pub use crate::stdlib::{collections::BTreeMap, sync::Arc};
     pub(crate) use crate::types::program::HintsCollection;
-    pub(crate) use crate::types::program::Program;
+    pub use crate::types::program::Program;
     pub(crate) use crate::types::program::SharedProgramData;
+
+    #[macro_export]
     macro_rules! program {
         //Empty program
         () => {
@@ -308,7 +320,7 @@ pub mod test_utils {
         }};
     }
 
-    pub(crate) use program;
+    pub use program;
 
     pub(crate) struct ProgramFlat {
         pub(crate) data: crate::utils::Vec<MaybeRelocatable>,
@@ -381,6 +393,7 @@ pub mod test_utils {
         }
     }
 
+    #[macro_export]
     macro_rules! vm {
         () => {{
             VirtualMachine::new(false)
@@ -390,8 +403,9 @@ pub mod test_utils {
             VirtualMachine::new($use_trace)
         }};
     }
-    pub(crate) use vm;
+    pub use vm;
 
+    #[macro_export]
     macro_rules! run_context {
         ( $vm: expr, $pc: expr, $ap: expr, $fp: expr ) => {
             $vm.run_context.pc = Relocatable::from((0, $pc));
@@ -399,8 +413,9 @@ pub mod test_utils {
             $vm.run_context.fp = $fp;
         };
     }
-    pub(crate) use run_context;
+    pub use run_context;
 
+    #[macro_export]
     macro_rules! ids_data {
         ( $( $name: expr ),* ) => {
             {
@@ -414,8 +429,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use ids_data;
+    pub use ids_data;
 
+    #[macro_export]
     macro_rules! non_continuous_ids_data {
         ( $( ($name: expr, $offset:expr) ),* $(,)? ) => {
             {
@@ -427,10 +443,10 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use non_continuous_ids_data;
+    pub use non_continuous_ids_data;
 
     #[track_caller]
-    pub(crate) fn trace_check(
+    pub fn trace_check(
         actual: &[TraceEntry],
         expected: &[(crate::utils::Relocatable, usize, usize)],
     ) {
@@ -440,13 +456,15 @@ pub mod test_utils {
         }
     }
 
+    #[macro_export]
     macro_rules! exec_scopes_ref {
         () => {
             &mut ExecutionScopes::new()
         };
     }
-    pub(crate) use exec_scopes_ref;
+    pub use exec_scopes_ref;
 
+    #[macro_export]
     macro_rules! run_hint {
         ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_scopes:expr, $constants:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
@@ -480,8 +498,9 @@ pub mod test_utils {
             )
         }};
     }
-    pub(crate) use run_hint;
+    pub use run_hint;
 
+    #[macro_export]
     macro_rules! add_segments {
         ($vm:expr, $n:expr) => {
             for _ in 0..$n {
@@ -489,8 +508,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use add_segments;
+    pub use add_segments;
 
+    #[macro_export]
     macro_rules! check_scope {
         ( $exec_scope: expr, [ $( ($name: expr, $val: expr)),*$(,)? ] $(,)? ) => {
             $(
@@ -498,8 +518,9 @@ pub mod test_utils {
             )*
         };
     }
-    pub(crate) use check_scope;
+    pub use check_scope;
 
+    #[macro_export]
     macro_rules! scope {
         () => { ExecutionScopes::new() };
         (  $( ($name: expr, $val: expr)),* $(,)?  ) => {
@@ -515,8 +536,9 @@ pub mod test_utils {
             }
         };
     }
-    pub(crate) use scope;
+    pub use scope;
 
+    #[macro_export]
     macro_rules! check_dictionary {
         ( $exec_scopes: expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
             $(
@@ -534,8 +556,9 @@ pub mod test_utils {
             *
         };
     }
-    pub(crate) use check_dictionary;
+    pub use check_dictionary;
 
+    #[macro_export]
     macro_rules! check_dict_ptr {
         ($exec_scopes: expr, $tracker_num: expr, ($i:expr, $off:expr)) => {
             assert_eq!(
@@ -551,8 +574,9 @@ pub mod test_utils {
             );
         };
     }
-    pub(crate) use check_dict_ptr;
+    pub use check_dict_ptr;
 
+    #[macro_export]
     macro_rules! dict_manager {
         ($exec_scopes:expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
             let mut tracker = DictTracker::new_empty(relocatable!($tracker_num, 0));
@@ -571,8 +595,9 @@ pub mod test_utils {
         };
 
     }
-    pub(crate) use dict_manager;
+    pub use dict_manager;
 
+    #[macro_export]
     macro_rules! dict_manager_default {
         ($exec_scopes:expr, $tracker_num:expr,$default:expr, $( ($key:expr, $val:expr )),* ) => {
             let mut tracker = DictTracker::new_default_dict(relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
@@ -590,15 +615,17 @@ pub mod test_utils {
             $exec_scopes.insert_value("dict_manager", crate::stdlib::rc::Rc::new(core::cell::RefCell::new(dict_manager)))
         };
     }
-    pub(crate) use dict_manager_default;
+    pub use dict_manager_default;
 
+    #[macro_export]
     macro_rules! vec_data {
         ( $( ($val:tt) ),* ) => {
             vec![$( vec_data_inner!($val) ),*]
         };
     }
-    pub(crate) use vec_data;
+    pub use vec_data;
 
+    #[macro_export]
     macro_rules! vec_data_inner {
         (( $val1:expr, $val2:expr )) => {
             mayberelocatable!($val1, $val2)
@@ -607,7 +634,7 @@ pub mod test_utils {
             mayberelocatable!($val)
         };
     }
-    pub(crate) use vec_data_inner;
+    pub use vec_data_inner;
 
     pub fn check_scope_value<T: core::fmt::Debug + core::cmp::PartialEq + 'static>(
         scopes: &ExecutionScopes,

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -56,6 +56,37 @@ pub mod test_utils {
     use crate::types::relocatable::MaybeRelocatable;
     use crate::vm::trace::trace_entry::TraceEntry;
 
+    #[cfg(test)]
+    pub(crate) mod bigint {
+        #[macro_export]
+        macro_rules! bigint {
+            ($val : expr) => {
+                Into::<num_bigint::BigInt>::into($val)
+            };
+        }
+        pub(crate) use bigint;
+
+        #[macro_export]
+        macro_rules! bigint_str {
+            ($val: expr) => {
+                num_bigint::BigInt::parse_bytes($val.as_bytes(), 10).expect("Couldn't parse bytes")
+            };
+            ($val: expr, $opt: expr) => {
+                num_bigint::BigInt::parse_bytes($val.as_bytes(), $opt)
+                    .expect("Couldn't parse bytes")
+            };
+        }
+        pub(crate) use bigint_str;
+
+        #[macro_export]
+        macro_rules! biguint {
+            ($val : expr) => {
+                Into::<num_bigint::BigUint>::into($val as u128)
+            };
+        }
+        pub(crate) use biguint;
+    }
+
     #[macro_export]
     macro_rules! felt_hex {
         ($val: expr) => {
@@ -69,33 +100,6 @@ pub mod test_utils {
             $crate::Felt252::from_dec_str($val).expect("Couldn't parse bytes")
         };
     }
-
-    #[macro_export]
-    macro_rules! bigint {
-        ($val : expr) => {
-            Into::<num_bigint::BigInt>::into($val)
-        };
-    }
-    pub use bigint;
-
-    #[macro_export]
-    macro_rules! bigint_str {
-        ($val: expr) => {
-            num_bigint::BigInt::parse_bytes($val.as_bytes(), 10).expect("Couldn't parse bytes")
-        };
-        ($val: expr, $opt: expr) => {
-            num_bigint::BigInt::parse_bytes($val.as_bytes(), $opt).expect("Couldn't parse bytes")
-        };
-    }
-    pub use bigint_str;
-
-    #[macro_export]
-    macro_rules! biguint {
-        ($val : expr) => {
-            Into::<num_bigint::BigUint>::into($val as u128)
-        };
-    }
-    pub use biguint;
 
     #[macro_export]
     macro_rules! biguint_str {
@@ -275,9 +279,11 @@ pub mod test_utils {
     }
     pub use cairo_runner;
 
-    pub use crate::stdlib::{collections::BTreeMap, sync::Arc};
+    #[allow(unused_imports)]
+    pub(crate) use crate::stdlib::collections::BTreeMap;
+    pub(crate) use crate::stdlib::sync::Arc;
     pub(crate) use crate::types::program::HintsCollection;
-    pub use crate::types::program::Program;
+    pub(crate) use crate::types::program::Program;
     pub(crate) use crate::types::program::SharedProgramData;
 
     #[macro_export]

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -17,7 +17,7 @@ pub struct ValidationRule(
 );
 
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, Debug)]
-pub(crate) struct MemoryCell(MaybeRelocatable, bool);
+pub struct MemoryCell(MaybeRelocatable, bool);
 
 impl MemoryCell {
     pub fn new(value: MaybeRelocatable) -> Self {
@@ -92,8 +92,8 @@ impl AddressSet {
 }
 
 pub struct Memory {
-    pub(crate) data: Vec<Vec<Option<MemoryCell>>>,
-    pub(crate) temp_data: Vec<Vec<Option<MemoryCell>>>,
+    pub data: Vec<Vec<Option<MemoryCell>>>,
+    pub temp_data: Vec<Vec<Option<MemoryCell>>>,
     // relocation_rules's keys map to temp_data's indices and therefore begin at
     // zero; that is, segment_index = -1 maps to key 0, -2 to key 1...
     pub(crate) relocation_rules: HashMap<usize, Relocatable>,

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -15,7 +15,7 @@ use crate::{
 pub struct MemorySegmentManager {
     pub segment_sizes: HashMap<usize, usize>,
     pub segment_used_sizes: Option<Vec<usize>>,
-    pub(crate) memory: Memory,
+    pub memory: Memory,
     // A map from segment index to a list of pairs (offset, page_id) that constitute the
     // public memory. Note that the offset is absolute (not based on the page_id).
     pub public_memory_offsets: HashMap<usize, Vec<(usize, usize)>>,


### PR DESCRIPTION
This PR makes all macros in the `test_utils` module public to allow for easier testing of hints (and other features) living in other crates/repositories.

Fixes #1595.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

