### PR TITLE
Feature: add a method to retrieve the output builtin from the VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * BREAKING: Remove `CairoRunner::add_additional_hash_builtin` & `VirtualMachine::disable_trace`[#1658](https://github.com/lambdaclass/cairo-vm/pull/1658)
 
 * feat: output builtin add_attribute method [#1691](https://github.com/lambdaclass/cairo-vm/pull/1691)
+ 
+* feat: add a method to retrieve the output builtin from the VM [#1690](https://github.com/lambdaclass/cairo-vm/pull/1690)
 
 * feat: Add zero segment [#1668](https://github.com/lambdaclass/cairo-vm/pull/1668)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "clap",
  "itertools 0.11.0",
  "mimalloc",
+ "num-traits 0.2.18",
  "rstest",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,6 @@ dependencies = [
  "clap",
  "itertools 0.11.0",
  "mimalloc",
- "num-traits 0.2.18",
  "rstest",
  "thiserror",
 ]

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -81,6 +81,8 @@ pub enum VirtualMachineError {
     InconsistentAutoDeduction(Box<(&'static str, MaybeRelocatable, Option<MaybeRelocatable>)>),
     #[error("Invalid hint encoding at pc: {0}")]
     InvalidHintEncoding(Box<MaybeRelocatable>),
+    #[error("Expected output builtin to be present")]
+    NoOutputBuiltin,
     #[error("Expected range_check builtin to be present")]
     NoRangeCheckBuiltin,
     #[error("Expected ecdsa builtin to be present")]

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -943,7 +943,9 @@ impl VirtualMachine {
         Err(VirtualMachineError::NoSignatureBuiltin)
     }
 
-    pub fn get_output_builtin_mut(&mut self) -> Result<&mut OutputBuiltinRunner, VirtualMachineError> {
+    pub fn get_output_builtin_mut(
+        &mut self,
+    ) -> Result<&mut OutputBuiltinRunner, VirtualMachineError> {
         for builtin in self.get_builtin_runners_as_mut() {
             if let BuiltinRunner::Output(output_builtin) = builtin {
                 return Ok(output_builtin);

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -32,7 +32,7 @@ use core::num::NonZeroUsize;
 use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
-use super::runners::builtin_runner::OUTPUT_BUILTIN_NAME;
+use super::runners::builtin_runner::{OutputBuiltinRunner, OUTPUT_BUILTIN_NAME};
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 
@@ -941,6 +941,16 @@ impl VirtualMachine {
         }
 
         Err(VirtualMachineError::NoSignatureBuiltin)
+    }
+
+    pub fn get_output_builtin(&mut self) -> Result<&mut OutputBuiltinRunner, VirtualMachineError> {
+        for builtin in self.get_builtin_runners_as_mut() {
+            if let BuiltinRunner::Output(output_builtin) = builtin {
+                return Ok(output_builtin);
+            };
+        }
+
+        Err(VirtualMachineError::NoOutputBuiltin)
     }
 
     #[cfg(feature = "with_tracer")]
@@ -3837,6 +3847,30 @@ mod tests {
 
         assert_eq!(builtins[0].name(), HASH_BUILTIN_NAME);
         assert_eq!(builtins[1].name(), BITWISE_BUILTIN_NAME);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_get_output_builtin() {
+        let mut vm = vm!();
+
+        assert_matches!(
+            vm.get_output_builtin(),
+            Err(VirtualMachineError::NoOutputBuiltin)
+        );
+
+        let output_builtin = OutputBuiltinRunner::new(true);
+        vm.builtin_runners.push(output_builtin.clone().into());
+
+        let vm_output_builtin = vm
+            .get_output_builtin()
+            .expect("Output builtin should be returned");
+
+        assert_eq!(vm_output_builtin.base(), output_builtin.base());
+        assert_eq!(vm_output_builtin.pages, output_builtin.pages);
+        assert_eq!(vm_output_builtin.attributes, output_builtin.attributes);
+        assert_eq!(vm_output_builtin.stop_ptr, output_builtin.stop_ptr);
+        assert_eq!(vm_output_builtin.included, output_builtin.included);
     }
 
     #[test]

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -943,7 +943,7 @@ impl VirtualMachine {
         Err(VirtualMachineError::NoSignatureBuiltin)
     }
 
-    pub fn get_output_builtin(&mut self) -> Result<&mut OutputBuiltinRunner, VirtualMachineError> {
+    pub fn get_output_builtin_mut(&mut self) -> Result<&mut OutputBuiltinRunner, VirtualMachineError> {
         for builtin in self.get_builtin_runners_as_mut() {
             if let BuiltinRunner::Output(output_builtin) = builtin {
                 return Ok(output_builtin);
@@ -3851,11 +3851,11 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn test_get_output_builtin() {
+    fn test_get_output_builtin_mut() {
         let mut vm = vm!();
 
         assert_matches!(
-            vm.get_output_builtin(),
+            vm.get_output_builtin_mut(),
             Err(VirtualMachineError::NoOutputBuiltin)
         );
 
@@ -3863,7 +3863,7 @@ mod tests {
         vm.builtin_runners.push(output_builtin.clone().into());
 
         let vm_output_builtin = vm
-            .get_output_builtin()
+            .get_output_builtin_mut()
             .expect("Output builtin should be returned");
 
         assert_eq!(vm_output_builtin.base(), output_builtin.base());


### PR DESCRIPTION
Problem: the output builtin often needs to be manipulated directly in the Starknet bootloader and OS hints.

Solution: add a `get_output_builtin() method on the `VirtualMachine` struct to retrieve a reference to the output builtin easily.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

