### PR TITLE
Restore `flamegraph` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,7 @@ build-cairo-2-compiler:
 cargo-deps:
 	cargo install --version 0.3.1 iai-callgrind-runner
 	cargo install --version 1.1.0 cargo-criterion
-	# Temporarily removed due to version issues. Installing cargo flamegraph pumps an error in rust 1.70
-	# cargo install --version 0.6.1 flamegraph
+	cargo install --version 0.6.1 flamegraph --locked
 	cargo install --version 1.14.0 hyperfine
 	cargo install --version 0.9.49 cargo-nextest
 	cargo install --version 0.5.9 cargo-llvm-cov
@@ -279,9 +278,8 @@ benchmark-action: cairo_bench_programs
 iai-benchmark-action: cairo_bench_programs
 	cargo bench --bench iai_benchmark
 
-# Temporarily removed due to version issues. Installing cargo flamegraph pumps an error in rust 1.70
-# flamegraph:
-# 	cargo flamegraph --root --bench criterion_benchmark -- --bench
+flamegraph:
+	cargo flamegraph --root --bench criterion_benchmark -- --bench
 
 compare_benchmarks: cairo_bench_programs
 	cd bench && ./run_benchmarks.sh


### PR DESCRIPTION
Installing `flamegraph` with locked dependencies works for rust 1.70, so we can restore this target
