### PR TITLE
[WIP] Set max combination size for check-all-features to speed up CI

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -108,3 +108,10 @@ harness = false
 name = "custom_hint"
 path = "../examples/custom_hint/src/main.rs"
 required-features = ["std"]
+
+[package.metadata.cargo-all-features]
+
+# The maximum number of features to try at once. Does not count features from `always_include_features`.
+# This is useful for reducing the number of combinations run for a crate with a large amount of features,
+# since in most cases a bug just needs a small set of 2-3 features to reproduce.
+max_combination_size = 4


### PR DESCRIPTION
The workflow `Make sure all features work (vm)` is already taking close to 50 minutes. As there is no way to partition the workflow into sets of features, this PR aims to fix this problem by setting up a max combination of features to reduce the cases to check.
Follow-up work: Investigate other workflows/ solutions that can allow us to properly partition this workflow

