### PR TITLE
Add `Labels` section to CONTRIBUTING.md + update changelog skip labels

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: dangoslen/changelog-enforcer@v3
       with:
-        skipLabels: pipelines,coverage
+        skipLabels: pipelines,tests,documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,15 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/lambda
   - `merge`
   - `wip`
 
+### Labels
+
+We recommend using the corresponding labels for each PR's purpose, the most commonly used labels include:
+
+- `documentation`: Improvements or additions to documentation
+- `tests`: Implementation of tests
+- `pipelines`: Improving CI/CD workflows
+- `enhancement`: Implementation of new features
+- `performance`: Performance-related improvements
 
 ## Attribution
 This guide is based on the **contributing.md**. [Make your own](https://contributing.md/)!


### PR DESCRIPTION
Adds a `Labels` section with short descriptions of commonly-used PR labels to CONTRIBUTING.md.
Removes `coverage` and adds `tests` & `documentation` labels to changelog workflow's skipLabels list.
Resaoning:
*  `tests` & `coverage` labels are often used for the same purposes  so it doesn't make sense to have both. (And having PRs with only improving coverage rather than testing as an objective has lead to unuseful tests being added in the past).
* There is no reason for documentation updates to be reflected in the changelog

