### PR TITLE
Show only layout builtins in air private input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: Show only layout builtins in air private input [#1651](https://github.com/lambdaclass/cairo-vm/pull/1651)
+
 * feat: Fix output serialization for cairo 1 [#1645](https://github.com/lambdaclass/cairo-vm/pull/1645)
   * Reverts changes added by #1630
   * Extends the serialization of Arrays added by the `print_output` flag to Spans and Dictionaries

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -233,4 +233,26 @@ mod tests {
         assert_matches!(private_input.0.get(KECCAK_BUILTIN_NAME), data if data == serializable_private_input.keccak.as_ref());
         assert_matches!(private_input.0.get(POSEIDON_BUILTIN_NAME), data if data == serializable_private_input.poseidon.as_ref());
     }
+
+    #[test]
+    fn serialize_air_private_input_small_layout_only_builtins() {
+        let config = crate::cairo_run::CairoRunConfig {
+            proof_mode: true,
+            relocate_mem: true,
+            trace_enabled: true,
+            layout: "small",
+            ..Default::default()
+        };
+        let (runner, vm) = crate::cairo_run::cairo_run(include_bytes!("../../cairo_programs/proof_programs/fibonacci.json"), &config, &mut crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor::new_empty()).unwrap();
+        let public_input = runner.get_air_private_input(&vm);
+        let serialized_public_input =
+            public_input.to_serializable("/dev/null".to_string(), "/dev/null".to_string());
+        assert!(serialized_public_input.pedersen.is_some());
+        assert!(serialized_public_input.range_check.is_some());
+        assert!(serialized_public_input.ecdsa.is_some());
+        assert!(serialized_public_input.bitwise.is_none());
+        assert!(serialized_public_input.ec_op.is_none());
+        assert!(serialized_public_input.keccak.is_none());
+        assert!(serialized_public_input.poseidon.is_none());
+    }
 }

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -165,6 +165,9 @@ mod tests {
         assert_matches::assert_matches,
     };
 
+    #[cfg(any(target_arch = "wasm32", no_std, not(feature = "std")))]
+    use crate::alloc::string::ToString;
+
     #[cfg(feature = "std")]
     #[test]
     fn test_from_serializable() {


### PR DESCRIPTION
When converting to serializable format, the air private input contained all the builtins instead of only the ones present in the layout, this worked fine when running with `starknet_with_keccak` layout but produces a different output from cairo_lang when using a different layout that doesn't use all the builtins
