### PR TITLE
`cairo1-run` CLI: Allow loading arguments from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* `cairo1-run` CLI: Allow loading arguments from file[#1739](https://github.com/lambdaclass/cairo-vm/pull/1739)
+
 * Serialize directly into writer in `CairoPie::write_zip_file`[#1736](https://github.com/lambdaclass/cairo-vm/pull/1736)
 
 * feat: Add support for cairo1 run with segements arena validation.

--- a/cairo1-run/README.md
+++ b/cairo1-run/README.md
@@ -55,6 +55,8 @@ The cairo1-run cli supports the following optional arguments:
 
 * `--args <ARGUMENTS>`: Receives the arguments to be passed to the program's main function. Receives whitespace-separated values which can be numbers or arrays, with arrays consisting of whitespace-separated numbers wrapped between brackets
 
+* `--args_file <FILENAME>`: Receives the name of the file from where arguments should be read. Expects the same argument format of the `--args` flag. Should be used if the list of arguments exceeds the shell's capacity.
+
 * `--trace_file <TRACE_FILE>`: Receives the name of a file and outputs the relocated trace into it
 
 * `--memory_file <MEMORY_FILE>`: Receives the name of a file and outputs the relocated memory into it

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -46,6 +46,7 @@ struct Args {
     // For example " --args '1 2 [1 2 3]'" will yield 3 arguments, with the last one being an array of 3 elements
     #[clap(long = "args", default_value = "", value_parser=process_args, conflicts_with = "args_file")]
     args: FuncArgs,
+    // Same rules from `args` apply here
     #[clap(long = "args_file", value_parser, value_hint=ValueHint::FilePath, conflicts_with = "args")]
     args_file: Option<PathBuf>,
     #[clap(long = "print_output", value_parser)]


### PR DESCRIPTION
Adds the `--args_file` that takes a filename and processes the arguments in the file as if they were sent via `--args`

