### PR TITLE
Fix: set up builtins initial stack based on program builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 
 * feat: output builtin features for bootloader support [#1580](https://github.com/lambdaclass/cairo-vm/pull/1580)
 
+* fix: set up builtins initial stack based on program builtins [#1632](https://github.com/lambdaclass/cairo-vm/pull/1632)
+
 #### [1.0.0-rc1] - 2024-02-23
 
 * Bump `starknet-types-core` dependency version to 0.0.9 [#1628](https://github.com/lambdaclass/cairo-vm/pull/1628)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -296,7 +296,7 @@ impl CairoRunner {
                         instance_def.ratio,
                         included,
                     )
-                        .into(),
+                    .into(),
                 );
             }
         }
@@ -613,10 +613,10 @@ impl CairoRunner {
             self.initial_ap = self.initial_fp;
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self
-                .program
-                .shared_program_data
-                .end
-                .ok_or(RunnerError::NoProgramEnd)?);
+                    .program
+                    .shared_program_data
+                    .end
+                    .ok_or(RunnerError::NoProgramEnd)?);
         }
 
         let return_fp = vm.segments.add();
@@ -690,11 +690,11 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = self.get_hint_data(references, hint_processor)?;
+        let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_ranges = self
+        let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
@@ -707,9 +707,9 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_data,
+                &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                    self.program
+                self.program
                     .shared_program_data
                     .hints_collection
                     .get_hint_range_for_pc(vm.run_context.pc.offset)
@@ -718,7 +718,7 @@ impl CairoRunner {
                     })
                     .unwrap_or(&[]),
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_ranges,
+                &mut hint_ranges,
                 &self.program.constants,
             )?;
 
@@ -741,18 +741,18 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = self.get_hint_data(references, hint_processor)?;
+        let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_ranges = self
+        let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
             .hints_ranges
             .clone();
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = &self
+        let hint_data = &self
             .program
             .shared_program_data
             .hints_collection
@@ -771,11 +771,11 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_data,
+                &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                    hint_data,
+                hint_data,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_ranges,
+                &mut hint_ranges,
                 &self.program.constants,
             )?;
         }
@@ -835,7 +835,7 @@ impl CairoRunner {
                     (rc_max - rc_min) as usize,
                 ))),
             )
-                .into());
+            .into());
         }
 
         Ok(())
@@ -884,7 +884,7 @@ impl CairoRunner {
                     diluted_usage_upper_bound,
                 ))),
             )
-                .into());
+            .into());
         }
 
         Ok(())
@@ -915,7 +915,8 @@ impl CairoRunner {
                 match self.check_used_cells(vm) {
                     Ok(_) => break,
                     Err(e) => match e {
-                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {}
+                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {
+                        }
                         e => return Err(e),
                     },
                 }
@@ -1225,7 +1226,7 @@ impl CairoRunner {
                 total_memory_units,
                 instance._public_memory_fraction,
             )
-                .into());
+            .into());
         }
 
         let instruction_memory_units = 4 * vm_current_step_u32;
@@ -1920,7 +1921,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
 
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -3805,7 +3806,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all_cairo", true);
@@ -4859,7 +4860,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/example_program.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -4930,7 +4931,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bitwise_builtin_test.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5049,7 +5050,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_function.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5093,7 +5094,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/assert_le_felt_hint.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5116,7 +5117,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5139,7 +5140,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5162,7 +5163,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5250,7 +5251,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5269,7 +5270,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5290,7 +5291,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5311,7 +5312,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5500,7 +5501,7 @@ mod tests {
             },
             &mut BuiltinHintProcessor::new_empty(),
         )
-            .unwrap();
+        .unwrap();
         let air_private_input = runner.get_air_private_input(&vm);
         assert!(air_private_input.0[HASH_BUILTIN_NAME].is_empty());
         assert!(air_private_input.0[RANGE_CHECK_BUILTIN_NAME].is_empty());

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -535,7 +535,7 @@ impl CairoRunner {
             if let Some(builtin_runner) = vm_builtin_map.get(builtin_name.name()) {
                 stack.append(&mut builtin_runner.initial_stack());
             } else {
-                stack.push(MaybeRelocatable::from((0, 0)));
+                stack.push(MaybeRelocatable::from(0));
             }
         }
 
@@ -5580,7 +5580,7 @@ mod tests {
                 assert_eq!(initial_stack, keccak_builtin_runner.initial_stack());
             }
             None => {
-                assert_eq!(initial_stack, vec![MaybeRelocatable::from((0, 0))]);
+                assert_eq!(initial_stack, vec![MaybeRelocatable::from(0)]);
             }
         }
     }

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -296,7 +296,7 @@ impl CairoRunner {
                         instance_def.ratio,
                         included,
                     )
-                    .into(),
+                        .into(),
                 );
             }
         }
@@ -613,10 +613,10 @@ impl CairoRunner {
             self.initial_ap = self.initial_fp;
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self
-                    .program
-                    .shared_program_data
-                    .end
-                    .ok_or(RunnerError::NoProgramEnd)?);
+                .program
+                .shared_program_data
+                .end
+                .ok_or(RunnerError::NoProgramEnd)?);
         }
 
         let return_fp = vm.segments.add();
@@ -690,11 +690,11 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
+            let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+            let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_ranges = self
+            let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
@@ -707,9 +707,9 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                    &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                self.program
+                    self.program
                     .shared_program_data
                     .hints_collection
                     .get_hint_range_for_pc(vm.run_context.pc.offset)
@@ -718,7 +718,7 @@ impl CairoRunner {
                     })
                     .unwrap_or(&[]),
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_ranges,
+                    &mut hint_ranges,
                 &self.program.constants,
             )?;
 
@@ -741,18 +741,18 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
+            let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+            let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_ranges = self
+            let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
             .hints_ranges
             .clone();
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = &self
+            let hint_data = &self
             .program
             .shared_program_data
             .hints_collection
@@ -771,11 +771,11 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                    &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                hint_data,
+                    hint_data,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_ranges,
+                    &mut hint_ranges,
                 &self.program.constants,
             )?;
         }
@@ -835,7 +835,7 @@ impl CairoRunner {
                     (rc_max - rc_min) as usize,
                 ))),
             )
-            .into());
+                .into());
         }
 
         Ok(())
@@ -884,7 +884,7 @@ impl CairoRunner {
                     diluted_usage_upper_bound,
                 ))),
             )
-            .into());
+                .into());
         }
 
         Ok(())
@@ -915,8 +915,7 @@ impl CairoRunner {
                 match self.check_used_cells(vm) {
                     Ok(_) => break,
                     Err(e) => match e {
-                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {
-                        }
+                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {}
                         e => return Err(e),
                     },
                 }
@@ -1226,7 +1225,7 @@ impl CairoRunner {
                 total_memory_units,
                 instance._public_memory_fraction,
             )
-            .into());
+                .into());
         }
 
         let instruction_memory_units = 4 * vm_current_step_u32;
@@ -1604,6 +1603,7 @@ mod tests {
         vm::trace::trace_entry::TraceEntry,
     };
     use assert_matches::assert_matches;
+    use rstest::rstest;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
@@ -1920,7 +1920,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
 
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -3805,7 +3805,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all_cairo", true);
@@ -4859,7 +4859,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/example_program.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -4930,7 +4930,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bitwise_builtin_test.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5049,7 +5049,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_function.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5093,7 +5093,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/assert_le_felt_hint.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5116,7 +5116,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5139,7 +5139,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5162,7 +5162,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5250,7 +5250,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5269,7 +5269,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5290,7 +5290,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5311,7 +5311,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5500,7 +5500,7 @@ mod tests {
             },
             &mut BuiltinHintProcessor::new_empty(),
         )
-        .unwrap();
+            .unwrap();
         let air_private_input = runner.get_air_private_input(&vm);
         assert!(air_private_input.0[HASH_BUILTIN_NAME].is_empty());
         assert!(air_private_input.0[RANGE_CHECK_BUILTIN_NAME].is_empty());
@@ -5526,5 +5526,68 @@ mod tests {
                 },
             })]
         );
+    }
+
+    #[test]
+    fn prepare_builtins_initial_stack_no_builtins() {
+        let layout = "small";
+        let proof_mode = false;
+        let trace_enabled = true;
+        let allow_missing_builtins = true;
+
+        let program_content =
+            include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json");
+        let program = Program::from_bytes(program_content, Some("main")).unwrap();
+
+        let mut cairo_runner = CairoRunner::new(&program, layout, proof_mode).unwrap();
+        let mut vm = VirtualMachine::new(trace_enabled);
+        let _ = cairo_runner
+            .initialize(&mut vm, allow_missing_builtins)
+            .unwrap();
+
+        let initial_stack = cairo_runner.prepare_builtins_initial_stack(&vm);
+        assert_eq!(initial_stack, vec![]);
+    }
+
+    #[rstest]
+    #[case("small", true)]
+    #[case("all_cairo", false)]
+    fn prepare_builtins_initial_stack_missing_builtins(
+        #[case] layout: &str,
+        #[case] allow_missing_builtins: bool,
+    ) {
+        let proof_mode = false;
+        let trace_enabled = true;
+
+        let program_content =
+            include_bytes!("../../../../cairo_programs/proof_programs/keccak_builtin.json");
+        let program = Program::from_bytes(program_content, Some("main")).unwrap();
+
+        let mut cairo_runner = CairoRunner::new(&program, layout, proof_mode).unwrap();
+        let mut vm = VirtualMachine::new(trace_enabled);
+        let _ = cairo_runner
+            .initialize(&mut vm, allow_missing_builtins)
+            .unwrap();
+
+        let initial_stack = cairo_runner.prepare_builtins_initial_stack(&vm);
+
+        let keccak_builtin_runner = {
+            let mut keccak = None;
+            for builtin in vm.get_builtin_runners() {
+                if let BuiltinRunner::Keccak(keccak_builtin_runner) = builtin {
+                    keccak = Some(keccak_builtin_runner);
+                };
+            }
+            keccak
+        };
+
+        match keccak_builtin_runner {
+            Some(keccak_builtin_runner) => {
+                assert_eq!(initial_stack, keccak_builtin_runner.initial_stack());
+            }
+            None => {
+                assert_eq!(initial_stack, vec![MaybeRelocatable::from((0, 0))]);
+            }
+        }
     }
 }

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -3253,15 +3253,12 @@ mod tests {
     }
 
     /// Test that `get_output()` works when the `output` builtin is not the first one.
-    // TODO review: this test swaps builtins, but builtins should appear in the order
-    //              specified in the program (i.e. ordered).
-    #[ignore = "this test does not seem to make sense"]
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_output_unordered_builtins() {
         //Initialization Phase
         let program = program!(
-            builtins = vec![BuiltinName::output, BuiltinName::bitwise],
+            builtins = vec![BuiltinName::bitwise, BuiltinName::output],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -3291,13 +3288,8 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner
-            .initialize_builtins(&mut vm, false)
+            .initialize_function_runner(&mut vm)
             .expect("Couldn't initialize builtins.");
-
-        // Swap the first and second builtins (first should be `output`).
-        vm.builtin_runners.swap(0, 1);
-
-        cairo_runner.initialize_segments(&mut vm, None);
 
         let end = cairo_runner
             .initialize_main_entrypoint(&mut vm)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -296,7 +296,7 @@ impl CairoRunner {
                         instance_def.ratio,
                         included,
                     )
-                    .into(),
+                        .into(),
                 );
             }
         }
@@ -518,13 +518,7 @@ impl CairoRunner {
         Ok(end)
     }
 
-    ///Initializes state for running a program from the main() entrypoint.
-    ///If self.is_proof_mode() == True, the execution starts from the start label rather then the main() function.
-    ///Returns the value of the program counter after returning from main.
-    fn initialize_main_entrypoint(
-        &mut self,
-        vm: &mut VirtualMachine,
-    ) -> Result<Relocatable, RunnerError> {
+    fn prepare_builtins_initial_stack(&self, vm: &VirtualMachine) -> Vec<MaybeRelocatable> {
         let mut stack = Vec::new();
 
         // Build a name -> builtin map for easier lookup
@@ -536,7 +530,7 @@ impl CairoRunner {
 
         // For each builtin in the program, set up the corresponding initial stack.
         // Builtins required in the program but not set up in the VM (i.e. when specifying
-        // `allow_missing_builtins` are set to (0, 0).
+        // `allow_missing_builtins`) are set to (0, 0).
         for builtin_name in self.program.builtins.iter() {
             if let Some(builtin_runner) = vm_builtin_map.get(builtin_name.name()) {
                 stack.append(&mut builtin_runner.initial_stack());
@@ -544,6 +538,18 @@ impl CairoRunner {
                 stack.push(MaybeRelocatable::from((0, 0)));
             }
         }
+
+        stack
+    }
+
+    ///Initializes state for running a program from the main() entrypoint.
+    ///If self.is_proof_mode() == True, the execution starts from the start label rather then the main() function.
+    ///Returns the value of the program counter after returning from main.
+    fn initialize_main_entrypoint(
+        &mut self,
+        vm: &mut VirtualMachine,
+    ) -> Result<Relocatable, RunnerError> {
+        let mut stack = self.prepare_builtins_initial_stack(vm);
 
         if self.is_proof_mode() {
             // In canonical proof mode, add the dummy last fp and pc to the public memory, so that the verifier can enforce
@@ -607,10 +613,10 @@ impl CairoRunner {
             self.initial_ap = self.initial_fp;
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self
-                    .program
-                    .shared_program_data
-                    .end
-                    .ok_or(RunnerError::NoProgramEnd)?);
+                .program
+                .shared_program_data
+                .end
+                .ok_or(RunnerError::NoProgramEnd)?);
         }
 
         let return_fp = vm.segments.add();
@@ -684,11 +690,11 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
+            let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+            let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_ranges = self
+            let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
@@ -701,9 +707,9 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                    &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                self.program
+                    self.program
                     .shared_program_data
                     .hints_collection
                     .get_hint_range_for_pc(vm.run_context.pc.offset)
@@ -712,7 +718,7 @@ impl CairoRunner {
                     })
                     .unwrap_or(&[]),
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_ranges,
+                    &mut hint_ranges,
                 &self.program.constants,
             )?;
 
@@ -735,18 +741,18 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
+            let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+            let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-        let mut hint_ranges = self
+            let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
             .hints_ranges
             .clone();
         #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = &self
+            let hint_data = &self
             .program
             .shared_program_data
             .hints_collection
@@ -765,11 +771,11 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                    &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                hint_data,
+                    hint_data,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_ranges,
+                    &mut hint_ranges,
                 &self.program.constants,
             )?;
         }
@@ -829,7 +835,7 @@ impl CairoRunner {
                     (rc_max - rc_min) as usize,
                 ))),
             )
-            .into());
+                .into());
         }
 
         Ok(())
@@ -878,7 +884,7 @@ impl CairoRunner {
                     diluted_usage_upper_bound,
                 ))),
             )
-            .into());
+                .into());
         }
 
         Ok(())
@@ -909,8 +915,7 @@ impl CairoRunner {
                 match self.check_used_cells(vm) {
                     Ok(_) => break,
                     Err(e) => match e {
-                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {
-                        }
+                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {}
                         e => return Err(e),
                     },
                 }
@@ -1220,7 +1225,7 @@ impl CairoRunner {
                 total_memory_units,
                 instance._public_memory_fraction,
             )
-            .into());
+                .into());
         }
 
         let instruction_memory_units = 4 * vm_current_step_u32;
@@ -1287,25 +1292,8 @@ impl CairoRunner {
         if !self.run_ended {
             return Err(RunnerError::ReadReturnValuesNoEndRun);
         }
-        let mut pointer = vm.get_ap();
-        let mut vm_builtin_map: HashMap<_, _> = vm
-            .builtin_runners
-            .iter_mut()
-            .map(|builtin| (builtin.name(), builtin))
-            .collect();
-
-        for builtin_name in ORDERED_BUILTINS.iter().rev() {
-            if let Some(builtin_runner) = vm_builtin_map.get_mut(builtin_name.name()) {
-                pointer = (*builtin_runner).final_stack(&vm.segments, pointer)?;
-            } else {
-                // If `allow_missing_builtins` is set, it is possible for a builtin to appear
-                // in the program and be absent from the VM. In this case, simply decrement
-                // the stack pointer.
-                if self.program.builtins.contains(builtin_name) {
-                    pointer = (pointer - 1)?;
-                }
-            }
-        }
+        let stack_ptr = vm.get_ap();
+        let stack_ptr = self.get_builtins_final_stack(vm, stack_ptr)?;
 
         if self.segments_finalized {
             return Err(RunnerError::FailedAddingReturnValues);
@@ -1315,7 +1303,7 @@ impl CairoRunner {
                 .execution_base
                 .as_ref()
                 .ok_or(RunnerError::NoExecBase)?;
-            let begin = pointer.offset - exec_base.offset;
+            let begin = stack_ptr.offset - exec_base.offset;
             let ap = vm.get_ap();
             let end = ap.offset - exec_base.offset;
             self.execution_public_memory
@@ -1331,10 +1319,8 @@ impl CairoRunner {
     pub fn get_builtins_final_stack(
         &self,
         vm: &mut VirtualMachine,
-        stack_ptr: Relocatable,
+        mut stack_ptr: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        let mut stack_ptr = Relocatable::from(&stack_ptr);
-
         let mut vm_builtin_map: HashMap<_, _> = vm
             .builtin_runners
             .iter_mut()
@@ -1933,7 +1919,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
 
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -3818,7 +3804,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all_cairo", true);
@@ -4872,7 +4858,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/example_program.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -4943,7 +4929,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bitwise_builtin_test.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5062,7 +5048,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_function.json"),
             None,
         )
-        .unwrap();
+            .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5106,7 +5092,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/assert_le_felt_hint.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5129,7 +5115,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5152,7 +5138,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5175,7 +5161,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5263,7 +5249,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5282,7 +5268,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5303,7 +5289,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5324,7 +5310,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-        .unwrap();
+            .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5513,7 +5499,7 @@ mod tests {
             },
             &mut BuiltinHintProcessor::new_empty(),
         )
-        .unwrap();
+            .unwrap();
         let air_private_input = runner.get_air_private_input(&vm);
         assert!(air_private_input.0[HASH_BUILTIN_NAME].is_empty());
         assert!(air_private_input.0[RANGE_CHECK_BUILTIN_NAME].is_empty());

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -5550,6 +5550,7 @@ mod tests {
         assert_eq!(initial_stack, vec![]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[rstest]
     #[case("small", true)]
     #[case("all_cairo", false)]

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1604,7 +1604,6 @@ mod tests {
         vm::trace::trace_entry::TraceEntry,
     };
     use assert_matches::assert_matches;
-    use rstest::rstest;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
@@ -5550,14 +5549,7 @@ mod tests {
         assert_eq!(initial_stack, vec![]);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[rstest]
-    #[case("small", true)]
-    #[case("all_cairo", false)]
-    fn prepare_builtins_initial_stack_missing_builtins(
-        #[case] layout: &str,
-        #[case] allow_missing_builtins: bool,
-    ) {
+    fn prepare_stack_for_program_with_builtin(layout: &str, allow_missing_builtins: bool) {
         let proof_mode = false;
         let trace_enabled = true;
 
@@ -5591,5 +5583,15 @@ mod tests {
                 assert_eq!(initial_stack, vec![MaybeRelocatable::from((0, 0))]);
             }
         }
+    }
+
+    #[test]
+    fn prepare_builtins_initial_stack() {
+        prepare_stack_for_program_with_builtin("all_cairo", false);
+    }
+
+    #[test]
+    fn prepare_builtins_initial_stack_missing_builtins() {
+        prepare_stack_for_program_with_builtin("small", true);
     }
 }

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -296,7 +296,7 @@ impl CairoRunner {
                         instance_def.ratio,
                         included,
                     )
-                        .into(),
+                    .into(),
                 );
             }
         }
@@ -613,10 +613,10 @@ impl CairoRunner {
             self.initial_ap = self.initial_fp;
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self
-                .program
-                .shared_program_data
-                .end
-                .ok_or(RunnerError::NoProgramEnd)?);
+                    .program
+                    .shared_program_data
+                    .end
+                    .ok_or(RunnerError::NoProgramEnd)?);
         }
 
         let return_fp = vm.segments.add();
@@ -690,11 +690,11 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = self.get_hint_data(references, hint_processor)?;
+        let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_ranges = self
+        let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
@@ -707,9 +707,9 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_data,
+                &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                    self.program
+                self.program
                     .shared_program_data
                     .hints_collection
                     .get_hint_range_for_pc(vm.run_context.pc.offset)
@@ -718,7 +718,7 @@ impl CairoRunner {
                     })
                     .unwrap_or(&[]),
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_ranges,
+                &mut hint_ranges,
                 &self.program.constants,
             )?;
 
@@ -741,18 +741,18 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let references = &self.program.shared_program_data.reference_manager;
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = self.get_hint_data(references, hint_processor)?;
+        let hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        let mut hint_data = self.get_hint_data(references, hint_processor)?;
         #[cfg(feature = "extensive_hints")]
-            let mut hint_ranges = self
+        let mut hint_ranges = self
             .program
             .shared_program_data
             .hints_collection
             .hints_ranges
             .clone();
         #[cfg(not(feature = "extensive_hints"))]
-            let hint_data = &self
+        let hint_data = &self
             .program
             .shared_program_data
             .hints_collection
@@ -771,11 +771,11 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_data,
+                &mut hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
-                    hint_data,
+                hint_data,
                 #[cfg(feature = "extensive_hints")]
-                    &mut hint_ranges,
+                &mut hint_ranges,
                 &self.program.constants,
             )?;
         }
@@ -835,7 +835,7 @@ impl CairoRunner {
                     (rc_max - rc_min) as usize,
                 ))),
             )
-                .into());
+            .into());
         }
 
         Ok(())
@@ -884,7 +884,7 @@ impl CairoRunner {
                     diluted_usage_upper_bound,
                 ))),
             )
-                .into());
+            .into());
         }
 
         Ok(())
@@ -915,7 +915,8 @@ impl CairoRunner {
                 match self.check_used_cells(vm) {
                     Ok(_) => break,
                     Err(e) => match e {
-                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {}
+                        VirtualMachineError::Memory(MemoryError::InsufficientAllocatedCells(_)) => {
+                        }
                         e => return Err(e),
                     },
                 }
@@ -1225,7 +1226,7 @@ impl CairoRunner {
                 total_memory_units,
                 instance._public_memory_fraction,
             )
-                .into());
+            .into());
         }
 
         let instruction_memory_units = 4 * vm_current_step_u32;
@@ -1919,7 +1920,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
 
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -3804,7 +3805,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/proof_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all_cairo", true);
@@ -4858,7 +4859,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/example_program.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -4929,7 +4930,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bitwise_builtin_test.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5048,7 +5049,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/bad_programs/error_msg_function.json"),
             None,
         )
-            .unwrap();
+        .unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
         let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -5092,7 +5093,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/assert_le_felt_hint.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5115,7 +5116,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5138,7 +5139,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5161,7 +5162,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/integration.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5249,7 +5250,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5268,7 +5269,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5289,7 +5290,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5310,7 +5311,7 @@ mod tests {
             include_bytes!("../../../../cairo_programs/fibonacci.json"),
             Some("main"),
         )
-            .unwrap();
+        .unwrap();
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = runner.initialize(&mut vm, false).unwrap();
@@ -5499,7 +5500,7 @@ mod tests {
             },
             &mut BuiltinHintProcessor::new_empty(),
         )
-            .unwrap();
+        .unwrap();
         let air_private_input = runner.get_air_private_input(&vm);
         assert!(air_private_input.0[HASH_BUILTIN_NAME].is_empty());
         assert!(air_private_input.0[RANGE_CHECK_BUILTIN_NAME].is_empty());


### PR DESCRIPTION
Problem: when using `allow-missing-builtins` for a program, some builtins requested by the program may not be part of the layout. This results in an incorrect configuration of the initial stack of the program as the program will expect pointers for all builtins, even though it may not access them later down the line. An example of this is any program that invokes another program (ex: the bootloader).

Solution: copy the Python VM implementation. We now iterate over the program builtins and set the initial stack of the builtin if it is set up in the VM and a default value of (0, 0) otherwise.

Fixes #1631.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

