### PR TITLE
fix: cairo1-run array argument's length can not be less than 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
 
 * feat: output builtin features for bootloader support [#1580](https://github.com/lambdaclass/cairo-vm/pull/1580)
 
+* fix: add support for arrays shorter than 2 as arguments for cairo1-run [#1737](https://github.com/lambdaclass/cairo-vm/pull/1737)
+
 #### [1.0.0-rc1] - 2024-02-23
 
 * Bump `starknet-types-core` dependency version to 0.0.9 [#1628](https://github.com/lambdaclass/cairo-vm/pull/1628)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: add support for arrays shorter than 2 as arguments for cairo1-run [#1737](https://github.com/lambdaclass/cairo-vm/pull/1737)
+
 * Serialize directly into writer in `CairoPie::write_zip_file`[#1736](https://github.com/lambdaclass/cairo-vm/pull/1736)
 
 * feat: Add support for cairo1 run with segements arena validation.
@@ -151,8 +153,6 @@
 * feat: Add cairo1-run output pretty-printing for felts, arrays/spans and dicts [#1630](https://github.com/lambdaclass/cairo-vm/pull/1630)
 
 * feat: output builtin features for bootloader support [#1580](https://github.com/lambdaclass/cairo-vm/pull/1580)
-
-* fix: add support for arrays shorter than 2 as arguments for cairo1-run [#1737](https://github.com/lambdaclass/cairo-vm/pull/1737)
 
 #### [1.0.0-rc1] - 2024-02-23
 

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -69,24 +69,36 @@ fn process_args(value: &str) -> Result<FuncArgs, String> {
     while let Some(value) = input.next() {
         // First argument in an array
         if value.starts_with('[') {
-            let mut array_arg =
-                vec![Felt252::from_dec_str(value.strip_prefix('[').unwrap()).unwrap()];
-            // Process following args in array
-            let mut array_end = false;
-            while !array_end {
-                if let Some(value) = input.next() {
-                    // Last arg in array
-                    if value.ends_with(']') {
-                        array_arg
-                            .push(Felt252::from_dec_str(value.strip_suffix(']').unwrap()).unwrap());
-                        array_end = true;
-                    } else {
-                        array_arg.push(Felt252::from_dec_str(value).unwrap())
+            if value.ends_with(']') {
+                if value.len() == 2 {
+                    args.push(FuncArg::Array(Vec::new()));
+                } else {
+                    args.push(FuncArg::Array(vec![Felt252::from_dec_str(
+                        value.strip_prefix('[').unwrap().strip_suffix(']').unwrap(),
+                    )
+                    .unwrap()]));
+                }
+            } else {
+                let mut array_arg =
+                    vec![Felt252::from_dec_str(value.strip_prefix('[').unwrap()).unwrap()];
+                // Process following args in array
+                let mut array_end = false;
+                while !array_end {
+                    if let Some(value) = input.next() {
+                        // Last arg in array
+                        if value.ends_with(']') {
+                            array_arg.push(
+                                Felt252::from_dec_str(value.strip_suffix(']').unwrap()).unwrap(),
+                            );
+                            array_end = true;
+                        } else {
+                            array_arg.push(Felt252::from_dec_str(value).unwrap())
+                        }
                     }
                 }
+                // Finalize array
+                args.push(FuncArg::Array(array_arg))
             }
-            // Finalize array
-            args.push(FuncArg::Array(array_arg))
         } else {
             // Single argument
             args.push(FuncArg::Single(Felt252::from_dec_str(value).unwrap()))

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -298,6 +298,8 @@ mod tests {
     #[case("null_ret.cairo", "null", None)]
     #[case("with_input/tensor.cairo", "1", Some("[2 2] [1 2 3 4]"))]
     #[case("with_input/array_input_sum.cairo", "12", Some("2 [1 2 3 4] 0 [9 8]"))]
+    #[case("with_input/array_length.cairo", "5", Some("[1 2 3 4] [1]"))]
+    #[case("with_input/array_length.cairo", "4", Some("[1 2 3 4] []"))]
     #[case("with_input/branching.cairo", "0", Some("17"))]
     #[case("with_input/branching.cairo", "1", Some("0"))]
     #[case("dictionaries.cairo", "1024", None)]

--- a/cairo_programs/cairo-1-programs/with_input/array_length.cairo
+++ b/cairo_programs/cairo-1-programs/with_input/array_length.cairo
@@ -1,0 +1,5 @@
+use array::ArrayTrait;
+
+fn main(array_a: Array<u32>, array_b: Array<u32>) -> u32 {
+    array_a.len() + array_b.len()
+}


### PR DESCRIPTION
# fix: cairo1-run array argument's length can not be less than 2

## Description

if the program has an argument which is an empty array or the length is 1, cairo1-run fails with error:

```
thread 'main' panicked at cairo1-run/src/main.rs:73:78:
called `Result::unwrap()` on an `Err` value: FromStrError
```

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

