### PR TITLE
Feature: output builtin `add_attribute` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: output builtin add_attribute method [#1691](https://github.com/lambdaclass/cairo-vm/pull/1691)
+
 * feat: Add zero segment [#1668](https://github.com/lambdaclass/cairo-vm/pull/1668)
 
 * feat: Bump cairo_lang to 0.13.1 in testing env [#1687](https://github.com/lambdaclass/cairo-vm/pull/1687)

--- a/vm/src/vm/runners/builtin_runner/output.rs
+++ b/vm/src/vm/runners/builtin_runner/output.rs
@@ -129,6 +129,10 @@ impl OutputBuiltinRunner {
         }
     }
 
+    pub fn add_attribute(&mut self, name: String, value: Vec<usize>) {
+        self.attributes.insert(name, value);
+    }
+
     pub fn get_additional_data(&self) -> BuiltinAdditionalData {
         BuiltinAdditionalData::Output(OutputBuiltinAdditionalData {
             pages: self.pages.clone(),
@@ -609,6 +613,18 @@ mod tests {
         assert!(
             matches!(result, Err(RunnerError::PageNotOnSegment(relocatable, base)) if relocatable == page_start && base == builtin.base())
         )
+    }
+
+    #[test]
+    pub fn add_attribute() {
+        let mut builtin = OutputBuiltinRunner::new(true);
+        assert!(builtin.attributes.is_empty());
+
+        let name = "gps_fact_topology".to_string();
+        let values = vec![0, 12, 30];
+        builtin.add_attribute(name.clone(), values.clone());
+
+        assert_eq!(builtin.attributes, HashMap::from([(name, values)]));
     }
 
     #[test]


### PR DESCRIPTION
Problem: some OS hints need to add attributes to the output builtin. The Python implementation defines an `add_attribute` method that is not present in `cairo-vm`.

Solution: port the `add_attribute` method.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

