### PR TITLE
Remove leftover mentions of `lambdaworks-felt` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,16 @@ You can then activate this environment by running
 You can add the following to your rust project's `Cargo.toml`:
 
 ```toml
-cairo-vm = { version = '0.7.0', features = ["lambdaworks-felt"] }
+cairo-vm = { version = '0.7.0'}
 ```
-
-The `features = ["lambdaworks-felt"]` part adds usage of [`lambdaworks-math`](https://github.com/lambdaclass/lambdaworks) as the backend for `Felt252`. This improves performance by more than 20%, and will be the default in the future.
 
 ### Running cairo-vm from CLI
 
 To run programs from the command line, first compile the repository from the cairo-vm-cli folder:
 
 ```bash
-cd cairo-vm-cli; cargo build --release -F lambdaworks-felt; cd ..
+cd cairo-vm-cli; cargo build --release; cd ..
 ```
-
-The `-F lambdaworks-felt` part adds usage of [`lambdaworks-math`](https://github.com/lambdaclass/lambdaworks) as the backend for `Felt252`. This improves performance by more than 20%, and will be the default in the future.
 
 Once the binary is built, it can be found in `target/release/` under the name `cairo-vm-cli`.
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -8,7 +8,6 @@
 //! - `with_mimalloc`: Use [`MiMalloc`](https://crates.io/crates/mimalloc) as the program global allocator.
 //! - `cairo-1-hints`: Enable hints that were introduced in Cairo 1. Not enabled by default.
 //! - `arbitrary`: Enables implementations of [`arbitrary::Arbitrary`](https://docs.rs/arbitrary/latest/arbitrary/) for some structs. Not enabled by default.
-//! - `lambdaworks-felt`: Enables usage of the [**lambdaworks**](https://github.com/lambdaclass/lambdaworks) backend for [`felt::Felt252`]. Not enabled by default.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(warnings)]


### PR DESCRIPTION
The feature is gone but the docs still live 🔪 

