### PR TITLE
Use locked dependencies to install `cargo-nextest` & `wasm-pack`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ cargo-deps:
 	# Temporarily removed due to version issues. Installing cargo flamegraph pumps an error in rust 1.70
 	# cargo install --version 0.6.1 flamegraph
 	cargo install --version 1.14.0 hyperfine
-	cargo install --version 0.9.49 cargo-nextest
+	cargo install --version 0.9.49 cargo-nextest --locked
 	cargo install --version 0.5.9 cargo-llvm-cov
 	cargo install --version 0.12.1 wasm-pack
 

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ cargo-deps:
 	cargo install --version 1.14.0 hyperfine
 	cargo install --version 0.9.49 cargo-nextest --locked
 	cargo install --version 0.5.9 cargo-llvm-cov
-	cargo install --version 0.12.1 wasm-pack
+	cargo install --version 0.12.1 wasm-pack --locked
 
 cairo1-run-deps:
 	cd cairo1-run; make deps


### PR DESCRIPTION
Installation of `cargo-nextest` is currently failing (both locally & in the `fresh-run` CI workflow) as one of it's dependencies has been updated to no longer be compatible with rust version lower than 1.74.
This PR solves this issue by passing the `--locked` flag when installing `cargo-nextest` in order to force the versions in the `Cargo.lock` to be used, with an older version of the dependency that is compatible with rust 1.70.
This is also the case for `wasm-pack`.
Closes #1613 
Closes #1612 
