### PR TITLE
Sort builtin segment info upon serialization for Cairo PIE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: Sort builtin segment info upon serialization for Cairo PIE [#1654](https://github.com/lambdaclass/cairo-vm/pull/1654)
+
 * feat: Fix output serialization for cairo 1 [#1645](https://github.com/lambdaclass/cairo-vm/pull/1645)
   * Reverts changes added by #1630
   * Extends the serialization of Arrays added by the `print_output` flag to Spans and Dictionaries

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -84,6 +84,7 @@ pub struct CairoPieMetadata {
     pub execution_segment: SegmentInfo,
     pub ret_fp_segment: SegmentInfo,
     pub ret_pc_segment: SegmentInfo,
+    #[serde(serialize_with = "serde_impl::serialize_builtin_segments")]
     pub builtin_segments: HashMap<String, SegmentInfo>,
     pub extra_segments: Vec<SegmentInfo>,
 }
@@ -132,8 +133,9 @@ impl CairoPie {
 mod serde_impl {
     use crate::stdlib::collections::HashMap;
     use num_traits::Num;
+    use serde::ser::SerializeMap;
 
-    use super::{CairoPieMemory, CAIRO_PIE_VERSION};
+    use super::{CairoPieMemory, SegmentInfo, CAIRO_PIE_VERSION};
     use crate::stdlib::prelude::{String, Vec};
     use crate::{
         types::relocatable::{MaybeRelocatable, Relocatable},
@@ -320,6 +322,33 @@ mod serde_impl {
         }
 
         seq_serializer.end()
+    }
+
+    pub fn serialize_builtin_segments<S>(
+        values: &HashMap<String, SegmentInfo>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map_serializer = serializer.serialize_map(Some(values.len()))?;
+        const BUILTIN_ORDERED_LIST: &'static [&'static str] = &[
+            "output",
+            "pedersen",
+            "range_check",
+            "ecdsa",
+            "bitwise",
+            "ec_op",
+            "keccak",
+            "poseidon",
+        ];
+
+        for name in BUILTIN_ORDERED_LIST {
+            if let Some(info) = values.get(*name) {
+                map_serializer.serialize_entry(name, info)?
+            }
+        }
+        map_serializer.end()
     }
 }
 

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -332,7 +332,7 @@ mod serde_impl {
         S: Serializer,
     {
         let mut map_serializer = serializer.serialize_map(Some(values.len()))?;
-        const BUILTIN_ORDERED_LIST: &'static [&'static str] = &[
+        const BUILTIN_ORDERED_LIST: &[&str] = &[
             "output",
             "pedersen",
             "range_check",


### PR DESCRIPTION
Adds custom serialization for builtin segment info.
This fixes pie validation checks failing due to builtin segment info map keys not following the same order as the builtin list

