### PR TITLE
Add `allow_missing_builtins` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat: Add `allow_missing_builtins` flag
+* feat(BREAKING): Add `allow_missing_builtins` flag [#1600](https://github.com/lambdaclass/cairo-vm/pull/1600)
 
     This new flag will skip the check that all builtins used by the program need to be present in the selected layout if enabled. It will also be enabled by default when running in proof_mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 #### Upcoming Changes
 
+* feat: Add `allow_missing_builtins` flag
+
+    This new flag will skip the check that all builtins used by the program need to be present in the selected layout if enabled. It will also be enabled by default when running in proof_mode.
+
+  * Add `allow_missing_builtins` flag to `cairo-vm-cli` crate
+  * Add `allow_missing_builtins` field to `CairoRunConfig` struct
+  * Add `allow_missing_builtins` boolean argument to `CairoRunner` methods `initialize` & `initialize_builtins`
+
 * feat(BREAKING): Remove unecessary conversion functions between `Felt` & `BigUint`/`BigInt` [#1562](https://github.com/lambdaclass/cairo-vm/pull/1562)
   * Remove the following functions:
     * felt_from_biguint

--- a/README.md
+++ b/README.md
@@ -169,13 +169,15 @@ The cairo-vm-cli supports the following optional arguments:
 
 - `--proof_mode`: Runs the program in proof_mode
 
-- `--secure_run`: Runs security checks after execution. Enabled by default when not in proof_mode
+- `--secure_run`: Runs security checks after execution. Enabled by default when not in proof_mode.
 
 - `--air_public_input <AIR_PUBLIC_INPUT>`: Receives the name of a file and outputs the AIR public inputs into it. Can only be used if proof_mode is also enabled.
 
 - `--air_private_input <AIR_PRIVATE_INPUT>`: Receives the name of a file and outputs the AIR private inputs into it. Can only be used if proof_mode, trace_file & memory_file are also enabled.
 
 - `--cairo_pie_output <CAIRO_PIE_OUTPUT>`: Receives the name of a file and outputs the Cairo PIE into it. Can only be used if proof_mode, is not enabled.
+
+- `--allow_missing_builtins`: Disables the check that all builtins used by the program need to be included in the selected layout. Enabled by default when in proof_mode.
 
 For example, to obtain the air public inputs from a fibonacci program run, we can run :
 

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -52,7 +52,7 @@ fn load_program_data(c: &mut Criterion) {
                     VirtualMachine::new(false),
                 )
             },
-            |(mut runner, mut vm)| _ = black_box(runner.initialize(black_box(&mut vm)).unwrap()),
+            |(mut runner, mut vm)| _ = black_box(runner.initialize(black_box(&mut vm), false).unwrap()),
             BatchSize::SmallInput,
         )
     });

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -52,7 +52,9 @@ fn load_program_data(c: &mut Criterion) {
                     VirtualMachine::new(false),
                 )
             },
-            |(mut runner, mut vm)| _ = black_box(runner.initialize(black_box(&mut vm), false).unwrap()),
+            |(mut runner, mut vm)| {
+                _ = black_box(runner.initialize(black_box(&mut vm), false).unwrap())
+            },
             BatchSize::SmallInput,
         )
     });

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -51,7 +51,7 @@ fn build_runner_helper() -> (CairoRunner, VirtualMachine) {
 #[inline(never)]
 fn load_program_data() {
     let (mut runner, mut vm) = build_runner_helper();
-    _ = black_box(runner.initialize(black_box(&mut vm, false)).unwrap());
+    _ = black_box(runner.initialize(black_box(&mut vm), false).unwrap());
 }
 
 main!(

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -51,7 +51,7 @@ fn build_runner_helper() -> (CairoRunner, VirtualMachine) {
 #[inline(never)]
 fn load_program_data() {
     let (mut runner, mut vm) = build_runner_helper();
-    _ = black_box(runner.initialize(black_box(&mut vm)).unwrap());
+    _ = black_box(runner.initialize(black_box(&mut vm, false)).unwrap());
 }
 
 main!(

--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -52,6 +52,8 @@ struct Args {
         conflicts_with_all = ["proof_mode", "air_private_input", "air_public_input"]
     )]
     cairo_pie_output: Option<String>,
+    #[structopt(long = "allow_missing_builtins")]
+    allow_missing_builtins: Option<bool>,
 }
 
 fn validate_layout(value: &str) -> Result<String, String> {
@@ -132,6 +134,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
         layout: &args.layout,
         proof_mode: args.proof_mode,
         secure_run: args.secure_run,
+        allow_missing_builtins: args.allow_missing_builtins,
         ..Default::default()
     };
 

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -370,7 +370,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
 
     let mut runner = CairoRunner::new_v2(&program, &args.layout, runner_mode)?;
     let mut vm = VirtualMachine::new(args.trace_file.is_some() || args.air_public_input.is_some());
-    let end = runner.initialize(&mut vm)?;
+    let end = runner.initialize(&mut vm, args.proof_mode)?;
 
     additional_initialization(&mut vm, data_len)?;
 

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -28,6 +28,7 @@ pub struct CairoRunConfig<'a> {
     pub proof_mode: bool,
     pub secure_run: Option<bool>,
     pub disable_trace_padding: bool,
+    pub allow_missing_builtins: Option<bool>,
 }
 
 #[cfg(feature = "arbitrary")]
@@ -56,6 +57,7 @@ impl<'a> Default for CairoRunConfig<'a> {
             proof_mode: false,
             secure_run: None,
             disable_trace_padding: false,
+            allow_missing_builtins: None,
         }
     }
 }
@@ -69,6 +71,10 @@ pub fn cairo_run_program(
         .secure_run
         .unwrap_or(!cairo_run_config.proof_mode);
 
+    let allow_missing_builtins = cairo_run_config
+        .allow_missing_builtins
+        .unwrap_or(cairo_run_config.proof_mode);
+
     let mut cairo_runner = CairoRunner::new(
         program,
         cairo_run_config.layout,
@@ -76,7 +82,7 @@ pub fn cairo_run_program(
     )?;
 
     let mut vm = VirtualMachine::new(cairo_run_config.trace_enabled);
-    let end = cairo_runner.initialize(&mut vm)?;
+    let end = cairo_runner.initialize(&mut vm, allow_missing_builtins)?;
     // check step calculation
 
     cairo_runner

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -236,7 +236,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         let end = cairo_runner
-            .initialize(&mut vm)
+            .initialize(&mut vm, false)
             .map_err(CairoRunError::Runner)?;
 
         assert!(cairo_runner
@@ -258,7 +258,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
@@ -378,7 +378,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -139,7 +139,12 @@ pub fn cairo_run_fuzzed_program(
 
     let mut vm = VirtualMachine::new(cairo_run_config.trace_enabled);
 
-    let _end = cairo_runner.initialize(&mut vm)?;
+    let _end = cairo_runner.initialize(
+        &mut vm,
+        cairo_run_config
+            .allow_missing_builtins
+            .unwrap_or(cairo_run_config.proof_mode),
+    )?;
 
     let res = match cairo_runner.run_until_steps(steps_limit, &mut vm, hint_executor) {
         Err(VirtualMachineError::EndOfProgram(_remaining)) => Ok(()), // program ran OK but ended before steps limit

--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -659,7 +659,7 @@ mod test {
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -673,7 +673,7 @@ mod test {
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -711,7 +711,7 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -870,7 +870,7 @@ cairo_programs/bad_programs/bad_range_check.cairo:11:5: (pc=0:6)
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();
@@ -915,7 +915,7 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();
@@ -954,7 +954,7 @@ cairo_programs/bad_programs/ec_recover_product_mod_m_zero.cairo:11:5: (pc=0:18)
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();
@@ -993,7 +993,7 @@ cairo_programs/bad_programs/ec_recover_div_mod_n_packed_n_zero.cairo:11:5: (pc=0
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();
@@ -1032,7 +1032,7 @@ cairo_programs/bad_programs/uint512_unsigned_div_rem_div_is_zero.cairo:15:2: (pc
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();
@@ -1069,7 +1069,7 @@ cairo_programs/bad_programs/uint256_sub_b_gt_256.cairo:10:2: (pc=0:12)
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         let error = cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .unwrap_err();

--- a/vm/src/vm/hooks.rs
+++ b/vm/src/vm/hooks.rs
@@ -131,7 +131,7 @@ mod tests {
         let mut vm = vm!();
         vm.hooks = Hooks::new(None, None, None);
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
@@ -179,7 +179,7 @@ mod tests {
         let mut vm = vm!();
         vm.hooks = Hooks::new(Some(Arc::new(before_first_step_hook)), None, None);
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -190,7 +190,7 @@ mod tests {
         let mut vm = vm!();
         vm.hooks = Hooks::new(None, Some(Arc::new(pre_step_hook)), None);
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -201,7 +201,7 @@ mod tests {
         let mut vm = vm!();
         vm.hooks = Hooks::new(None, None, Some(Arc::new(post_step_hook)));
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -252,7 +252,7 @@ mod tests {
             Some(Arc::new(post_step_hook)),
         );
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());

--- a/vm/src/vm/runners/builtin_runner/bitwise.rs
+++ b/vm/src/vm/runners/builtin_runner/bitwise.rs
@@ -393,7 +393,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -438,7 +438,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/ec_op.rs
+++ b/vm/src/vm/runners/builtin_runner/ec_op.rs
@@ -464,7 +464,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -509,7 +509,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/hash.rs
+++ b/vm/src/vm/runners/builtin_runner/hash.rs
@@ -381,7 +381,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -425,7 +425,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/keccak.rs
+++ b/vm/src/vm/runners/builtin_runner/keccak.rs
@@ -421,7 +421,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -826,7 +826,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -873,7 +873,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -917,7 +917,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -961,7 +961,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/poseidon.rs
+++ b/vm/src/vm/runners/builtin_runner/poseidon.rs
@@ -365,7 +365,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -409,7 +409,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/builtin_runner/range_check.rs
+++ b/vm/src/vm/runners/builtin_runner/range_check.rs
@@ -379,7 +379,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)
@@ -423,7 +423,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        let address = cairo_runner.initialize(&mut vm).unwrap();
+        let address = cairo_runner.initialize(&mut vm, false).unwrap();
 
         cairo_runner
             .run_until_pc(address, &mut vm, &mut hint_processor)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -240,6 +240,10 @@ impl CairoRunner {
         Ok(end)
     }
 
+    /// Creates the builtin runners according to the builtins used by the program and the selected layout
+    /// When running in proof_mode, all builtins in the layout will be created, and only those in the program will be included
+    /// When not running in proof_mode, only program builtins will be created and included
+    /// Unless `allow_missing_builtins` is set to true, an error will be returned if a builtin is included in the program but not on the layout
     pub fn initialize_builtins(
         &self,
         vm: &mut VirtualMachine,

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1571,7 +1571,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn check_memory_usage_ok_case() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::range_check, BuiltinName::output];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1607,26 +1606,36 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_builtins_with_disordered_builtins() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::range_check, BuiltinName::output];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        assert!(cairo_runner.initialize_builtins(&mut vm).is_err());
+        assert!(cairo_runner.initialize_builtins(&mut vm, false).is_err());
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn create_cairo_runner_with_ordered_but_missing_builtins() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
+    fn create_cairo_runner_missing_builtins_no_allow_missing() {
         let program = program![BuiltinName::output, BuiltinName::ecdsa];
-        //We only check that the creation doesnt panic
-        let _cairo_runner = cairo_runner!(program);
+        let mut cairo_runner = cairo_runner!(program);
+        let mut vm = vm!();
+        assert_matches!(
+            cairo_runner.initialize(&mut vm, false),
+            RunnerError::NoBuiltinForInstance(_)
+        )
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn create_cairo_runner_missing_builtins_allow_missing() {
+        let program = program![BuiltinName::output, BuiltinName::ecdsa];
+        let mut cairo_runner = cairo_runner!(program);
+        let mut vm = vm!();
+        assert!(cairo_runner.initialize(&mut vm, true).is_ok())
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_with_base() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1635,7 +1644,7 @@ mod tests {
             offset: 9,
         });
         add_segments!(vm, 6);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, program_base);
         assert_eq!(
             cairo_runner.program_base,
@@ -1660,11 +1669,10 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_segments_no_base() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         assert_eq!(
             cairo_runner.program_base,
@@ -1689,14 +1697,13 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_empty_data_and_stack() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.program_base = Some(relocatable!(1, 0));
         cairo_runner.execution_base = Some(relocatable!(2, 0));
         let stack = Vec::new();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_state(&mut vm, 1, stack).unwrap();
         assert_eq!(
             cairo_runner.initial_pc,
@@ -1710,7 +1717,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_some_data_empty_stack() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(
             builtins = vec![BuiltinName::output],
             data = vec_data!((4), (6)),
@@ -1733,7 +1739,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_empty_data_some_stack() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1750,7 +1755,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_state_no_program_base() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1771,7 +1775,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn initialize_state_no_execution_base() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1789,7 +1792,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_entrypoint_empty_stack() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1811,7 +1813,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_function_entrypoint_some_stack() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1838,7 +1839,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn initialize_function_entrypoint_no_execution_base() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1852,7 +1852,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn initialize_main_entrypoint_no_main() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1862,7 +1861,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_main_entrypoint() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(main = Some(1),);
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1887,7 +1885,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.initialize(&mut vm).unwrap();
+        cairo_runner.initialize(&mut vm, false).unwrap();
         assert_eq!(
             vm.segments
                 .memory
@@ -1899,7 +1897,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_no_builtins() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(main = Some(1),);
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -1916,14 +1913,13 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_with_range_check_valid() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(builtins = vec![BuiltinName::range_check], main = Some(1),);
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
         cairo_runner.initial_ap = Some(relocatable!(1, 2));
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         vm.segments = segments![((2, 0), 23), ((2, 1), 233)];
         assert_eq!(vm.builtin_runners[0].name(), RANGE_CHECK_BUILTIN_NAME);
@@ -1945,14 +1941,13 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_vm_with_range_check_invalid() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(builtins = vec![BuiltinName::range_check], main = Some(1),);
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
         cairo_runner.initial_ap = Some(relocatable!(1, 2));
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         vm.segments = segments![((2, 1), 23), ((2, 4), (-1))];
 
@@ -2076,7 +2071,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2165,7 +2160,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2330,7 +2325,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2445,7 +2440,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2584,7 +2579,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2822,7 +2817,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -2961,7 +2956,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -3081,7 +3076,7 @@ mod tests {
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         assert_eq!(vm.builtin_runners[0].name(), OUTPUT_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[0].base(), 2);
@@ -3136,7 +3131,7 @@ mod tests {
         );
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -3177,7 +3172,7 @@ mod tests {
         );
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
@@ -3199,7 +3194,7 @@ mod tests {
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         assert_eq!(vm.builtin_runners[0].name(), OUTPUT_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[0].base(), 2);
@@ -3253,7 +3248,7 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner
-            .initialize_builtins(&mut vm)
+            .initialize_builtins(&mut vm, false)
             .expect("Couldn't initialize builtins.");
 
         // Swap the first and second builtins (first should be `output`).
@@ -3291,7 +3286,7 @@ mod tests {
         ];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         assert_eq!(vm.builtin_runners[0].name(), OUTPUT_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[1].name(), HASH_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[2].name(), RANGE_CHECK_BUILTIN_NAME);
@@ -3349,7 +3344,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
 
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
@@ -3373,7 +3368,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(&program);
         let mut vm = vm!(true);
         assert_matches!(
-            cairo_runner.initialize(&mut vm),
+            cairo_runner.initialize(&mut vm, false),
             Err(RunnerError::MissingMain)
         );
     }
@@ -3428,7 +3423,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
 
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
@@ -3501,7 +3496,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
 
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
@@ -3773,7 +3768,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program, "all_cairo", true);
         let mut vm = vm!(true);
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .expect("Call to `CairoRunner::run_until_pc()` failed.");
@@ -4188,7 +4183,6 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_initial_fp_can_be_obtained() {
-        //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program![BuiltinName::output];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -4454,7 +4448,7 @@ mod tests {
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "plain");
         assert_eq!(
-            cairo_runner.initialize_builtins(&mut vm),
+            cairo_runner.initialize_builtins(&mut vm, false),
             Err(RunnerError::NoBuiltinForInstance(Box::new((
                 HashSet::from([BuiltinName::output.name()]),
                 String::from("plain")
@@ -4469,7 +4463,7 @@ mod tests {
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "plain");
         assert_eq!(
-            cairo_runner.initialize_builtins(&mut vm),
+            cairo_runner.initialize_builtins(&mut vm, false),
             Err(RunnerError::NoBuiltinForInstance(Box::new((
                 HashSet::from([BuiltinName::output.name(), HASH_BUILTIN_NAME]),
                 String::from("plain")
@@ -4484,7 +4478,7 @@ mod tests {
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "small");
         assert_eq!(
-            cairo_runner.initialize_builtins(&mut vm),
+            cairo_runner.initialize_builtins(&mut vm, false),
             Err(RunnerError::NoBuiltinForInstance(Box::new((
                 HashSet::from([BuiltinName::bitwise.name()]),
                 String::from("small")
@@ -4522,7 +4516,7 @@ mod tests {
         let mut runner = cairo_runner!(program);
         runner.runner_mode = RunnerMode::ProofModeCanonical;
         let mut vm = vm!();
-        runner.initialize_builtins(&mut vm).unwrap();
+        runner.initialize_builtins(&mut vm, false).unwrap();
         runner.initialize_segments(&mut vm, None);
         assert_eq!(runner.execution_base, Some(Relocatable::from((1, 0))));
         assert_eq!(runner.program_base, Some(Relocatable::from((0, 0))));
@@ -4858,7 +4852,7 @@ mod tests {
             .pc
             .unwrap();
 
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         assert_matches!(
             cairo_runner.run_from_entrypoint(
@@ -4879,7 +4873,9 @@ mod tests {
         let mut new_vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        new_cairo_runner.initialize_builtins(&mut new_vm).unwrap();
+        new_cairo_runner
+            .initialize_builtins(&mut new_vm, false)
+            .unwrap();
         new_cairo_runner.initialize_segments(&mut new_vm, None);
 
         let fib_entrypoint = program
@@ -5046,7 +5042,7 @@ mod tests {
             .pc
             .unwrap();
 
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_builtins(&mut vm, false).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
 
         let result = cairo_runner.run_from_entrypoint(
@@ -5079,7 +5075,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
@@ -5102,7 +5098,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
@@ -5125,7 +5121,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
@@ -5149,7 +5145,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
@@ -5237,7 +5233,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
 
         // program takes 80 steps
         assert_matches!(
@@ -5256,7 +5252,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         let mut hint_processor = BuiltinHintProcessor::new(HashMap::new(), RunResources::new(81));
         // program takes 81 steps
         assert_matches!(
@@ -5277,7 +5273,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         let mut hint_processor = BuiltinHintProcessor::new(HashMap::new(), RunResources::new(80));
         // program takes 80 steps
         assert_matches!(
@@ -5298,7 +5294,7 @@ mod tests {
         .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        let end = runner.initialize(&mut vm).unwrap();
+        let end = runner.initialize(&mut vm, false).unwrap();
         let mut hint_processor = BuiltinHintProcessor::new(HashMap::new(), RunResources::new(9));
         // program takes 9 steps
         assert_matches!(

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -228,15 +228,23 @@ impl CairoRunner {
         }
     }
 
-    pub fn initialize(&mut self, vm: &mut VirtualMachine) -> Result<Relocatable, RunnerError> {
-        self.initialize_builtins(vm)?;
+    pub fn initialize(
+        &mut self,
+        vm: &mut VirtualMachine,
+        allow_missing_builtins: bool,
+    ) -> Result<Relocatable, RunnerError> {
+        self.initialize_builtins(vm, allow_missing_builtins)?;
         self.initialize_segments(vm, None);
         let end = self.initialize_main_entrypoint(vm)?;
         self.initialize_vm(vm)?;
         Ok(end)
     }
 
-    pub fn initialize_builtins(&self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
+    pub fn initialize_builtins(
+        &self,
+        vm: &mut VirtualMachine,
+        allow_missing_builtins: bool,
+    ) -> Result<(), RunnerError> {
         let builtin_ordered_list = vec![
             BuiltinName::output,
             BuiltinName::pedersen,
@@ -316,7 +324,7 @@ impl CairoRunner {
                     .push(PoseidonBuiltinRunner::new(instance_def.ratio, included).into());
             }
         }
-        if !program_builtins.is_empty() {
+        if !program_builtins.is_empty() && !allow_missing_builtins {
             return Err(RunnerError::NoBuiltinForInstance(Box::new((
                 program_builtins.iter().map(|n| n.name()).collect(),
                 self.layout._name.clone(),

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1624,7 +1624,7 @@ mod tests {
         let mut vm = vm!();
         assert_matches!(
             cairo_runner.initialize(&mut vm, false),
-            RunnerError::NoBuiltinForInstance(_)
+            Err(RunnerError::NoBuiltinForInstance(_))
         )
     }
 

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1618,23 +1618,23 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn create_cairo_runner_missing_builtins_no_allow_missing() {
+    fn initialize_builtins_missing_builtins_no_allow_missing() {
         let program = program![BuiltinName::output, BuiltinName::ecdsa];
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         assert_matches!(
-            cairo_runner.initialize(&mut vm, false),
+            cairo_runner.initialize_builtins(&mut vm, false),
             Err(RunnerError::NoBuiltinForInstance(_))
         )
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn create_cairo_runner_missing_builtins_allow_missing() {
+    fn initialize_builtins_missing_builtins_allow_missing() {
         let program = program![BuiltinName::output, BuiltinName::ecdsa];
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        assert!(cairo_runner.initialize(&mut vm, true).is_ok())
+        assert!(cairo_runner.initialize_builtins(&mut vm, true).is_ok())
     }
 
     #[test]

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1611,7 +1611,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_builtins_with_disordered_builtins() {
         let program = program![BuiltinName::range_check, BuiltinName::output];
-        let cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program, "plain");
         let mut vm = vm!();
         assert!(cairo_runner.initialize_builtins(&mut vm, false).is_err());
     }
@@ -1620,7 +1620,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn initialize_builtins_missing_builtins_no_allow_missing() {
         let program = program![BuiltinName::output, BuiltinName::ecdsa];
-        let cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program, "plain");
         let mut vm = vm!();
         assert_matches!(
             cairo_runner.initialize_builtins(&mut vm, false),

--- a/vm/src/vm/security.rs
+++ b/vm/src/vm/security.rs
@@ -120,7 +120,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         vm.segments.compute_effective_sizes();
         assert_matches!(verify_secure_runner(&runner, true, None, &mut vm), Ok(()));
     }
@@ -133,7 +133,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
 
         vm.segments = segments![((0, 0), 100)];
         vm.segments.segment_used_sizes = Some(vec![1]);
@@ -152,7 +152,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
 
         vm.segments = segments![((0, 0), 100)];
         vm.segments.segment_used_sizes = Some(vec![1]);
@@ -170,7 +170,7 @@ mod test {
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         vm.builtin_runners[0].set_stop_ptr(0);
         vm.segments.memory = memory![((2, 0), 1)];
         vm.segments.segment_used_sizes = Some(vec![0, 0, 0, 0]);
@@ -188,7 +188,7 @@ mod test {
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         runner
             .end_run(false, false, &mut vm, &mut hint_processor)
@@ -217,7 +217,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         vm.segments.memory = memory![
             ((0, 0), (1, 0)),
             ((0, 1), (2, 1)),
@@ -245,7 +245,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         vm.segments.memory = memory![
             ((0, 1), (1, 0)),
             ((0, 2), (2, 1)),
@@ -273,7 +273,7 @@ mod test {
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        runner.initialize(&mut vm).unwrap();
+        runner.initialize(&mut vm, false).unwrap();
         vm.segments.memory = memory![
             ((0, 0), (1, 0)),
             ((0, 1), (2, 1)),

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -4367,7 +4367,7 @@ mod tests {
             let mut hint_processor = BuiltinHintProcessor::new_empty();
             let mut cairo_runner = cairo_runner!(program);
             let end = cairo_runner
-                .initialize(&mut virtual_machine_from_builder)
+                .initialize(&mut virtual_machine_from_builder, false)
                 .unwrap();
 
             assert!(cairo_runner

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -4255,7 +4255,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
@@ -4280,7 +4280,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program, "all_cairo", false);
         let mut vm = vm!();
 
-        let end = cairo_runner.initialize(&mut vm).unwrap();
+        let end = cairo_runner.initialize(&mut vm, false).unwrap();
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());


### PR DESCRIPTION
This new flag will skip the check that all builtins used by the program need to be present in the selected layout if enabled. It will also be enabled by default when running in proof_mode. 
This flag has been added to : CLI, CairoRunConfig, CairoRunner::initialize & CairoRunner::initialize_builtins
Documentation has been added/updated
Other changes: Removed outdated comment from many cairo_runner tests
