### PR TITLE
Add range_check96 builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 #### Upcoming Changes
 
+* feat(BREAKING): Add range_check96 builtin[#1698](https://github.com/lambdaclass/cairo-vm/pull/1698)
+  * Add the new `range_check96` builtin to the `all_cairo` layout.
+  * `RangeCheckBuiltinRunner` changes:
+    * Method `new` is now private, `new_standard` & `new_96` were added to replace its functionality, these methods no longer allow the caller to set a value for `n_parts` and instead rely on constants based on the range_check variant.
+    * Remove field `_bound`, replacing it with public method `bound`.
+    * Add public methods `name` & `n_parts`.
+
 * BREAKING: Remove `CairoRunner::add_additional_hash_builtin` & `VirtualMachine::disable_trace`[#1658](https://github.com/lambdaclass/cairo-vm/pull/1658)
 
 * feat: output builtin add_attribute method [#1691](https://github.com/lambdaclass/cairo-vm/pull/1691)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * feat(BREAKING): Add range_check96 builtin[#1698](https://github.com/lambdaclass/cairo-vm/pull/1698)
   * Add the new `range_check96` builtin to the `all_cairo` layout.
   * `RangeCheckBuiltinRunner` changes:
-    * Method `new` is now private, `new_standard` & `new_96` were added to replace its functionality, these methods no longer allow the caller to set a value for `n_parts` and instead rely on constants based on the range_check variant.
+    * Remove field `n_parts`, replacing it with const generic `N_PARTS`.
+    * Remome `n_parts` argument form method `new`.
     * Remove field `_bound`, replacing it with public method `bound`.
     * Add public methods `name` & `n_parts`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "clap",
  "itertools 0.11.0",
  "mimalloc",
+ "num-traits 0.2.18",
  "rstest",
  "thiserror",
 ]

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -496,7 +496,10 @@ fn create_entry_code(
                 BuiltinName::ec_op => EcOpType::ID,
                 BuiltinName::poseidon => PoseidonType::ID,
                 BuiltinName::segment_arena => SegmentArenaType::ID,
-                BuiltinName::keccak | BuiltinName::ecdsa | BuiltinName::output => return fp_loc,
+                BuiltinName::keccak
+                | BuiltinName::ecdsa
+                | BuiltinName::output
+                | BuiltinName::range_check96 => return fp_loc,
             };
             signature
                 .ret_types

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -169,8 +169,7 @@ pub fn assert_le_felt_v_0_8(
         return Err(HintError::NonLeFelt252(Box::new((*a, *b))));
     }
     let bound = vm.get_range_check_builtin()?.bound();
-    let small_inputs =
-        Felt252::from((a < bound && b - a < *bound) as u8);
+    let small_inputs = Felt252::from((a < bound && b - a < *bound) as u8);
     insert_value_from_var_name("small_inputs", small_inputs, vm, ids_data, ap_tracking)
 }
 
@@ -365,9 +364,7 @@ pub fn is_positive(
     let (sign, abs_value) = value_as_int.into_parts();
     //Main logic (assert a is positive)
     if abs_value >= range_check_builtin.bound().to_biguint() {
-        return Err(HintError::ValueOutsideValidRange(Box::new(
-            value,
-        )));
+        return Err(HintError::ValueOutsideValidRange(Box::new(value)));
     }
 
     let result = Felt252::from((sign == Sign::Plus) as u8);
@@ -506,10 +503,7 @@ pub fn unsigned_div_rem(
 
     // Main logic
     if div.is_zero() || div.as_ref() > &div_prime_by_bound(*builtin_bound)? {
-        return Err(HintError::OutOfValidRange(Box::new((
-            div,
-            *builtin_bound,
-        ))));
+        return Err(HintError::OutOfValidRange(Box::new((div, *builtin_bound))));
     }
 
     let (q, r) = value.div_rem(&(div).try_into().map_err(|_| MathError::DividedByZero)?);

--- a/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -176,7 +176,7 @@ pub fn assert_le_felt_v_0_8(
     }
     let bound = vm.get_range_check_builtin()?.bound();
     let small_inputs =
-        Felt252::from((a.as_ref() < &bound && b.as_ref() - a.as_ref() < *bound) as u8);
+        Felt252::from((a.as_ref() < bound && b.as_ref() - a.as_ref() < *bound) as u8);
     insert_value_from_var_name("small_inputs", small_inputs, vm, ids_data, ap_tracking)
 }
 

--- a/vm/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -247,8 +247,7 @@ pub fn squash_dict(
     let ptr_diff = get_integer_from_var_name("ptr_diff", vm, ids_data, ap_tracking)?;
     let n_accesses = get_integer_from_var_name("n_accesses", vm, ids_data, ap_tracking)?;
     //Get range_check_builtin
-    let range_check_builtin = vm.get_range_check_builtin()?;
-    let range_check_bound = range_check_builtin._bound;
+    let range_check_bound = *vm.get_range_check_builtin()?.bound();
     //Main Logic
     let ptr_diff = ptr_diff
         .to_usize()
@@ -285,7 +284,7 @@ pub fn squash_dict(
     keys.sort();
     keys.reverse();
     //Are the keys used bigger than the range_check bound.
-    let big_keys = if keys[0] >= range_check_bound.unwrap() {
+    let big_keys = if keys[0] >= range_check_bound {
         Felt252::ONE
     } else {
         Felt252::ZERO

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -13,7 +13,7 @@ use crate::{
         prelude::*,
         sync::Arc,
     },
-    utils::CAIRO_PRIME,
+    utils::CAIRO_PRIME, vm::runners::builtin_runner::RANGE_CHECK_96_BUILTIN_NAME,
 };
 
 use crate::utils::PRIME_STR;
@@ -55,6 +55,7 @@ pub enum BuiltinName {
     ec_op,
     poseidon,
     segment_arena,
+    range_check96,
 }
 
 impl BuiltinName {
@@ -69,6 +70,7 @@ impl BuiltinName {
             BuiltinName::ec_op => EC_OP_BUILTIN_NAME,
             BuiltinName::poseidon => POSEIDON_BUILTIN_NAME,
             BuiltinName::segment_arena => SEGMENT_ARENA_BUILTIN_NAME,
+            BuiltinName::range_check96 => RANGE_CHECK_96_BUILTIN_NAME,
         }
     }
 }

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -13,7 +13,8 @@ use crate::{
         prelude::*,
         sync::Arc,
     },
-    utils::CAIRO_PRIME, vm::runners::builtin_runner::RANGE_CHECK_96_BUILTIN_NAME,
+    utils::CAIRO_PRIME,
+    vm::runners::builtin_runner::RANGE_CHECK_96_BUILTIN_NAME,
 };
 
 use crate::utils::PRIME_STR;

--- a/vm/src/types/instance_definitions/builtins_instance_def.rs
+++ b/vm/src/types/instance_definitions/builtins_instance_def.rs
@@ -16,6 +16,7 @@ pub(crate) struct BuiltinsInstanceDef {
     pub(crate) ec_op: Option<EcOpInstanceDef>,
     pub(crate) keccak: Option<KeccakInstanceDef>,
     pub(crate) poseidon: Option<PoseidonInstanceDef>,
+    pub(crate) range_check96: Option<RangeCheckInstanceDef>,
 }
 
 impl BuiltinsInstanceDef {
@@ -29,6 +30,7 @@ impl BuiltinsInstanceDef {
             ec_op: None,
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 
@@ -42,6 +44,7 @@ impl BuiltinsInstanceDef {
             ec_op: None,
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 
@@ -55,6 +58,7 @@ impl BuiltinsInstanceDef {
             ec_op: None,
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 
@@ -68,6 +72,7 @@ impl BuiltinsInstanceDef {
             ec_op: None,
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 
@@ -81,6 +86,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
             keccak: None,
             poseidon: Some(PoseidonInstanceDef::default()),
+            range_check96: None,
         }
     }
 
@@ -94,6 +100,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
             keccak: Some(KeccakInstanceDef::new(Some(2048), vec![200; 8])),
             poseidon: Some(PoseidonInstanceDef::default()),
+            range_check96: None,
         }
     }
 
@@ -107,6 +114,7 @@ impl BuiltinsInstanceDef {
             ec_op: None,
             keccak: None,
             poseidon: Some(PoseidonInstanceDef::new(Some(8))),
+            range_check96: None,
         }
     }
 
@@ -120,6 +128,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
             keccak: Some(KeccakInstanceDef::new(Some(2048), vec![200; 8])),
             poseidon: Some(PoseidonInstanceDef::new(Some(256))),
+            range_check96: Some(RangeCheckInstanceDef::new(Some(8), 6)),
         }
     }
 
@@ -133,6 +142,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::default()),
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 
@@ -146,6 +156,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::new(None)),
             keccak: None,
             poseidon: None,
+            range_check96: None,
         }
     }
 }

--- a/vm/src/types/instance_definitions/builtins_instance_def.rs
+++ b/vm/src/types/instance_definitions/builtins_instance_def.rs
@@ -80,7 +80,7 @@ impl BuiltinsInstanceDef {
         BuiltinsInstanceDef {
             output: true,
             pedersen: Some(PedersenInstanceDef::new(Some(32), 1)),
-            range_check: Some(RangeCheckInstanceDef::new(Some(16), 8)),
+            range_check: Some(RangeCheckInstanceDef::new(Some(16))),
             ecdsa: Some(EcdsaInstanceDef::new(Some(2048))),
             bitwise: Some(BitwiseInstanceDef::new(Some(64))),
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
@@ -94,7 +94,7 @@ impl BuiltinsInstanceDef {
         BuiltinsInstanceDef {
             output: true,
             pedersen: Some(PedersenInstanceDef::new(Some(32), 1)),
-            range_check: Some(RangeCheckInstanceDef::new(Some(16), 8)),
+            range_check: Some(RangeCheckInstanceDef::new(Some(16))),
             ecdsa: Some(EcdsaInstanceDef::new(Some(2048))),
             bitwise: Some(BitwiseInstanceDef::new(Some(64))),
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
@@ -128,7 +128,7 @@ impl BuiltinsInstanceDef {
             ec_op: Some(EcOpInstanceDef::new(Some(1024))),
             keccak: Some(KeccakInstanceDef::new(Some(2048), vec![200; 8])),
             poseidon: Some(PoseidonInstanceDef::new(Some(256))),
-            range_check96: Some(RangeCheckInstanceDef::new(Some(8), 6)),
+            range_check96: Some(RangeCheckInstanceDef::new(Some(8))),
         }
     }
 
@@ -150,7 +150,7 @@ impl BuiltinsInstanceDef {
         BuiltinsInstanceDef {
             output: true,
             pedersen: Some(PedersenInstanceDef::new(None, 4)),
-            range_check: Some(RangeCheckInstanceDef::new(None, 8)),
+            range_check: Some(RangeCheckInstanceDef::new(None)),
             ecdsa: Some(EcdsaInstanceDef::new(None)),
             bitwise: Some(BitwiseInstanceDef::new(None)),
             ec_op: Some(EcOpInstanceDef::new(None)),

--- a/vm/src/types/instance_definitions/range_check_instance_def.rs
+++ b/vm/src/types/instance_definitions/range_check_instance_def.rs
@@ -4,27 +4,15 @@ pub(crate) const CELLS_PER_RANGE_CHECK: u32 = 1;
 #[derive(Serialize, Debug, PartialEq)]
 pub(crate) struct RangeCheckInstanceDef {
     pub(crate) ratio: Option<u32>,
-    pub(crate) n_parts: u32,
 }
 
 impl RangeCheckInstanceDef {
     pub(crate) fn default() -> Self {
-        RangeCheckInstanceDef {
-            ratio: Some(8),
-            n_parts: 8,
-        }
+        RangeCheckInstanceDef { ratio: Some(8) }
     }
 
-    pub(crate) fn new(ratio: Option<u32>, n_parts: u32) -> Self {
-        RangeCheckInstanceDef { ratio, n_parts }
-    }
-
-    pub(crate) fn _cells_per_builtin(&self) -> u32 {
-        CELLS_PER_RANGE_CHECK
-    }
-
-    pub(crate) fn _range_check_units_per_builtin(&self) -> u32 {
-        self.n_parts
+    pub(crate) fn new(ratio: Option<u32>) -> Self {
+        RangeCheckInstanceDef { ratio }
     }
 }
 
@@ -37,35 +25,15 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn get_range_check_units_per_builtin() {
-        let builtin_instance = RangeCheckInstanceDef::default();
-        assert_eq!(builtin_instance._range_check_units_per_builtin(), 8);
-    }
-
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn get_cells_per_builtin() {
-        let builtin_instance = RangeCheckInstanceDef::default();
-        assert_eq!(builtin_instance._cells_per_builtin(), 1);
-    }
-
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
-        let builtin_instance = RangeCheckInstanceDef {
-            ratio: Some(10),
-            n_parts: 10,
-        };
-        assert_eq!(RangeCheckInstanceDef::new(Some(10), 10), builtin_instance);
+        let builtin_instance = RangeCheckInstanceDef { ratio: Some(10) };
+        assert_eq!(RangeCheckInstanceDef::new(Some(10)), builtin_instance);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_default() {
-        let builtin_instance = RangeCheckInstanceDef {
-            ratio: Some(8),
-            n_parts: 8,
-        };
+        let builtin_instance = RangeCheckInstanceDef { ratio: Some(8) };
         assert_eq!(RangeCheckInstanceDef::default(), builtin_instance);
     }
 }

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -236,7 +236,7 @@ pub mod test_utils {
         () => {{
             let mut vm = VirtualMachine::new(false);
             vm.builtin_runners = vec![
-                $crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner::new_standard(
+                $crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner::<8>::new(
                     Some(8),
                     true,
                 )

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -236,8 +236,11 @@ pub mod test_utils {
         () => {{
             let mut vm = VirtualMachine::new(false);
             vm.builtin_runners = vec![
-                $crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner::new(Some(8), 8, true)
-                    .into(),
+                $crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner::new_standard(
+                    Some(8),
+                    true,
+                )
+                .into(),
             ];
             vm
         }};

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -35,6 +35,7 @@ use super::cairo_pie::BuiltinAdditionalData;
 pub const OUTPUT_BUILTIN_NAME: &str = "output_builtin";
 pub const HASH_BUILTIN_NAME: &str = "pedersen_builtin";
 pub const RANGE_CHECK_BUILTIN_NAME: &str = "range_check_builtin";
+pub const RANGE_CHECK_96_BUILTIN_NAME: &str = "range_check_96_builtin";
 pub const SIGNATURE_BUILTIN_NAME: &str = "ecdsa_builtin";
 pub const BITWISE_BUILTIN_NAME: &str = "bitwise_builtin";
 pub const EC_OP_BUILTIN_NAME: &str = "ec_op_builtin";
@@ -315,7 +316,7 @@ impl BuiltinRunner {
         match self {
             BuiltinRunner::RangeCheck(range_check) => {
                 let (used_cells, _) = self.get_used_cells_and_allocated_size(vm)?;
-                Ok(used_cells * range_check.n_parts as usize)
+                Ok(used_cells * range_check.n_parts() as usize)
             }
             _ => Ok(0),
         }
@@ -379,7 +380,7 @@ impl BuiltinRunner {
             BuiltinRunner::Bitwise(_) => BITWISE_BUILTIN_NAME,
             BuiltinRunner::EcOp(_) => EC_OP_BUILTIN_NAME,
             BuiltinRunner::Hash(_) => HASH_BUILTIN_NAME,
-            BuiltinRunner::RangeCheck(_) => RANGE_CHECK_BUILTIN_NAME,
+            BuiltinRunner::RangeCheck(b) => b.name(),
             BuiltinRunner::Output(_) => OUTPUT_BUILTIN_NAME,
             BuiltinRunner::Keccak(_) => KECCAK_BUILTIN_NAME,
             BuiltinRunner::Signature(_) => SIGNATURE_BUILTIN_NAME,

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -656,7 +656,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_n_input_cells_range_check() {
-        let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
+        let range_check = RangeCheckBuiltinRunner::new_standard(Some(10), true);
         let builtin: BuiltinRunner = range_check.clone().into();
         assert_eq!(range_check.n_input_cells, builtin.n_input_cells())
     }
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_cells_per_instance_range_check() {
-        let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
+        let range_check = RangeCheckBuiltinRunner::new_standard(Some(10), true);
         let builtin: BuiltinRunner = range_check.clone().into();
         assert_eq!(range_check.cells_per_instance, builtin.cells_per_instance())
     }
@@ -760,7 +760,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_name_range_check() {
-        let range_check = RangeCheckBuiltinRunner::new(Some(10), 10, true);
+        let range_check = RangeCheckBuiltinRunner::new_standard(Some(10), true);
         let builtin: BuiltinRunner = range_check.into();
         assert_eq!(RANGE_CHECK_BUILTIN_NAME, builtin.name())
     }
@@ -930,7 +930,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_range_check_with_items() {
-        let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(10), 12, true));
+        let builtin =
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(10), true));
 
         let mut vm = vm!();
 
@@ -1017,7 +1018,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_allocated_memory_units_range_check() {
-        let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+        let builtin =
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         let mut vm = vm!();
         vm.current_step = 8;
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(1));
@@ -1069,7 +1071,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_range_check_usage_range_check() {
-        let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+        let builtin =
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
         assert_eq!(builtin.get_range_check_usage(&memory), Some((0, 4)));
     }
@@ -1160,7 +1163,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_diluted_check_units_range_check() {
-        let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+        let builtin =
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         assert_eq!(builtin.get_used_diluted_check_units(270, 7), 0);
     }
 
@@ -1185,7 +1189,7 @@ mod tests {
         let output_builtin: BuiltinRunner = OutputBuiltinRunner::new(true).into();
         assert_eq!(output_builtin.get_memory_segment_addresses(), (0, None),);
         let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         assert_eq!(
             range_check_builtin.get_memory_segment_addresses(),
             (0, None),
@@ -1321,7 +1325,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_missing_memory_cells_with_offsets() {
-        let range_check_builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let range_check_builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
         let builtin: BuiltinRunner = range_check_builtin.into();
         let mut vm = vm!();
 
@@ -1346,7 +1350,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_missing_memory_cells() {
         let builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         let mut vm = vm!();
 
         vm.segments.memory = memory![((0, 1), 1)];
@@ -1362,7 +1366,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn run_security_checks_range_check_empty() {
-        let range_check_builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let range_check_builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
 
         let builtin: BuiltinRunner = range_check_builtin.into();
 
@@ -1560,7 +1564,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_used_perm_range_check_units_range_check() {
-        let builtin_runner: BuiltinRunner = RangeCheckBuiltinRunner::new(Some(8), 8, true).into();
+        let builtin_runner: BuiltinRunner =
+            RangeCheckBuiltinRunner::new_standard(Some(8), true).into();
         let mut vm = vm!();
 
         vm.current_step = 8;
@@ -1582,7 +1587,7 @@ mod tests {
         let output_builtin: BuiltinRunner = OutputBuiltinRunner::new(true).into();
         assert_eq!(output_builtin.ratio(), None,);
         let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         assert_eq!(range_check_builtin.ratio(), (Some(8)),);
         let keccak_builtin: BuiltinRunner =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
@@ -1637,7 +1642,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![4]);
 
         let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, true));
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), true));
         assert_eq!(range_check_builtin.get_used_instances(&vm.segments), Ok(4));
     }
 
@@ -1652,7 +1657,7 @@ mod tests {
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false)),
             BuiltinRunner::Hash(HashBuiltinRunner::new(Some(1), false)),
             BuiltinRunner::Output(OutputBuiltinRunner::new(false)),
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, false)),
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), false)),
             BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
                 &KeccakInstanceDef::default(),
                 false,
@@ -1680,7 +1685,7 @@ mod tests {
             BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false)),
             BuiltinRunner::Hash(HashBuiltinRunner::new(Some(1), false)),
             BuiltinRunner::Output(OutputBuiltinRunner::new(false)),
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(Some(8), 8, false)),
+            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new_standard(Some(8), false)),
             BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
                 &KeccakInstanceDef::default(),
                 false,

--- a/vm/src/vm/runners/builtin_runner/modulo.rs
+++ b/vm/src/vm/runners/builtin_runner/modulo.rs
@@ -739,8 +739,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 18927,
-                        offsets_ptr: 18959,
+                        values_ptr: 23023
+                        offsets_ptr: 23055
                         n: 2,
                         batch: BTreeMap::from([(
                             0,
@@ -769,8 +769,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 18927,
-                        offsets_ptr: 18962,
+                        values_ptr: 23023,
+                        offsets_ptr: 23058,
                         n: 1,
                         batch: BTreeMap::from([(
                             0,
@@ -794,7 +794,7 @@ mod tests {
                         ),])
                     }
                 ],
-                zero_value_address: 18027
+                zero_value_address: 22123
             })
         );
         assert_eq!(
@@ -807,8 +807,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 18927,
-                        offsets_ptr: 18965,
+                        values_ptr: 23023,
+                        offsets_ptr: 23061,
                         n: 3,
                         batch: BTreeMap::from([(
                             0,
@@ -837,8 +837,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 18927,
-                        offsets_ptr: 18968,
+                        values_ptr: 23023,
+                        offsets_ptr: 23064,
                         n: 2,
                         batch: BTreeMap::from([(
                             0,
@@ -867,8 +867,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 18927,
-                        offsets_ptr: 18971,
+                        values_ptr: 23023,
+                        offsets_ptr: 23067,
                         n: 1,
                         batch: BTreeMap::from([(
                             0,

--- a/vm/src/vm/runners/builtin_runner/modulo.rs
+++ b/vm/src/vm/runners/builtin_runner/modulo.rs
@@ -739,8 +739,8 @@ mod tests {
                         p1: Felt252::ONE,
                         p2: Felt252::ZERO,
                         p3: Felt252::ZERO,
-                        values_ptr: 23023
-                        offsets_ptr: 23055
+                        values_ptr: 23023,
+                        offsets_ptr: 23055,
                         n: 2,
                         batch: BTreeMap::from([(
                             0,
@@ -892,7 +892,7 @@ mod tests {
                         ),])
                     }
                 ],
-                zero_value_address: 18027
+                zero_value_address: 22123
             })
         )
     }

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -55,7 +55,9 @@ use num_traits::{ToPrimitive, Zero};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    builtin_runner::{KeccakBuiltinRunner, PoseidonBuiltinRunner},
+    builtin_runner::{
+        KeccakBuiltinRunner, PoseidonBuiltinRunner, RC_N_PARTS_96, RC_N_PARTS_STANDARD,
+    },
     cairo_pie::{self, CairoPie, CairoPieMetadata, CairoPieVersion},
 };
 
@@ -285,7 +287,11 @@ impl CairoRunner {
             let included = program_builtins.remove(&BuiltinName::range_check);
             if included || self.is_proof_mode() {
                 builtin_runners.push(
-                    RangeCheckBuiltinRunner::new_standard(instance_def.ratio, included).into(),
+                    RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(
+                        instance_def.ratio,
+                        included,
+                    )
+                    .into(),
                 );
             }
         }
@@ -329,8 +335,10 @@ impl CairoRunner {
         if let Some(instance_def) = self.layout.builtins.range_check96.as_ref() {
             let included = program_builtins.remove(&BuiltinName::range_check96);
             if included || self.is_proof_mode() {
-                builtin_runners
-                    .push(RangeCheckBuiltinRunner::new_96(instance_def.ratio, included).into());
+                builtin_runners.push(
+                    RangeCheckBuiltinRunner::<RC_N_PARTS_96>::new(instance_def.ratio, included)
+                        .into(),
+                );
             }
         }
         if !program_builtins.is_empty() && !allow_missing_builtins {
@@ -376,9 +384,9 @@ impl CairoRunner {
                 BuiltinName::pedersen => vm
                     .builtin_runners
                     .push(HashBuiltinRunner::new(Some(32), true).into()),
-                BuiltinName::range_check => vm
-                    .builtin_runners
-                    .push(RangeCheckBuiltinRunner::new_standard(Some(1), true).into()),
+                BuiltinName::range_check => vm.builtin_runners.push(
+                    RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(1), true).into(),
+                ),
                 BuiltinName::output => vm
                     .builtin_runners
                     .push(OutputBuiltinRunner::new(true).into()),
@@ -406,7 +414,7 @@ impl CairoRunner {
                 }
                 BuiltinName::range_check96 => vm
                     .builtin_runners
-                    .push(RangeCheckBuiltinRunner::new_96(Some(1), true).into()),
+                    .push(RangeCheckBuiltinRunner::<RC_N_PARTS_96>::new(Some(1), true).into()),
             }
         }
 
@@ -4082,7 +4090,8 @@ mod tests {
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(12), true).into()];
+        vm.builtin_runners =
+            vec![RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(12), true).into()];
 
         assert_matches!(
             cairo_runner.get_perm_range_check_limits(&vm),
@@ -4136,7 +4145,8 @@ mod tests {
 
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(8), true).into()];
+        vm.builtin_runners =
+            vec![RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true).into()];
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];
@@ -4203,7 +4213,8 @@ mod tests {
 
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(8), true).into()];
+        vm.builtin_runners =
+            vec![RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true).into()];
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -259,6 +259,7 @@ impl CairoRunner {
             BuiltinName::ec_op,
             BuiltinName::keccak,
             BuiltinName::poseidon,
+            BuiltinName::range_check96,
         ];
         if !is_subsequence(&self.program.builtins, &builtin_ordered_list) {
             return Err(RunnerError::DisorderedBuiltins);
@@ -327,6 +328,20 @@ impl CairoRunner {
             if included || self.is_proof_mode() {
                 builtin_runners
                     .push(PoseidonBuiltinRunner::new(instance_def.ratio, included).into());
+            }
+        }
+
+        if let Some(instance_def) = self.layout.builtins.range_check96.as_ref() {
+            let included = program_builtins.remove(&BuiltinName::range_check96);
+            if included || self.is_proof_mode() {
+                builtin_runners.push(
+                    RangeCheckBuiltinRunner::new(
+                        instance_def.ratio,
+                        instance_def.n_parts,
+                        included,
+                    )
+                    .into(),
+                );
             }
         }
         if !program_builtins.is_empty() && !allow_missing_builtins {
@@ -400,6 +415,9 @@ impl CairoRunner {
                             .push(SegmentArenaBuiltinRunner::new(true).into())
                     }
                 }
+                BuiltinName::range_check96 => vm
+                    .builtin_runners
+                    .push(RangeCheckBuiltinRunner::new(Some(1), 6, true).into()),
             }
         }
 

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -285,12 +285,7 @@ impl CairoRunner {
             let included = program_builtins.remove(&BuiltinName::range_check);
             if included || self.is_proof_mode() {
                 builtin_runners.push(
-                    RangeCheckBuiltinRunner::new(
-                        instance_def.ratio,
-                        instance_def.n_parts,
-                        included,
-                    )
-                    .into(),
+                    RangeCheckBuiltinRunner::new_standard(instance_def.ratio, included).into(),
                 );
             }
         }
@@ -334,14 +329,8 @@ impl CairoRunner {
         if let Some(instance_def) = self.layout.builtins.range_check96.as_ref() {
             let included = program_builtins.remove(&BuiltinName::range_check96);
             if included || self.is_proof_mode() {
-                builtin_runners.push(
-                    RangeCheckBuiltinRunner::new(
-                        instance_def.ratio,
-                        instance_def.n_parts,
-                        included,
-                    )
-                    .into(),
-                );
+                builtin_runners
+                    .push(RangeCheckBuiltinRunner::new_96(instance_def.ratio, included).into());
             }
         }
         if !program_builtins.is_empty() && !allow_missing_builtins {
@@ -389,7 +378,7 @@ impl CairoRunner {
                     .push(HashBuiltinRunner::new(Some(32), true).into()),
                 BuiltinName::range_check => vm
                     .builtin_runners
-                    .push(RangeCheckBuiltinRunner::new(Some(1), 8, true).into()),
+                    .push(RangeCheckBuiltinRunner::new_standard(Some(1), true).into()),
                 BuiltinName::output => vm
                     .builtin_runners
                     .push(OutputBuiltinRunner::new(true).into()),
@@ -417,7 +406,7 @@ impl CairoRunner {
                 }
                 BuiltinName::range_check96 => vm
                     .builtin_runners
-                    .push(RangeCheckBuiltinRunner::new(Some(1), 6, true).into()),
+                    .push(RangeCheckBuiltinRunner::new_96(Some(1), true).into()),
             }
         }
 
@@ -4093,7 +4082,7 @@ mod tests {
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(12), 5, true).into()];
+        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(12), true).into()];
 
         assert_matches!(
             cairo_runner.get_perm_range_check_limits(&vm),
@@ -4147,7 +4136,7 @@ mod tests {
 
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(8), 8, true).into()];
+        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(8), true).into()];
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];
@@ -4214,7 +4203,7 @@ mod tests {
 
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new(Some(8), 8, true).into()];
+        vm.builtin_runners = vec![RangeCheckBuiltinRunner::new_standard(Some(8), true).into()];
         vm.segments.memory.data = vec![vec![Some(MemoryCell::new(mayberelocatable!(
             0x80FF_8000_0530u64
         )))]];

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -35,8 +35,8 @@ use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
 use super::runners::builtin_runner::{
-    ModBuiltinRunner, ADD_MOD_BUILTIN_NAME, MUL_MOD_BUILTIN_NAME,
-    OUTPUT_BUILTIN_NAME, RC_N_PARTS_STANDARD,
+    ModBuiltinRunner, ADD_MOD_BUILTIN_NAME, MUL_MOD_BUILTIN_NAME, OUTPUT_BUILTIN_NAME,
+    RC_N_PARTS_STANDARD,
 };
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -32,7 +32,7 @@ use core::num::NonZeroUsize;
 use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
-use super::runners::builtin_runner::OUTPUT_BUILTIN_NAME;
+use super::runners::builtin_runner::{OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 
@@ -925,7 +925,7 @@ impl VirtualMachine {
     pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
         for builtin in &self.builtin_runners {
             if let BuiltinRunner::RangeCheck(range_check_builtin) = builtin {
-                if matches!(range_check_builtin.name(), RANGE_CHECK_BUILTIN_NAME) {
+                if range_check_builtin.name() == RANGE_CHECK_BUILTIN_NAME {
                     return Ok(range_check_builtin);
                 }
             };

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -32,7 +32,9 @@ use core::num::NonZeroUsize;
 use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
-use super::runners::builtin_runner::{OutputBuiltinRunner, OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
+use super::runners::builtin_runner::{
+    OutputBuiltinRunner, OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME,
+};
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -925,7 +925,9 @@ impl VirtualMachine {
     pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
         for builtin in &self.builtin_runners {
             if let BuiltinRunner::RangeCheck(range_check_builtin) = builtin {
-                return Ok(range_check_builtin);
+                if matches!(range_check_builtin.name(), RANGE_CHECK_BUILTIN_NAME) {
+                    return Ok(range_check_builtin);
+                }
             };
         }
         Err(VirtualMachineError::NoRangeCheckBuiltin)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -33,7 +33,7 @@ use num_traits::{ToPrimitive, Zero};
 
 use super::errors::runner_errors::RunnerError;
 use super::runners::builtin_runner::{
-    OutputBuiltinRunner, OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME,
+    OutputBuiltinRunner, OUTPUT_BUILTIN_NAME, RC_N_PARTS_STANDARD,
 };
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
@@ -924,12 +924,12 @@ impl VirtualMachine {
         self.segments.memory.get_integer_range(addr, size)
     }
 
-    pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
+    pub fn get_range_check_builtin(
+        &self,
+    ) -> Result<&RangeCheckBuiltinRunner<RC_N_PARTS_STANDARD>, VirtualMachineError> {
         for builtin in &self.builtin_runners {
             if let BuiltinRunner::RangeCheck(range_check_builtin) = builtin {
-                if range_check_builtin.name() == RANGE_CHECK_BUILTIN_NAME {
-                    return Ok(range_check_builtin);
-                }
+                return Ok(range_check_builtin);
             };
         }
         Err(VirtualMachineError::NoRangeCheckBuiltin)

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -779,7 +779,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_within_bounds() {
-        let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
         builtin.add_validation_rule(&mut segments.memory);
@@ -804,7 +804,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_outside_bounds() {
-        let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         segments.add();
         builtin.initialize_segments(&mut segments);
@@ -895,7 +895,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_relocatable_value() {
-        let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
         segments.memory = memory![((0, 0), (0, 4))];
@@ -912,7 +912,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_out_of_bounds_diff_segment() {
-        let mut builtin = RangeCheckBuiltinRunner::new(Some(8), 8, true);
+        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         segments.memory = Memory::new();
         segments.add();

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -608,7 +608,9 @@ mod memory_tests {
         types::instance_definitions::ecdsa_instance_def::EcdsaInstanceDef,
         utils::test_utils::*,
         vm::{
-            runners::builtin_runner::{RangeCheckBuiltinRunner, SignatureBuiltinRunner},
+            runners::builtin_runner::{
+                RangeCheckBuiltinRunner, SignatureBuiltinRunner, RC_N_PARTS_STANDARD,
+            },
             vm_memory::memory_segments::MemorySegmentManager,
         },
     };
@@ -779,7 +781,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_within_bounds() {
-        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
+        let mut builtin = RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
         builtin.add_validation_rule(&mut segments.memory);
@@ -804,7 +806,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_outside_bounds() {
-        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
+        let mut builtin = RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         segments.add();
         builtin.initialize_segments(&mut segments);
@@ -895,7 +897,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_relocatable_value() {
-        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
+        let mut builtin = RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
         segments.memory = memory![((0, 0), (0, 4))];
@@ -912,7 +914,7 @@ mod memory_tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn validate_existing_memory_for_range_check_out_of_bounds_diff_segment() {
-        let mut builtin = RangeCheckBuiltinRunner::new_standard(Some(8), true);
+        let mut builtin = RangeCheckBuiltinRunner::<RC_N_PARTS_STANDARD>::new(Some(8), true);
         let mut segments = MemorySegmentManager::new();
         segments.memory = Memory::new();
         segments.add();


### PR DESCRIPTION
Refactors RangeCheckBuiltinRunner to accomodate both standard and 96 variants
Adds range_check96 to all_cairo layout
Integration test added in #1699 as it depends on #1673 
