### PR TITLE
Add `docs` label to `changelog` workflow skiplist

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: dangoslen/changelog-enforcer@v3
       with:
-        skipLabels: pipelines,coverage
+        skipLabels: pipelines,coverage,docs


### PR DESCRIPTION
There is no reason for doc updates to be reflected in the changelog

