### PR TITLE
perf: cache-friendly `MemoryCell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,6 +1369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper_threading"
+version = "0.9.2"
+dependencies = [
+ "cairo-vm",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
 name = "iai-callgrind"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,9 +2046,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -2047,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2633,6 +2642,37 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,15 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,12 +268,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cairo-felt"
@@ -982,12 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,15 +1304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,19 +1321,6 @@ dependencies = [
  "ahash 0.8.6",
  "allocator-api2",
  "serde",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "spin 0.9.8",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1564,13 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.1.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ebb7299e567bbc393b50eef9de8db7728605567b7e5cc31634e34b4c8875ba"
-dependencies = [
- "heapless",
- "rand",
-]
+checksum = "9ee7dcab3968c71896b8ee4dc829147acc918cffe897af6265b1894527fe3add"
 
 [[package]]
 name = "lazy_static"
@@ -1578,7 +1531,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -2450,15 +2403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "sprs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,12 +2412,6 @@ dependencies = [
  "num-complex",
  "num-traits 0.1.43",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-crypto"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ name = "hyper_threading"
 version = "0.9.2"
 dependencies = [
  "cairo-vm",
+ "mimalloc",
  "rayon",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "vm",
     "hint_accountant",
     "examples/wasm-demo",
-    "cairo1-run"
+    "cairo1-run",
+    "examples/hyper_threading"
 ]
 default-members = [
     "cairo-vm-cli",

--- a/examples/hyper_threading/Cargo.toml
+++ b/examples/hyper_threading/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hyper_threading"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+
+
+[dependencies]
+cairo-vm = { workspace = true }
+rayon = "1.9.0"
+tracing = "0.1.40"

--- a/examples/hyper_threading/Cargo.toml
+++ b/examples/hyper_threading/Cargo.toml
@@ -12,3 +12,11 @@ keywords.workspace = true
 cairo-vm = { workspace = true }
 rayon = "1.9.0"
 tracing = "0.1.40"
+mimalloc = { version = "0.1.37", default-features = false, optional = true }
+
+
+
+[features]
+default = ["with_mimalloc"]
+with_mimalloc = ["cairo-vm/with_mimalloc", "mimalloc"]
+lambdaworks-felt = ["cairo-vm/lambdaworks-felt"]

--- a/examples/hyper_threading/hyper-threading.sh
+++ b/examples/hyper_threading/hyper-threading.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 thread_counts=(1 2 4 5 6 7 8 9 10 11 12 13 14 16 32 )
-binary="target/release/hyper_threading"
+binary="../../target/release/hyper_threading"
 
 
 cmd="hyperfine -r 1"

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -1,0 +1,54 @@
+use cairo_vm::{
+    cairo_run::{cairo_run, CairoRunConfig},
+    hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+// Define a macro to prepend a relative path to the file names
+macro_rules! include_bytes_relative {
+    ($fname:expr) => {
+        include_bytes!(concat!("../../../cairo_programs/benchmarks/", $fname))
+    };
+}
+
+fn main() {
+    let programs_bytes: [Vec<u8>; 18] = [
+        include_bytes_relative!("big_factorial.json").to_vec(),
+        include_bytes_relative!("big_fibonacci.json").to_vec(),
+        include_bytes_relative!("blake2s_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("compare_arrays_200000.json").to_vec(),
+        include_bytes_relative!("dict_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("field_arithmetic_get_square_benchmark.json").to_vec(),
+        include_bytes_relative!("integration_builtins.json").to_vec(),
+        include_bytes_relative!("keccak_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("linear_search.json").to_vec(),
+        include_bytes_relative!("math_cmp_and_pow_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("math_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("memory_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("operations_with_data_structures_benchmarks.json").to_vec(),
+        include_bytes_relative!("pedersen.json").to_vec(),
+        include_bytes_relative!("poseidon_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("secp_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("set_integration_benchmark.json").to_vec(),
+        include_bytes_relative!("uint256_integration_benchmark.json").to_vec(),
+    ];
+
+    let start_time = std::time::Instant::now();
+
+    programs_bytes.into_par_iter().for_each(|program| {
+        let cairo_run_config = CairoRunConfig {
+            entrypoint: "main",
+            trace_enabled: false,
+            relocate_mem: false,
+            layout: "all_cairo",
+            proof_mode: true,
+            secure_run: Some(false),
+            ..Default::default()
+        };
+        let mut hint_executor = BuiltinHintProcessor::new_empty();
+
+        let _result = cairo_run(&program, &cairo_run_config, &mut hint_executor)
+            .expect("Couldn't run program");
+    });
+    let _elapsed = start_time.elapsed();
+}

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = { version = "1.4.0", default-features = false, features = [
     "spin_no_std",
 ] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
-lambdaworks-math = { version = "0.1.2", default-features = false, optional = true }
+lambdaworks-math = { version = "0.5.0", default-features = false, optional = true }
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
 proptest = { version = "1.2.0", optional = true }
 

--- a/felt/src/lib_bigint_felt.rs
+++ b/felt/src/lib_bigint_felt.rs
@@ -119,6 +119,18 @@ impl Felt252 {
         value.into()
     }
 
+    pub fn from_raw(mut raw: [u64; 4]) -> Self {
+        raw[0] &= 0xfffffffffffffff;
+        let slice = unsafe { core::slice::from_raw_parts(raw.as_ptr() as *const u8, 32) };
+        Self::from_bytes_be(slice)
+    }
+
+    pub fn raw(&self) -> [u64; 4] {
+        let mut raw = self.to_le_digits();
+        raw.reverse();
+        raw
+    }
+
     #[deprecated]
     pub fn modpow(&self, exponent: &Felt252, modulus: &Felt252) -> Self {
         Self {

--- a/felt/src/lib_bigint_felt.rs
+++ b/felt/src/lib_bigint_felt.rs
@@ -121,8 +121,9 @@ impl Felt252 {
 
     pub fn from_raw(mut raw: [u64; 4]) -> Self {
         raw[0] &= 0xfffffffffffffff;
+        raw.reverse();
         let slice = unsafe { core::slice::from_raw_parts(raw.as_ptr() as *const u8, 32) };
-        Self::from_bytes_be(slice)
+        Self::from_bytes_le(slice)
     }
 
     pub fn raw(&self) -> [u64; 4] {

--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -105,26 +105,36 @@ from_num!(i32, i64);
 // TODO: move to upstream?
 impl From<i64> for Felt252 {
     fn from(value: i64) -> Self {
-        let value = if !value.is_negative() {
-            FieldElement::new(UnsignedInteger::from_u64(value as u64))
+        if !value.is_negative() {
+            Self {
+                value: FieldElement::new(UnsignedInteger::from_u64(value as u64)),
+            }
         } else {
             let abs_minus_one = UnsignedInteger::from_u64(-(value + 1) as u64);
-            FieldElement::zero() - FieldElement::one() - FieldElement::new(abs_minus_one)
-        };
-        Self { value }
+            Self::zero()
+                - Self::one()
+                - Self {
+                    value: FieldElement::new(abs_minus_one),
+                }
+        }
     }
 }
 
 // TODO: move to upstream?
 impl From<i128> for Felt252 {
     fn from(value: i128) -> Self {
-        let value = if !value.is_negative() {
-            FieldElement::new(UnsignedInteger::from_u128(value as u128))
+        if !value.is_negative() {
+            Self {
+                value: FieldElement::new(UnsignedInteger::from_u128(value as u128)),
+            }
         } else {
             let abs_minus_one = UnsignedInteger::from_u128(-(value + 1) as u128);
-            FieldElement::zero() - FieldElement::one() - FieldElement::new(abs_minus_one)
-        };
-        Self { value }
+            Self::zero()
+                - Self::one()
+                - Self {
+                    value: FieldElement::new(abs_minus_one),
+                }
+        }
     }
 }
 
@@ -211,6 +221,17 @@ impl From<Felt252> for BigInt {
 impl Felt252 {
     pub fn new<T: Into<Felt252>>(value: T) -> Self {
         value.into()
+    }
+
+    pub fn from_raw(mut raw: [u64; 4]) -> Self {
+        raw[0] &= 0xfffffffffffffff;
+        Self {
+            value: FieldElement::from_raw(UnsignedInteger::from_limbs(raw)),
+        }
+    }
+
+    pub fn raw(&self) -> [u64; 4] {
+        self.value.to_raw().limbs
     }
 
     pub fn iter_u64_digits(&self) -> impl Iterator<Item = u64> {
@@ -701,37 +722,33 @@ impl<'a> Rem<&'a Felt252> for Felt252 {
 impl Zero for Felt252 {
     fn zero() -> Self {
         Self {
-            value: FieldElement::from_raw(&Stark252PrimeField::ZERO),
+            value: FieldElement::from_raw(Stark252PrimeField::ZERO),
         }
     }
 
     fn is_zero(&self) -> bool {
-        self.value == FieldElement::from_raw(&Stark252PrimeField::ZERO)
+        self.value == FieldElement::from_raw(Stark252PrimeField::ZERO)
     }
 }
 
 impl One for Felt252 {
     fn one() -> Self {
-        let value = FieldElement::from_raw(&Stark252PrimeField::ONE);
+        let value = FieldElement::from_raw(Stark252PrimeField::ONE);
         Self { value }
     }
 
     fn is_one(&self) -> bool {
-        self.value == FieldElement::from_raw(&Stark252PrimeField::ONE)
+        self.value == FieldElement::from_raw(Stark252PrimeField::ONE)
     }
 }
 
 impl Bounded for Felt252 {
     fn min_value() -> Self {
-        Self {
-            value: FieldElement::zero(),
-        }
+        Self::zero()
     }
 
     fn max_value() -> Self {
-        Self {
-            value: FieldElement::zero() - FieldElement::one(),
-        }
+        Self::zero() - Self::one()
     }
 }
 

--- a/felt/src/lib_lambdaworks.rs
+++ b/felt/src/lib_lambdaworks.rs
@@ -120,6 +120,18 @@ impl From<i64> for Felt252 {
     }
 }
 
+impl From<&BigInt> for Felt252 {
+    fn from(value: &BigInt) -> Self {
+        let val = value.mod_floor(&CAIRO_PRIME_BIGUINT.to_bigint().expect("cannot fail"));
+        let mut limbs = [0; 4];
+        for (i, l) in (0..4).rev().zip(val.iter_u64_digits()) {
+            limbs[i] = l;
+        }
+        let value = FieldElement::new(UnsignedInteger::from_limbs(limbs));
+        Self { value }
+    }
+}
+
 // TODO: move to upstream?
 impl From<i128> for Felt252 {
     fn from(value: i128) -> Self {

--- a/hyper-threading.sh
+++ b/hyper-threading.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+thread_counts=(1 2 4 5 6 7 8 9 10 11 12 13 14 16 32 )
+binary="target/release/hyper_threading"
+
+
+cmd="hyperfine -r 1"
+
+# Build the command string with all thread counts
+for threads in "${thread_counts[@]}"; do
+    # For hyperfine, wrap each command in 'sh -c' to correctly handle the environment variable
+    cmd+=" -n \"threads: ${threads}\" 'sh -c \"RAYON_NUM_THREADS=${threads} ${binary}\"'"
+done
+
+# Execute the hyperfine command
+echo "Executing benchmark for all thread counts"
+eval $cmd

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -245,9 +245,9 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
-        assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &mut hint_processor)
-            .is_ok());
+        let res = cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor);
+        dbg!(&res);
+        assert!(res.is_ok());
         assert!(cairo_runner.relocate(&mut vm, true).is_ok());
         // `main` returns without doing nothing, but `not_main` sets `[ap]` to `1`
         // Memory location was found empirically and simply hardcoded

--- a/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -260,7 +260,7 @@ mod tests {
 
         assert_matches!(
             get_integer_from_var_name("value", &vm, &ids_data, &ApTracking::new()),
-            Ok(Cow::Borrowed(x)) if x == &Felt252::new(1)
+            Ok(Cow::Owned(x)) if x == Felt252::new(1)
         );
     }
 

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -421,7 +421,7 @@ impl BuiltinRunner {
         for i in 0..n {
             for j in 0..n_input_cells {
                 let offset = cells_per_instance * i + j;
-                if let None | Some(None) = builtin_segment.get(offset) {
+                if let None | Some(true) = builtin_segment.get(offset).map(|x| x.is_none()) {
                     missing_offsets.push(offset)
                 }
             }
@@ -438,7 +438,7 @@ impl BuiltinRunner {
         for i in 0..n {
             for j in n_input_cells..cells_per_instance {
                 let offset = cells_per_instance * i + j;
-                if let None | Some(None) = builtin_segment.get(offset) {
+                if let None | Some(true) = builtin_segment.get(offset).map(|x| x.is_none()) {
                     vm.verify_auto_deductions_for_addr(
                         Relocatable::from((builtin_segment_index as isize, offset)),
                         self,
@@ -572,6 +572,7 @@ mod tests {
         },
         utils::test_utils::*,
         vm::vm_core::VirtualMachine,
+        vm::vm_memory::memory::MemoryCell,
     };
     use assert_matches::assert_matches;
 
@@ -1352,7 +1353,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.segments.memory.data = vec![vec![None, None, None]];
+        vm.segments.memory.data = vec![vec![MemoryCell::NONE, MemoryCell::NONE, MemoryCell::NONE]];
 
         assert_matches!(builtin.run_security_checks(&vm), Ok(()));
     }

--- a/vm/src/vm/runners/builtin_runner/range_check.rs
+++ b/vm/src/vm/runners/builtin_runner/range_check.rs
@@ -129,8 +129,8 @@ impl RangeCheckBuiltinRunner {
 
         // Split value into n_parts parts of less than _INNER_RC_BOUND size.
         for value in range_check_segment {
+            // FIXME: ensure is_some
             rc_bounds = value
-                .as_ref()?
                 .get_value()
                 .get_int_ref()?
                 .to_le_digits()

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -771,8 +771,8 @@ impl CairoRunner {
         self.relocated_memory.push(None);
         for (index, segment) in vm.segments.memory.data.iter().enumerate() {
             for (seg_offset, cell) in segment.iter().enumerate() {
-                match cell {
-                    Some(cell) => {
+                match cell.is_some() {
+                    true => {
                         let relocated_addr = relocate_address(
                             Relocatable::from((index as isize, seg_offset)),
                             relocation_table,
@@ -783,7 +783,7 @@ impl CairoRunner {
                         }
                         self.relocated_memory[relocated_addr] = Some(value);
                     }
-                    None => self.relocated_memory.push(None),
+                    _ => self.relocated_memory.push(None),
                 }
             }
         }
@@ -3905,11 +3905,11 @@ mod tests {
 
         vm.segments.memory.data = vec![
             vec![
-                Some(MemoryCell::new(Felt252::new(0x8000_8023_8012u64).into())),
-                Some(MemoryCell::new(Felt252::new(0xBFFF_8000_0620u64).into())),
-                Some(MemoryCell::new(Felt252::new(0x8FFF_8000_0750u64).into())),
+                MemoryCell::new(Felt252::new(0x8000_8023_8012u64).into()),
+                MemoryCell::new(Felt252::new(0xBFFF_8000_0620u64).into()),
+                MemoryCell::new(Felt252::new(0x8FFF_8000_0750u64).into()),
             ],
-            vec![Some(MemoryCell::new((0isize, 0usize).into())); 128 * 1024],
+            vec![MemoryCell::new((0isize, 0usize).into()); 128 * 1024],
         ];
 
         cairo_runner
@@ -3932,9 +3932,9 @@ mod tests {
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
+        vm.segments.memory.data = vec![vec![MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
-        )))]];
+        ))]];
         vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(12), 5, true).into()];
 
         assert_matches!(
@@ -3968,9 +3968,9 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners = vec![];
         vm.current_step = 10000;
-        vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
+        vm.segments.memory.data = vec![vec![MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
-        )))]];
+        ))]];
         vm.trace = Some(vec![TraceEntry {
             pc: 0,
             ap: 0,
@@ -3990,9 +3990,9 @@ mod tests {
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(8), 8, true).into()];
-        vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
+        vm.segments.memory.data = vec![vec![MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
-        )))]];
+        ))]];
         vm.trace = Some(vec![TraceEntry {
             pc: 0,
             ap: 0,
@@ -4058,9 +4058,9 @@ mod tests {
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(8), 8, true).into()];
-        vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
+        vm.segments.memory.data = vec![vec![MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
-        )))]];
+        ))]];
         vm.trace = Some(vec![TraceEntry {
             pc: 0,
             ap: 0,
@@ -4555,7 +4555,7 @@ mod tests {
         vm.builtin_runners.push(output_builtin.into());
         vm.segments.memory.data = vec![
             vec![],
-            vec![Some(MemoryCell::new(MaybeRelocatable::from((0, 0))))],
+            vec![MemoryCell::new(MaybeRelocatable::from((0, 0)))],
             vec![],
         ];
         vm.set_ap(1);
@@ -4585,8 +4585,8 @@ mod tests {
         let output_builtin = OutputBuiltinRunner::new(true);
         vm.builtin_runners.push(output_builtin.into());
         vm.segments.memory.data = vec![
-            vec![Some(MemoryCell::new(MaybeRelocatable::from((0, 0))))],
-            vec![Some(MemoryCell::new(MaybeRelocatable::from((0, 1))))],
+            vec![MemoryCell::new(MaybeRelocatable::from((0, 0)))],
+            vec![MemoryCell::new(MaybeRelocatable::from((0, 1)))],
             vec![],
         ];
         vm.set_ap(1);
@@ -4619,10 +4619,10 @@ mod tests {
         vm.builtin_runners.push(bitwise_builtin.into());
         cairo_runner.initialize_segments(&mut vm, None);
         vm.segments.memory.data = vec![
-            vec![Some(MemoryCell::new(MaybeRelocatable::from((0, 0))))],
+            vec![MemoryCell::new(MaybeRelocatable::from((0, 0)))],
             vec![
-                Some(MemoryCell::new(MaybeRelocatable::from((2, 0)))),
-                Some(MemoryCell::new(MaybeRelocatable::from((3, 5)))),
+                MemoryCell::new(MaybeRelocatable::from((2, 0))),
+                MemoryCell::new(MaybeRelocatable::from((3, 5))),
             ],
             vec![],
         ];

--- a/vm/src/vm/security.rs
+++ b/vm/src/vm/security.rs
@@ -65,10 +65,11 @@ pub fn verify_secure_runner(
     // Asumption: If temporary memory is empty, this means no temporary memory addresses were generated and all addresses in memory are real
     if !vm.segments.memory.temp_data.is_empty() {
         for value in vm.segments.memory.data.iter().flatten() {
-            match value.as_ref().map(|x| x.get_value()) {
-                Some(MaybeRelocatable::RelocatableValue(addr)) if addr.segment_index < 0 => {
+            // FIXME: handle is_none
+            match value.get_value() {
+                MaybeRelocatable::RelocatableValue(addr) if addr.segment_index < 0 => {
                     return Err(VirtualMachineError::InvalidMemoryValueTemporaryAddress(
-                        Box::new(*addr),
+                        Box::new(addr),
                     ))
                 }
                 _ => {}

--- a/vm/src/vm/security.rs
+++ b/vm/src/vm/security.rs
@@ -66,6 +66,9 @@ pub fn verify_secure_runner(
     if !vm.segments.memory.temp_data.is_empty() {
         for value in vm.segments.memory.data.iter().flatten() {
             // FIXME: handle is_none
+            if value.is_none() {
+                continue;
+            }
             match value.get_value() {
                 MaybeRelocatable::RelocatableValue(addr) if addr.segment_index < 0 => {
                     return Err(VirtualMachineError::InvalidMemoryValueTemporaryAddress(

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -623,12 +623,11 @@ impl VirtualMachine {
                     )
                     .map_err(VirtualMachineError::RunnerError)?
                 {
-                    let value = value.as_ref().map(|x| x.get_value());
-                    if Some(&deduced_memory_cell) != value && value.is_some() {
+                    if value.is_some() && deduced_memory_cell != value.get_value() {
                         return Err(VirtualMachineError::InconsistentAutoDeduction(Box::new((
                             builtin.name(),
                             deduced_memory_cell,
-                            value.cloned(),
+                            Some(value.get_value()),
                         ))));
                     }
                 }
@@ -2925,8 +2924,8 @@ mod tests {
         //Check that the following addresses have been accessed:
         // Addresses have been copied from python execution:
         let mem = vm.segments.memory.data;
-        assert!(mem[1][0].as_ref().unwrap().is_accessed());
-        assert!(mem[1][1].as_ref().unwrap().is_accessed());
+        assert!(mem[1][0].is_accessed());
+        assert!(mem[1][1].is_accessed());
     }
 
     #[test]
@@ -3015,15 +3014,15 @@ mod tests {
         //Check that the following addresses have been accessed:
         // Addresses have been copied from python execution:
         let mem = &vm.segments.memory.data;
-        assert!(mem[0][1].as_ref().unwrap().is_accessed());
-        assert!(mem[0][4].as_ref().unwrap().is_accessed());
-        assert!(mem[0][6].as_ref().unwrap().is_accessed());
-        assert!(mem[1][0].as_ref().unwrap().is_accessed());
-        assert!(mem[1][1].as_ref().unwrap().is_accessed());
-        assert!(mem[1][2].as_ref().unwrap().is_accessed());
-        assert!(mem[1][3].as_ref().unwrap().is_accessed());
-        assert!(mem[1][4].as_ref().unwrap().is_accessed());
-        assert!(mem[1][5].as_ref().unwrap().is_accessed());
+        assert!(mem[0][1].is_accessed());
+        assert!(mem[0][4].is_accessed());
+        assert!(mem[0][6].is_accessed());
+        assert!(mem[1][0].is_accessed());
+        assert!(mem[1][1].is_accessed());
+        assert!(mem[1][2].is_accessed());
+        assert!(mem[1][3].is_accessed());
+        assert!(mem[1][4].is_accessed());
+        assert!(mem[1][5].is_accessed());
         assert_eq!(
             vm.segments
                 .memory
@@ -4122,11 +4121,11 @@ mod tests {
         //Check that the following addresses have been accessed:
         // Addresses have been copied from python execution:
         let mem = &vm.segments.memory.data;
-        assert!(mem[0][0].as_ref().unwrap().is_accessed());
-        assert!(mem[0][1].as_ref().unwrap().is_accessed());
-        assert!(mem[0][2].as_ref().unwrap().is_accessed());
-        assert!(mem[0][10].as_ref().unwrap().is_accessed());
-        assert!(mem[1][1].as_ref().unwrap().is_accessed());
+        assert!(mem[0][0].is_accessed());
+        assert!(mem[0][1].is_accessed());
+        assert!(mem[0][2].is_accessed());
+        assert!(mem[0][10].is_accessed());
+        assert!(mem[1][1].is_accessed());
         assert_eq!(
             vm.segments
                 .memory

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -262,8 +262,12 @@ impl Memory {
                 let value = cell.get_value();
                 match value {
                     MaybeRelocatable::RelocatableValue(addr) if addr.segment_index < 0 => {
-                        *cell =
+                        let mut new_cell =
                             MemoryCell::new(Memory::relocate_address(addr, &self.relocation_rules));
+                        if cell.is_accessed() {
+                            new_cell.mark_accessed();
+                        }
+                        *cell = new_cell;
                     }
                     _ => {}
                 }

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -64,7 +64,7 @@ impl From<MaybeRelocatable> for MemoryCell {
             MaybeRelocatable::RelocatableValue(x) => Self([
                 Self::RELOCATABLE_MASK,
                 0,
-                u64::from_le_bytes(x.segment_index.to_le_bytes()),
+                u64::from_ne_bytes(x.segment_index.to_ne_bytes()),
                 x.offset as u64,
             ]),
         }
@@ -77,7 +77,7 @@ impl From<MemoryCell> for MaybeRelocatable {
         let flags = cell.0[0];
         match flags & MemoryCell::RELOCATABLE_MASK {
             MemoryCell::RELOCATABLE_MASK => Self::from((
-                isize::from_le_bytes(cell.0[2].to_le_bytes()),
+                isize::from_ne_bytes(cell.0[2].to_ne_bytes()),
                 cell.0[3] as usize,
             )),
             _ => Self::Int(Felt252::from_raw(cell.0)),

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -17,6 +17,7 @@ pub struct ValidationRule(
 );
 
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Debug)]
+#[repr(align(32))]
 pub(crate) struct MemoryCell([u64; 4]);
 
 impl MemoryCell {

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -222,9 +222,12 @@ impl Memory {
             &self.data
         };
         let (i, j) = from_relocatable_to_indexes(relocatable);
+        let cell = data.get(i)?.get(j)?;
+        if cell.is_none() {
+            return None;
+        }
         Some(Cow::Owned(
-            self.relocate_value(&data.get(i)?.get(j)?.get_value())
-                .into_owned(),
+            self.relocate_value(&cell.get_value()).into_owned(),
         ))
     }
 

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -89,7 +89,6 @@ pub struct AddressSet(Vec<bv::BitVec>);
 
 impl AddressSet {
     pub(crate) fn new() -> Self {
-        println!("{}", core::mem::size_of::<MemoryCell>());
         Self(Vec::new())
     }
 

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -63,8 +63,8 @@ impl From<MaybeRelocatable> for MemoryCell {
             MaybeRelocatable::Int(x) => Self(x.raw()),
             MaybeRelocatable::RelocatableValue(x) => Self([
                 Self::RELOCATABLE_MASK,
-                x.segment_index.is_negative() as u64,
-                x.segment_index.unsigned_abs() as u64,
+                0,
+                u64::from_le_bytes(x.segment_index.to_le_bytes()),
                 x.offset as u64,
             ]),
         }
@@ -77,7 +77,7 @@ impl From<MemoryCell> for MaybeRelocatable {
         let flags = cell.0[0];
         match flags & MemoryCell::RELOCATABLE_MASK {
             MemoryCell::RELOCATABLE_MASK => Self::from((
-                (1isize - 2 * cell.0[1] as isize) * cell.0[2] as isize,
+                isize::from_le_bytes(cell.0[2].to_le_bytes()),
                 cell.0[3] as usize,
             )),
             _ => Self::Int(Felt252::from_raw(cell.0)),

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -516,9 +516,9 @@ mod tests {
         assert_eq!(
             segments.memory.data[1],
             vec![
-                Some(MemoryCell::new(mayberelocatable!(11))),
-                Some(MemoryCell::new(mayberelocatable!(12))),
-                Some(MemoryCell::new(mayberelocatable!(1))),
+                MemoryCell::new(mayberelocatable!(11)),
+                MemoryCell::new(mayberelocatable!(12)),
+                MemoryCell::new(mayberelocatable!(1)),
             ]
         );
     }
@@ -543,9 +543,9 @@ mod tests {
         assert_eq!(
             segments.memory.data[1],
             vec![
-                Some(MemoryCell::new(MaybeRelocatable::from((0, 1)))),
-                Some(MemoryCell::new(MaybeRelocatable::from((0, 2)))),
-                Some(MemoryCell::new(MaybeRelocatable::from((0, 3)))),
+                MemoryCell::new(MaybeRelocatable::from((0, 1))),
+                MemoryCell::new(MaybeRelocatable::from((0, 2))),
+                MemoryCell::new(MaybeRelocatable::from((0, 3))),
             ]
         );
     }


### PR DESCRIPTION
Refactors `MemoryCell` to store a simple `[u64; 4]` to use the cache more appropriately.
This structure is now a fixed 32 bytes with 32 bytes alignment, meaning any given cell
in the VM memory will never be split across two different cache lines, and eviction will
be minimized in virtue of being the optimal size for a `Felt` of 252 bits.

The cost of this change is no longer being able to extract the `MemoryCell` value as a
simple reference, but requiring a conversion for the "normal" `MaybeRelocatable`, that
is, it implies extra computation and extra copying to extract values. This behaves well
for Lambdaworks where the data is inline in the array, but quite a hit for the `BigUint`
implementation, which now allocates and frees memory much more often.
Upgrading is recommended only when using Lambdaworks. The tradeoff is deemed acceptable
since only the Lambdaworks (actually `types-rs`) implementation is preserved for the
1.x branch.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

