### PR TITLE
Use return type info from sierra when serializing return values in cairo1-run crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat(BREAKING): Use return type info from sierra when serializing return values n cairo1-run crate [#1665](https://github.com/lambdaclass/cairo-vm/pull/1665)
+* feat(BREAKING): Use return type info from sierra when serializing return values in cairo1-run crate [#1665](https://github.com/lambdaclass/cairo-vm/pull/1665)
   * Removed public function `serialize_output`.
   * Add field `serialize_output` to `Cairo1RunConfig`.
   * Function `cairo_run_program` now returns an extra `Option<String>` value with the serialized output if `serialize_output` is enabled in the config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+
+* feat(BREAKING): Use return type info from sierra when serializing return values n cairo1-run crate [#1665](https://github.com/lambdaclass/cairo-vm/pull/1665)
+  * Removed public function `serialize_output`.
+  * Add field `serialize_output` to `Cairo1RunConfig`.
+  * Function `cairo_run_program` now returns an extra `Option<String>` value with the serialized output if `serialize_output` is enabled in the config.
+  * Output serialization improved as it now uses the sierra program data to identify return value's types.
+
 * feat: add a `--tracer` option which hosts a web server that shows the line by line execution of cairo code along with memory registers [#1265](https://github.com/lambdaclass/cairo-vm/pull/1265)
 
 * feat: Fix error handling in `initialize_state`[#1657](https://github.com/lambdaclass/cairo-vm/pull/1657)

--- a/cairo1-run/Cargo.toml
+++ b/cairo1-run/Cargo.toml
@@ -26,6 +26,7 @@ bincode.workspace = true
 assert_matches = "1.5.0"
 rstest = "0.17.0"
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
+num-traits = { version = "0.2", default-features = false }
 
 [features]
 default = ["with_mimalloc"]

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -861,7 +861,11 @@ fn serialize_output_inner<'a>(
                 .to_usize()
                 .expect("Invalid enum tag");
             // Convert casm variant idx to sierra variant idx
-            let variant_idx = num_variants - 1 - (casm_variant_idx >> 1);
+            let variant_idx = if *num_variants > 2 {
+                num_variants - 1 - (casm_variant_idx >> 1)
+            } else {
+                casm_variant_idx
+            };
             let variant_type_id = &info.variants[variant_idx];
 
             // Handle core::bool separately

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -811,7 +811,6 @@ fn serialize_output_inner<'a>(
             }
             output_string.push(']');
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Bitwise(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Box(info) => {
             // As this represents a pointer, we need to extract it's values
             let ptr = return_values_iter
@@ -833,8 +832,12 @@ fn serialize_output_inner<'a>(
                 type_sizes,
             )
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Const(_) => todo!(),
+        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Const(_) => {
+            unimplemented!("Not supported in the current version")
+        },
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Felt252(_)
+        // Only unsigned integer values implement Into<Bytes31>
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Bytes31(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint8(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint16(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint32(_)
@@ -848,7 +851,6 @@ fn serialize_output_inner<'a>(
                 .expect("Value is not an integer");
             output_string.push_str(&val.to_string());
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint8(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint16(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint32(_)
@@ -893,13 +895,11 @@ fn serialize_output_inner<'a>(
                 &mut data_iter,
                 output_string,
                 vm,
-                &info.ty,
+                dbg!(&info.ty),
                 sierra_program_registry,
                 type_sizes,
             )
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::RangeCheck(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uninitialized(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Enum(info) => {
             // First we check if it is a Panic enum, as we already handled panics when fetching return values,
             // we can ignore them and move on to the non-panic variant
@@ -1046,18 +1046,6 @@ fn serialize_output_inner<'a>(
             }
             output_string.push('}');
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::EcOp(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::EcPoint(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::EcState(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::GasBuiltin(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::BuiltinCosts(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Pedersen(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Poseidon(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Felt252DictEntry(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::StarkNet(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::SegmentArena(_) => {
-            panic!("Unexpected return value type")
-        }
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::SquashedFelt252Dict(info) => {
             // Process Dictionary
             let dict_start = return_values_iter
@@ -1104,7 +1092,7 @@ fn serialize_output_inner<'a>(
             }
             output_string.push('}');
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Span(_) => todo!(),
+        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Span(_) => unimplemented!("Span types get resolved to Array in the current version"),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Snapshot(info) => {
             serialize_output_inner(
                 return_values_iter,
@@ -1115,8 +1103,8 @@ fn serialize_output_inner<'a>(
                 type_sizes,
             )
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Bytes31(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::BoundedInt(_) => todo!(),
+        cairo_lang_sierra::extensions::core::CoreTypeConcrete::BoundedInt(_) => unimplemented!("This is a Trait, shouldn't be returned"),
+        _ => panic!("Unexpected return type")
     }
 }
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -26,6 +26,7 @@ use cairo_lang_sierra_type_size::get_type_size_map;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_vm::{
     hint_processor::cairo_1_hint_processor::hint_processor::Cairo1HintProcessor,
+    math_utils::signed_felt,
     serde::deserialize_program::{
         ApTracking, BuiltinName, FlowTrackingData, HintParams, ReferenceManager,
     },
@@ -841,23 +842,31 @@ fn serialize_output_inner<'a>(
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Felt252(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint8(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint16(_)
-        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint32(_) => {
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint32(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint64(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint128(_) => {
             maybe_add_whitespace(output_string);
             let val = return_values_iter
                 .next()
                 .expect("Missing return value")
                 .get_int()
-                .expect("u32 value is not an integer");
+                .expect("Value is not an integer");
             output_string.push_str(&val.to_string());
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint64(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint128(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint128MulGuarantee(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint8(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint16(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint32(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint64(_) => todo!(),
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint128(_) => todo!(),
+        cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint8(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint16(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint32(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint64(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Sint128(_) => {
+            maybe_add_whitespace(output_string);
+            let val = return_values_iter
+                .next()
+                .expect("Missing return value")
+                .get_int()
+                .expect("Value is not an integer");
+            output_string.push_str(&signed_felt(val).to_string());
+        }
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::NonZero(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Nullable(info) => {
             // As this represents a pointer, we need to extract it's values

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -225,13 +225,13 @@ pub fn cairo_run_program(
     let return_values = fetch_return_values(return_type_size, return_type_id, &vm)?;
 
     let serialized_output = if cairo_run_config.serialize_output {
-        Some(dbg!(serialize_output(
+        Some(serialize_output(
             &return_values,
             &mut vm,
             return_type_id,
             &sierra_program_registry,
             &type_sizes,
-        )))
+        ))
     } else {
         None
     };
@@ -751,11 +751,11 @@ fn finalize_builtins(
     Ok(())
 }
 
-fn serialize_output<'a>(
-    return_values: &Vec<MaybeRelocatable>,
+fn serialize_output(
+    return_values: &[MaybeRelocatable],
     vm: &mut VirtualMachine,
     return_type_id: &ConcreteTypeId,
-    sierra_program_registry: &'a ProgramRegistry<CoreType, CoreLibfunc>,
+    sierra_program_registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     type_sizes: &UnorderedHashMap<ConcreteTypeId, i16>,
 ) -> String {
     let mut output_string = String::new();
@@ -771,12 +771,12 @@ fn serialize_output<'a>(
     output_string
 }
 
-fn serialize_output_inner<'a>(
+fn serialize_output_inner(
     return_values_iter: &mut Peekable<Iter<MaybeRelocatable>>,
     output_string: &mut String,
     vm: &mut VirtualMachine,
     return_type_id: &ConcreteTypeId,
-    sierra_program_registry: &'a ProgramRegistry<CoreType, CoreLibfunc>,
+    sierra_program_registry: &ProgramRegistry<CoreType, CoreLibfunc>,
     type_sizes: &UnorderedHashMap<ConcreteTypeId, i16>,
 ) {
     match sierra_program_registry.get_type(return_type_id).unwrap() {
@@ -895,7 +895,7 @@ fn serialize_output_inner<'a>(
                 &mut data_iter,
                 output_string,
                 vm,
-                dbg!(&info.ty),
+                &info.ty,
                 sierra_program_registry,
                 type_sizes,
             )
@@ -1059,7 +1059,7 @@ fn serialize_output_inner<'a>(
                 .get_relocatable()
                 .expect("Squashed dict_end ptr not Relocatable");
             let dict_size = (dict_end - dict_start).unwrap();
-            if !(dict_size % 3 == 0) {
+            if dict_size % 3 != 0 {
                 panic!("Return value is not a valid SquashedFelt252Dict")
             }
             // Fetch dictionary values type id

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -881,7 +881,6 @@ fn serialize_output_inner<'a>(
                     );
                 }
             }
-
             let num_variants = &info.variants.len();
             let casm_variant_idx: usize = return_values_iter
                 .next()
@@ -917,14 +916,15 @@ fn serialize_output_inner<'a>(
                                 .is_some_and(|size| size.is_zero()),
                         "Malformed bool enum"
                     );
+
+                    let boolean_string = match variant_idx {
+                        0 => "false",
+                        _ => "true",
+                    };
+                    maybe_add_whitespace(output_string);
+                    output_string.push_str(boolean_string);
+                    return;
                 }
-                let boolean_string = match variant_idx {
-                    0 => "false",
-                    _ => "true",
-                };
-                maybe_add_whitespace(output_string);
-                output_string.push_str(boolean_string);
-                return;
             }
             // TODO: Something similar to the bool handling could be done for unit enum variants if we could get the type info with the variant names
 
@@ -1016,7 +1016,14 @@ fn serialize_output_inner<'a>(
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::StarkNet(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::SegmentArena(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Snapshot(info) => {
-            serialize_output_inner(return_values_iter, output_string, vm, &info.ty, sierra_program_registry, type_sizes)
+            serialize_output_inner(
+                return_values_iter,
+                output_string,
+                vm,
+                &info.ty,
+                sierra_program_registry,
+                type_sizes,
+            )
         }
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Bytes31(_) => todo!(),
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::BoundedInt(_) => todo!(),

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -845,10 +845,10 @@ fn serialize_output_inner<'a>(
                         return_values_iter,
                         output_string,
                         vm,
-                        &info.variants[1],
+                        &info.variants[0],
                         sierra_program_registry,
                         type_sizes,
-                    )
+                    );
                 }
             }
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -1103,7 +1103,6 @@ fn serialize_output_inner(
                 type_sizes,
             )
         }
-        cairo_lang_sierra::extensions::core::CoreTypeConcrete::BoundedInt(_) => unimplemented!("This is a Trait, shouldn't be returned"),
         _ => panic!("Unexpected return type")
     }
 }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -967,13 +967,13 @@ fn serialize_output_inner(
             // TODO: Something similar to the bool handling could be done for unit enum variants if we could get the type info with the variant names
 
             // Space is always allocated for the largest enum member, padding with zeros in front for the smaller variants
-            // We have to remove this variants
             let mut max_variant_size = 0;
             for variant in &info.variants {
                 let variant_size = type_sizes.get(variant).unwrap();
                 max_variant_size = std::cmp::max(max_variant_size, *variant_size)
             }
             for _ in 0..max_variant_size - type_sizes.get(variant_type_id).unwrap() {
+                // Remove padding
                 assert_eq!(
                     return_values_iter.next(),
                     Some(&MaybeRelocatable::from(0)),

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -669,4 +669,13 @@ mod tests {
         let expected_output = "{0:10 1:20 2:30} 3";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dict_with_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dict_with_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_run_dict_with_struct(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        let expected_output = "{0: 1 true 1: 1 false 2: 1 true}";
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -678,4 +678,13 @@ mod tests {
         let expected_output = "{0: 1 true 1: 1 false 2: 1 true}";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict_squash.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict_squash.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_run_felt_dict_squash(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        let expected_output = "{66675: [4 5 6] 66676: [1 2 3]}";
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -639,7 +639,7 @@ mod tests {
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
     fn test_run_felt_dict(#[case] args: &[&str]) {
         let args = args.iter().cloned().map(String::from);
-        let expected_output = "{66675:[8 9 10 11] 66676:[1 2 3]}";
+        let expected_output = "{66675: [8 9 10 11] 66676: [1 2 3]}";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
 

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -596,7 +596,7 @@ mod tests {
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/tensor_new.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
     fn test_run_tensor_new(#[case] args: &[&str]) {
         let args = args.iter().cloned().map(String::from);
-        let expected_output = "[1 2] [1 false 2 true]";
+        let expected_output = "[1 2] [1 false 1 true]";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -551,7 +551,7 @@ mod tests {
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/simple.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
     fn test_run_simple_ok(#[case] args: &[&str]) {
         let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1");
+        assert_matches!(run(args), Ok(Some(res)) if res == "true");
     }
 
     #[rstest]

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -696,4 +696,13 @@ mod tests {
         let expected_output = "null";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bytes31_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bytes31_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_run_bytes31_ret(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        let expected_output = "123";
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -687,4 +687,13 @@ mod tests {
         let expected_output = "{66675: [4 5 6] 66676: [1 2 3]}";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/null_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/null_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_run_null_ret(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        let expected_output = "null";
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -233,7 +233,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
     let sierra_program = compile_cairo_project_at_path(&args.filename, compiler_config)
         .map_err(|err| Error::SierraCompilation(err.to_string()))?;
 
-    let (runner, vm, return_values, serialized_output) =
+    let (runner, vm, _, serialized_output) =
         cairo_run::cairo_run_program(&sierra_program, cairo_run_config)?;
 
     if let Some(file_path) = args.air_public_input {

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -590,4 +590,13 @@ mod tests {
         let expected_output = "123";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/tensor_new.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/tensor_new.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
+    fn test_run_tensor_new(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        let expected_output = "[1 2] [1 false 2 true]";
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -235,6 +235,9 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
     let (runner, vm, return_values) =
         cairo_run::cairo_run_program(&sierra_program, cairo_run_config)?;
 
+    println!("{}", vm.segments);
+    println!("{:?}", return_values);
+
     let output_string = if args.print_output {
         Some(serialize_output(&vm, &return_values))
     } else {

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -487,7 +487,7 @@ mod tests {
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/hello.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
     fn test_run_hello_ok(#[case] args: &[&str]) {
         let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1 1234");
+        assert_matches!(run(args), Ok(Some(res)) if res == "1234");
     }
 
     #[rstest]
@@ -666,7 +666,7 @@ mod tests {
     #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/nullable_box_vec.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
     fn test_run_nullable_box_vec(#[case] args: &[&str]) {
         let args = args.iter().cloned().map(String::from);
-        let expected_output = "{0:10 1:20 2:30} 3";
+        let expected_output = "{0: 10 1: 20 2: 30} 3";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
 

--- a/cairo_programs/cairo-1-programs/bytes31_ret.cairo
+++ b/cairo_programs/cairo-1-programs/bytes31_ret.cairo
@@ -1,0 +1,5 @@
+fn main() -> bytes31 {
+    let a: u128 = 123;
+    let b: bytes31 = a.into();
+    b
+}

--- a/cairo_programs/cairo-1-programs/dict_with_struct.cairo
+++ b/cairo_programs/cairo-1-programs/dict_with_struct.cairo
@@ -1,0 +1,24 @@
+use core::nullable::{nullable_from_box, match_nullable, FromNullableResult};
+
+
+#[derive(Drop, Copy)]
+struct FP16x16 {
+    mag: u32,
+    sign: bool
+}
+
+fn main() -> Felt252Dict<Nullable<FP16x16>> {
+    // Create the dictionary
+    let mut d: Felt252Dict<Nullable<FP16x16>> = Default::default();
+
+    let box_a = BoxTrait::new(FP16x16 { mag: 1, sign: false });
+    let box_b = BoxTrait::new(FP16x16 { mag: 1, sign: true });
+    let box_c = BoxTrait::new(FP16x16 { mag: 1, sign: true });
+
+    // Insert it as a `Span`
+    d.insert(0, nullable_from_box(box_c));
+    d.insert(1, nullable_from_box(box_a));
+    d.insert(2, nullable_from_box(box_b));
+
+    d
+}

--- a/cairo_programs/cairo-1-programs/felt_dict_squash.cairo
+++ b/cairo_programs/cairo-1-programs/felt_dict_squash.cairo
@@ -1,0 +1,18 @@
+use core::nullable::{nullable_from_box, match_nullable, FromNullableResult};
+use core::dict::Felt252DictEntry;
+
+fn main() -> SquashedFelt252Dict<Nullable<Span<felt252>>> {
+    // Create the dictionary
+    let mut d: Felt252Dict<Nullable<Span<felt252>>> = Default::default();
+
+    // Create the array to insert
+    let a = array![8, 9, 10, 11];
+    let b = array![1, 2, 3];
+    let c = array![4, 5, 6];
+
+    // Insert it as a `Span`
+    d.insert(66675, nullable_from_box(BoxTrait::new(a.span())));
+    d.insert(66676, nullable_from_box(BoxTrait::new(b.span())));
+    d.insert(66675, nullable_from_box(BoxTrait::new(c.span())));
+    d.squash()
+}

--- a/cairo_programs/cairo-1-programs/null_ret.cairo
+++ b/cairo_programs/cairo-1-programs/null_ret.cairo
@@ -1,0 +1,3 @@
+fn main() -> Nullable<u32> {
+   null()
+}

--- a/cairo_programs/cairo-1-programs/tensor_new.cairo
+++ b/cairo_programs/cairo-1-programs/tensor_new.cairo
@@ -1,0 +1,65 @@
+// FP16x16
+#[derive(Serde, Copy, Drop)]
+struct FP16x16 {
+    mag: u32,
+    sign: bool
+}
+
+trait FixedTrait<T, MAG> {
+    fn new(mag: MAG, sign: bool) -> T;
+}
+
+impl FP16x16Impl of FixedTrait<FP16x16, u32> {
+    fn new(mag: u32, sign: bool) -> FP16x16 {
+        FP16x16 { mag: mag, sign: sign }
+    }
+}
+
+//Tensor
+#[derive(Copy, Drop)]
+struct Tensor<T> {
+    shape: Span<usize>,
+    data: Span<T>,
+}
+
+trait TensorTrait<T> {
+    fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
+}
+
+impl FP16x16Tensor of TensorTrait<FP16x16> {
+    fn new(shape: Span<usize>, data: Span<FP16x16>) -> Tensor<FP16x16> {
+        new_tensor(shape, data)
+    }
+}
+
+fn new_tensor<T>(shape: Span<usize>, data: Span<T>) -> Tensor<T> {
+    check_shape::<T>(shape, data);
+    Tensor::<T> { shape, data }
+}
+
+fn check_shape<T>(shape: Span<usize>, data: Span<T>) {
+    assert(len_from_shape(shape) == data.len(), 'wrong tensor shape');
+}
+
+fn len_from_shape(mut shape: Span<usize>) -> usize {
+    let mut result: usize = 1;
+
+    loop {
+        match shape.pop_front() {
+            Option::Some(item) => { result *= *item; },
+            Option::None => { break; }
+        };
+    };
+
+    result
+}
+
+fn main() -> Tensor<FP16x16> {
+     TensorTrait::new(
+         array![1, 2].span(),
+         array![
+           FixedTrait::new(1, false), 
+           FixedTrait::new(1, true)
+         ].span()
+    )
+}


### PR DESCRIPTION
Closes #1664 
Uses sierra program data to serialize each return value according to its concrete type.
Removes the public `serialize_output` function in favor of an internal `serialize_output` function used by `cairo_run_program`.
Possible follow up work: See if we can find the names of the enum variants & struct fields in the sierra program data and include them in the serialization.
