### PR TITLE
Simplify `get_offset_value_reference` and add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: simplify `get_offset_value_reference` logic and add unit tests for it [#1662] (https://github.com/lambdaclass/cairo-vm/pull/1662)
+
 * feat: Add `print_output` flag to `cairo-1` crate [#1575] (https://github.com/lambdaclass/cairo-vm/pull/1575)
 
 * bugfixes(BREAKING): Fix memory hole count inconsistencies #[1585] (https://github.com/lambdaclass/cairo-vm/pull/1585)


### PR DESCRIPTION
# Simplify `get_offset_value_reference` and add unit tests

## Description

- The logical test on `base_addr` and `offset` to know if we should return null is implicitly already provided by the Relocatable addition in the last step of the `get_offset_value_reference` function, so that I don't think it's needed is as an overhead.
- Two unit tests are added to test edge configurations.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

