### PR TITLE
Use `Program::from_file` in hyperthreading crate

### DIFF
--- a/examples/hyper_threading/Cargo.toml
+++ b/examples/hyper_threading/Cargo.toml
@@ -9,6 +9,6 @@ keywords.workspace = true
 
 
 [dependencies]
-cairo-vm = { workspace = true }
+cairo-vm = { workspace = true, features = ["std"] }
 rayon = "1.9.0"
 tracing = "0.1.40"

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 // Define build_filename macro to prepend a relative path to the file names
 macro_rules! build_filename {
     ($fname:expr) => {
-        format!("../../../cairo_programs/benchmarks/{}", $fname)
+        format!("cairo_programs/benchmarks/{}", $fname)
     };
 }
 

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -5,39 +5,39 @@ use cairo_vm::{
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-// Define include_bytes_relative macro to prepend a relative path to the file names
+// Define build_path macro to prepend a relative path to the file names
 macro_rules! include_bytes_relative {
     ($fname:expr) => {
-        include_bytes!(concat!("../../../cairo_programs/benchmarks/", $fname))
+        build_path!(Path::new(format!("../../../cairo_programs/benchmarks/{}", $fname)))
     };
 }
 
 fn main() {
     let mut programs = Vec::new();
 
-    let programs_bytes: [Vec<u8>; 18] = [
-        include_bytes_relative!("big_factorial.json").to_vec(),
-        include_bytes_relative!("big_fibonacci.json").to_vec(),
-        include_bytes_relative!("blake2s_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("compare_arrays_200000.json").to_vec(),
-        include_bytes_relative!("dict_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("field_arithmetic_get_square_benchmark.json").to_vec(),
-        include_bytes_relative!("integration_builtins.json").to_vec(),
-        include_bytes_relative!("keccak_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("linear_search.json").to_vec(),
-        include_bytes_relative!("math_cmp_and_pow_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("math_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("memory_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("operations_with_data_structures_benchmarks.json").to_vec(),
-        include_bytes_relative!("pedersen.json").to_vec(),
-        include_bytes_relative!("poseidon_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("secp_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("set_integration_benchmark.json").to_vec(),
-        include_bytes_relative!("uint256_integration_benchmark.json").to_vec(),
+    let program_paths: [Path; 18] = [
+        build_path!("big_factorial.json").to_vec(),
+        build_path!("big_fibonacci.json").to_vec(),
+        build_path!("blake2s_integration_benchmark.json").to_vec(),
+        build_path!("compare_arrays_200000.json").to_vec(),
+        build_path!("dict_integration_benchmark.json").to_vec(),
+        build_path!("field_arithmetic_get_square_benchmark.json").to_vec(),
+        build_path!("integration_builtins.json").to_vec(),
+        build_path!("keccak_integration_benchmark.json").to_vec(),
+        build_path!("linear_search.json").to_vec(),
+        build_path!("math_cmp_and_pow_integration_benchmark.json").to_vec(),
+        build_path!("math_integration_benchmark.json").to_vec(),
+        build_path!("memory_integration_benchmark.json").to_vec(),
+        build_path!("operations_with_data_structures_benchmarks.json").to_vec(),
+        build_path!("pedersen.json").to_vec(),
+        build_path!("poseidon_integration_benchmark.json").to_vec(),
+        build_path!("secp_integration_benchmark.json").to_vec(),
+        build_path!("set_integration_benchmark.json").to_vec(),
+        build_path!("uint256_integration_benchmark.json").to_vec(),
     ];
 
-    for bytes in &programs_bytes {
-        programs.push(Program::from_bytes(bytes.as_slice(), Some("main")).unwrap())
+    for path in &programs_paths {
+        programs.push(Program::from_file(path, Some("main")).unwrap())
     }
 
     let start_time = std::time::Instant::now();

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -4,40 +4,43 @@ use cairo_vm::{
     types::program::Program,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::path::Path;
 
-// Define build_path macro to prepend a relative path to the file names
-macro_rules! include_bytes_relative {
+// Define build_filename macro to prepend a relative path to the file names
+macro_rules! build_filename {
     ($fname:expr) => {
-        build_path!(Path::new(format!("../../../cairo_programs/benchmarks/{}", $fname)))
+        format!("../../../cairo_programs/benchmarks/{}", $fname)
     };
 }
 
 fn main() {
     let mut programs = Vec::new();
 
-    let program_paths: [Path; 18] = [
-        build_path!("big_factorial.json").to_vec(),
-        build_path!("big_fibonacci.json").to_vec(),
-        build_path!("blake2s_integration_benchmark.json").to_vec(),
-        build_path!("compare_arrays_200000.json").to_vec(),
-        build_path!("dict_integration_benchmark.json").to_vec(),
-        build_path!("field_arithmetic_get_square_benchmark.json").to_vec(),
-        build_path!("integration_builtins.json").to_vec(),
-        build_path!("keccak_integration_benchmark.json").to_vec(),
-        build_path!("linear_search.json").to_vec(),
-        build_path!("math_cmp_and_pow_integration_benchmark.json").to_vec(),
-        build_path!("math_integration_benchmark.json").to_vec(),
-        build_path!("memory_integration_benchmark.json").to_vec(),
-        build_path!("operations_with_data_structures_benchmarks.json").to_vec(),
-        build_path!("pedersen.json").to_vec(),
-        build_path!("poseidon_integration_benchmark.json").to_vec(),
-        build_path!("secp_integration_benchmark.json").to_vec(),
-        build_path!("set_integration_benchmark.json").to_vec(),
-        build_path!("uint256_integration_benchmark.json").to_vec(),
+    let program_filenames: [String; 18] = [
+        build_filename!("big_factorial.json"),
+        build_filename!("big_fibonacci.json"),
+        build_filename!("blake2s_integration_benchmark.json"),
+        build_filename!("compare_arrays_200000.json"),
+        build_filename!("dict_integration_benchmark.json"),
+        build_filename!("field_arithmetic_get_square_benchmark.json"),
+        build_filename!("integration_builtins.json"),
+        build_filename!("keccak_integration_benchmark.json"),
+        build_filename!("linear_search.json"),
+        build_filename!("math_cmp_and_pow_integration_benchmark.json"),
+        build_filename!("math_integration_benchmark.json"),
+        build_filename!("memory_integration_benchmark.json"),
+        build_filename!("operations_with_data_structures_benchmarks.json"),
+        build_filename!("pedersen.json"),
+        build_filename!("poseidon_integration_benchmark.json"),
+        build_filename!("secp_integration_benchmark.json"),
+        build_filename!("set_integration_benchmark.json"),
+        build_filename!("uint256_integration_benchmark.json"),
     ];
 
-    for path in &programs_paths {
-        programs.push(Program::from_file(path, Some("main")).unwrap())
+    let n_programs = &program_filenames.len();
+
+    for filename in program_filenames{
+        programs.push(Program::from_file(Path::new(&filename), Some("main")).unwrap())
     }
 
     let start_time = std::time::Instant::now();
@@ -61,7 +64,5 @@ fn main() {
     });
     let elapsed = start_time.elapsed();
 
-    let programs_len: &usize = &programs_bytes.clone().len();
-
-    tracing::info!(%programs_len, ?elapsed, "Finished");
+    tracing::info!(%n_programs, ?elapsed, "Finished");
 }

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
 
     let n_programs = &program_filenames.len();
 
-    for filename in program_filenames{
+    for filename in program_filenames {
         programs.push(Program::from_file(Path::new(&filename), Some("main")).unwrap())
     }
 


### PR DESCRIPTION
The fresh run daily workflow is currently failing as compiling the hyperthreading crate requires bench files to be compiled due to the usage of `include_bytes` macro. As the hyperthreading crate doesn't need to be no-std, we can just read the programs from their paths.
Closes #1684 & Closes #1683 
