### PR TITLE
Fix cairo1-run `validate_layouts`

### DIFF
--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -114,6 +114,7 @@ fn validate_layout(value: &str) -> Result<String, String> {
         "plain"
         | "small"
         | "dex"
+        | "recursive"
         | "starknet"
         | "starknet_with_keccak"
         | "recursive_large_output"


### PR DESCRIPTION
"recursive" layout was not marked as valid

