### PR TITLE
[Cairo 1] Add flag to append return values to output segment when not running in proof_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 #### Upcoming Changes
 
+* feat: Add flag to append return values to output segment when not running in proof_mode [#1646](https://github.com/lambdaclass/cairo-vm/pull/1646)
+  * Adds the flag `append_return_values` to both the CLI and `Cairo1RunConfig` struct.
+  * Enabling flag will add the output builtin and the necessary instructions to append the return values to the output builtin's memory segment.
+
+* feat: Append return values to the output segment when running cairo1-run in proof_mode [#1597](https://github.com/lambdaclass/cairo-vm/pull/1597)
+  * Add instructions to the proof_mode header to copy return values to the output segment before initiating the infinite loop
+  * Output builtin is now always included when running cairo 1 programs in proof_mode
+
 * feat: Add cairo1-run output pretty-printing for felts, arrays/spans and dicts [#1630](https://github.com/lambdaclass/cairo-vm/pull/1630)
 
 * feat: output builtin features for bootloader support [#1580](https://github.com/lambdaclass/cairo-vm/pull/1580)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
   * Adds the flag `append_return_values` to both the CLI and `Cairo1RunConfig` struct.
   * Enabling flag will add the output builtin and the necessary instructions to append the return values to the output builtin's memory segment.
 
-* feat: Append return values to the output segment when running cairo1-run in proof_mode [#1597](https://github.com/lambdaclass/cairo-vm/pull/1597)
-  * Add instructions to the proof_mode header to copy return values to the output segment before initiating the infinite loop
-  * Output builtin is now always included when running cairo 1 programs in proof_mode
-
 * feat: Add cairo1-run output pretty-printing for felts, arrays/spans and dicts [#1630](https://github.com/lambdaclass/cairo-vm/pull/1630)
 
 * feat: output builtin features for bootloader support [#1580](https://github.com/lambdaclass/cairo-vm/pull/1580)

--- a/cairo1-run/README.md
+++ b/cairo1-run/README.md
@@ -66,3 +66,5 @@ The cairo1-run cli supports the following optional arguments:
 * `--air_private_input <AIR_PRIVATE_INPUT>`: Receives the name of a file and outputs the AIR private inputs into it. Can only be used if proof_mode, trace_file & memory_file are also enabled.
 
 * `--cairo_pie_output <CAIRO_PIE_OUTPUT>`: Receives the name of a file and outputs the Cairo PIE into it. Can only be used if proof_mode, is not enabled.
+
+* `--append_return_values`: Adds extra instructions to the program in order to append the return values to the output builtin's segment. This is the default behaviour for proof_mode.

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -210,17 +210,19 @@ pub fn cairo_run_program(
     // Set stop pointers for builtins so we can obtain the air public input
     if cairo_run_config.finalize_builtins {
         finalize_builtins(
-            cairo_run_config.proof_mode,
+            cairo_run_config.proof_mode || cairo_run_config.append_return_values,
             &main_func.signature.ret_types,
             &type_sizes,
             &mut vm,
         )?;
 
-        // Build execution public memory
-        if cairo_run_config.proof_mode {
+        if cairo_run_config.proof_mode || cairo_run_config.append_return_values {
             // As the output builtin is not used by the program we need to compute it's stop ptr manually
             vm.set_output_stop_ptr_offset(return_type_size as usize);
+        }
 
+        // Build execution public memory
+        if cairo_run_config.proof_mode {
             runner.finalize_segments(&mut vm)?;
         }
     }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -210,14 +210,14 @@ pub fn cairo_run_program(
     // Set stop pointers for builtins so we can obtain the air public input
     if cairo_run_config.finalize_builtins {
         finalize_builtins(
-            cairo_run_config.proof_mode || cairo_run_config.append_return_values,
+            cairo_run_config.proof_mode,
             &main_func.signature.ret_types,
             &type_sizes,
             &mut vm,
         )?;
 
         // Build execution public memory
-        if cairo_run_config.proof_mode || cairo_run_config.append_return_values {
+        if cairo_run_config.proof_mode {
             // As the output builtin is not used by the program we need to compute it's stop ptr manually
             vm.set_output_stop_ptr_offset(return_type_size as usize);
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -783,10 +783,12 @@ mod tests {
             proof_mode,
             layout: "all_cairo",
             append_return_values: !proof_mode, // This is so we can test appending return values when not running in proof_mode
+            finalize_builtins: true,
             ..Default::default()
         };
         // Run program
-        let (_, vm, return_values) = cairo_run_program(&sierra_program, cairo_run_config).unwrap();
+        let (runner, vm, return_values) =
+            cairo_run_program(&sierra_program, cairo_run_config).unwrap();
         // When the return type is a PanicResult, we remove the panic wrapper when returning the ret values
         // And handle the panics returning an error, so we need to add it here
         let return_values = if main_hash_panic_result(&sierra_program) {
@@ -806,5 +808,10 @@ mod tests {
         assert!(vm
             .get_maybe(&Relocatable::from((2_isize, return_values.len())))
             .is_none());
+
+        // Check that cairo_pie can be outputted when not running in proof_mode
+        if !proof_mode {
+            assert!(runner.get_cairo_pie(&vm).is_ok())
+        }
     }
 }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -194,7 +194,7 @@ pub fn cairo_run_program(
 
     // Run it until the end / infinite loop in proof_mode
     runner.run_until_pc(end, &mut vm, &mut hint_processor)?;
-    if cairo_run_config.proof_mode {
+    if cairo_run_config.proof_mode || cairo_run_config.append_return_values {
         // As we will be inserting the return values into the output segment after running the main program (right before the infinite loop) the computed size for the output builtin will be 0
         // We need to manually set the segment size for the output builtin's segment so memory hole counting doesn't fail due to having a higher accessed address count than the segment's size
         vm.segments

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -355,7 +355,7 @@ fn create_append_return_values_header(
     // The pc offset where the original program should start
     // Without this header it should start at 0, but we add 2 for each call and jump instruction (as both of them use immediate values)
     // and also 1 for each instruction added to copy each return value into the output segment
-    let program_start_offset: i16 = return_type_size;
+    let program_start_offset: i16 = 2 + return_type_size;
 
     let mut ctx = casm! {};
     casm_extend! {ctx,

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -209,14 +209,14 @@ pub fn cairo_run_program(
     // Set stop pointers for builtins so we can obtain the air public input
     if cairo_run_config.finalize_builtins {
         finalize_builtins(
-            cairo_run_config.proof_mode,
+            cairo_run_config.proof_mode || cairo_run_config.append_return_values,
             &main_func.signature.ret_types,
             &type_sizes,
             &mut vm,
         )?;
 
         // Build execution public memory
-        if cairo_run_config.proof_mode {
+        if cairo_run_config.proof_mode || cairo_run_config.append_return_values {
             // As the output builtin is not used by the program we need to compute it's stop ptr manually
             vm.set_output_stop_ptr_offset(return_type_size as usize);
 
@@ -644,7 +644,7 @@ fn fetch_return_values(
 // Calculates builtins' final_stack setting each stop_ptr
 // Calling this function is a must if either air_public_input or cairo_pie are needed
 fn finalize_builtins(
-    proof_mode: bool,
+    skip_output: bool,
     main_ret_types: &[ConcreteTypeId],
     type_sizes: &UnorderedHashMap<ConcreteTypeId, i16>,
     vm: &mut VirtualMachine,
@@ -683,7 +683,7 @@ fn finalize_builtins(
     }
 
     // Set stop pointer for each builtin
-    vm.builtins_final_stack_from_stack_pointer_dict(&builtin_name_to_stack_pointer, proof_mode)?;
+    vm.builtins_final_stack_from_stack_pointer_dict(&builtin_name_to_stack_pointer, skip_output)?;
     Ok(())
 }
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -58,6 +58,8 @@ pub struct Cairo1RunConfig<'a> {
     // Should be true if either air_public_input or cairo_pie_output are needed
     // Sets builtins stop_ptr by calling `final_stack` on each builtin
     pub finalize_builtins: bool,
+    // Appends return values to the output segment. This is performed by default when running in proof_mode
+    pub append_return_values: bool,
 }
 
 impl Default for Cairo1RunConfig<'_> {
@@ -69,6 +71,7 @@ impl Default for Cairo1RunConfig<'_> {
             layout: "plain",
             proof_mode: false,
             finalize_builtins: false,
+            append_return_values: false,
         }
     }
 }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -355,7 +355,7 @@ fn create_append_return_values_header(
     // The pc offset where the original program should start
     // Without this header it should start at 0, but we add 2 for each call and jump instruction (as both of them use immediate values)
     // and also 1 for each instruction added to copy each return value into the output segment
-    let program_start_offset: i16 = 2 + return_type_size;
+    let program_start_offset: i16 = 3 + return_type_size;
 
     let mut ctx = casm! {};
     casm_extend! {ctx,
@@ -443,7 +443,7 @@ fn create_entry_code(
         let generic_ty = &info.long_id.generic_id;
         if let Some(offset) = builtin_offset.get(generic_ty) {
             let mut offset = *offset;
-            if proof_mode {
+            if proof_mode || append_output {
                 // Everything is off by 2 due to the proof mode header
                 offset += 2;
             }
@@ -774,7 +774,10 @@ mod tests {
     #[case("../cairo_programs/cairo-1-programs/simple_struct.cairo")]
     #[case("../cairo_programs/cairo-1-programs/simple.cairo")]
     #[case("../cairo_programs/cairo-1-programs/struct_span_return.cairo")]
-    fn check_append_ret_values_to_output_segment(#[case] filename: &str, #[values(true, false)] proof_mode: bool) {
+    fn check_append_ret_values_to_output_segment(
+        #[case] filename: &str,
+        #[values(true, false)] proof_mode: bool,
+    ) {
         // Compile to sierra
         let sierra_program = compile_to_sierra(filename);
         // Set proof_mode

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -369,6 +369,9 @@ fn create_append_return_values_header(
             [ap - j] = [[fp + output_fp_offset] + i as i16];
         };
     }
+    casm_extend! {ctx,
+        ret;
+    };
     ctx.instructions
 }
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -101,7 +101,6 @@ pub fn cairo_run_program(
         &type_sizes,
         main_func,
         initial_gas,
-        cairo_run_config.proof_mode,
         cairo_run_config.proof_mode || cairo_run_config.append_return_values,
         cairo_run_config.args,
     )?;
@@ -383,7 +382,6 @@ fn create_entry_code(
     type_sizes: &UnorderedHashMap<ConcreteTypeId, i16>,
     func: &Function,
     initial_gas: usize,
-    proof_mode: bool,
     append_output: bool,
     args: &[FuncArg],
 ) -> Result<(Vec<Instruction>, Vec<BuiltinName>), Error> {
@@ -443,7 +441,7 @@ fn create_entry_code(
         let generic_ty = &info.long_id.generic_id;
         if let Some(offset) = builtin_offset.get(generic_ty) {
             let mut offset = *offset;
-            if proof_mode || append_output {
+            if append_output {
                 // Everything is off by 2 due to the proof mode header
                 offset += 2;
             }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -771,13 +771,14 @@ mod tests {
     #[case("../cairo_programs/cairo-1-programs/simple_struct.cairo")]
     #[case("../cairo_programs/cairo-1-programs/simple.cairo")]
     #[case("../cairo_programs/cairo-1-programs/struct_span_return.cairo")]
-    fn check_append_ret_values_to_output_segment(#[case] filename: &str) {
+    fn check_append_ret_values_to_output_segment(#[case] filename: &str, #[values(true, false)] proof_mode: bool) {
         // Compile to sierra
         let sierra_program = compile_to_sierra(filename);
         // Set proof_mode
         let cairo_run_config = Cairo1RunConfig {
-            proof_mode: true,
+            proof_mode,
             layout: "all_cairo",
+            append_return_values: !proof_mode, // This is so we can test appending return values when not running in proof_mode
             ..Default::default()
         };
         // Run program

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -339,10 +339,8 @@ fn create_proof_mode_header(builtin_count: i16, return_type_size: i16) -> Vec<In
     ctx.instructions
 }
 
-// Create proof_mode specific instructions
-// Including the "canonical" proof mode instructions (the ones added by the compiler in cairo 0)
-// wich call the firt program instruction and then initiate an infinite loop.
-// And also appending the return values to the output builtin's memory segment
+// Create specific instructions to append the return values to the output segment when not running in proof_mode
+// Call the firt program instruction, appends the return values to the output builtin's memory segment and then returns
 fn create_append_return_values_header(
     builtin_count: i16,
     return_type_size: i16,
@@ -352,7 +350,7 @@ fn create_append_return_values_header(
     let output_fp_offset: i16 = -(builtin_count + 2); // The 2 here represents the return_fp & end segments
 
     // The pc offset where the original program should start
-    // Without this header it should start at 0, but we add 2 for each call and jump instruction (as both of them use immediate values)
+    // Without this header it should start at 0, but we add 2 for the call and 1 for the return instruction
     // and also 1 for each instruction added to copy each return value into the output segment
     let program_start_offset: i16 = 3 + return_type_size;
 

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -58,6 +58,13 @@ struct Args {
     args: FuncArgs,
     #[clap(long = "print_output", value_parser)]
     print_output: bool,
+    #[clap(
+        long = "append_return_values",
+        // We need to add these air_private_input & air_public_input or else
+        // passing cairo_pie_output + either of these without proof_mode will not fail
+        conflicts_with_all = ["proof_mode", "air_private_input", "air_public_input"]
+    )]
+    append_return_values: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -211,6 +218,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         trace_enabled: args.trace_file.is_some() || args.air_public_input.is_some(),
         args: &args.args.0,
         finalize_builtins: args.air_private_input.is_some() || args.cairo_pie_output.is_some(),
+        append_return_values: args.append_return_values,
         ..Default::default()
     };
 

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -211,6 +211,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         trace_enabled: args.trace_file.is_some() || args.air_public_input.is_some(),
         args: &args.args.0,
         finalize_builtins: args.air_private_input.is_some() || args.cairo_pie_output.is_some(),
+        ..Default::default()
     };
 
     let compiler_config = CompilerConfig {

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -219,7 +219,6 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         args: &args.args.0,
         finalize_builtins: args.air_private_input.is_some() || args.cairo_pie_output.is_some(),
         append_return_values: args.append_return_values,
-        ..Default::default()
     };
 
     let compiler_config = CompilerConfig {

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -113,7 +113,7 @@ impl CairoPie {
         let file = File::create(file_path)?;
         let mut zip_writer = ZipWriter::new(file);
         let options =
-            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         zip_writer.start_file("version.json", options)?;
         zip_writer.write_all(serde_json::to_string(&self.version)?.as_bytes())?;
         zip_writer.start_file("metadata.json", options)?;


### PR DESCRIPTION
  * Adds the flag `append_return_values` to both the CLI and `Cairo1RunConfig` struct.
  * Enabling flag will add the output builtin and the necessary instructions to append the return values to the output builtin's memory segment.