### PR TITLE
Add test coverage for `get_constant_from_var_name`

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -277,4 +277,46 @@ mod tests {
             Err(HintError::IdentifierNotInteger(bx)) if *bx == ("value".to_string(), (1,0).into())
         );
     }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_get_constant_from_var_name_with_point() {
+        let ids_data = HashMap::from([
+            ("value".to_string(), Felt252::from(2)),
+            ("ids.MAX_LOW".to_string(), Felt252::from(20)),
+        ]);
+
+        assert_eq!(
+            *get_constant_from_var_name("MAX_LOW", &ids_data).unwrap(),
+            Felt252::from(20)
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_get_constant_from_var_name_without_point() {
+        let ids_data = HashMap::from([
+            ("value".to_string(), Felt252::from(2)),
+            ("ids.MAX_LOW".to_string(), Felt252::from(20)),
+        ]);
+
+        assert_eq!(
+            *get_constant_from_var_name("value", &ids_data).unwrap(),
+            Felt252::from(2)
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_get_constant_from_var_name_invalid() {
+        let ids_data = HashMap::from([
+            ("value".to_string(), Felt252::from(2)),
+            ("ids.MAX_LOW".to_string(), Felt252::from(20)),
+        ]);
+
+        assert_matches!(
+            get_constant_from_var_name("MAX_HIGH", &ids_data),
+            Err(HintError::MissingConstant(bx)) if *bx == "MAX_HIGH".to_string()
+        );
+    }
 }


### PR DESCRIPTION
# Add test coverage for `get_constant_from_var_name`

## Description

Add a series of unit tests for `get_constant_from_var_name` hint util method.

## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

