### PR TITLE
Complete test suite of `BuiltinRunner` `get_memory_segment_addresses`

### DIFF
--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -1189,6 +1189,18 @@ mod tests {
             range_check_builtin.get_memory_segment_addresses(),
             (0, None),
         );
+        let keccak_builtin: BuiltinRunner = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
+            &KeccakInstanceDef::default(),
+            true,
+        ));
+        assert_eq!(keccak_builtin.get_memory_segment_addresses(), (0, None),);
+        let signature_builtin: BuiltinRunner = BuiltinRunner::Signature(
+            SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(Some(10)), true),
+        );
+        assert_eq!(signature_builtin.get_memory_segment_addresses(), (0, None),);
+        let poseidon_builtin: BuiltinRunner =
+            BuiltinRunner::Poseidon(PoseidonBuiltinRunner::new(Some(32), true));
+        assert_eq!(poseidon_builtin.get_memory_segment_addresses(), (0, None),);
     }
 
     #[test]


### PR DESCRIPTION
# Complete test suite of `BuiltinRunner` `get_memory_segment_addresses`

## Description

A few test assertions are added to the test suite related to `get_memory_segment_addresses` for `BuiltinRunner` implementation in order to complete the test coverage with all the implemented builtins.

## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

