### PR TITLE
[Cairo 1 Run] Refactor integration tests + check that return values taken from output segment are correct

### DIFF
--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -1217,7 +1217,7 @@ mod tests {
             ..Default::default()
         };
         // Run program
-        let (runner, vm, return_values, _) =
+        let (_, vm, return_values, _) =
             cairo_run_program(&sierra_program, cairo_run_config).unwrap();
         // When the return type is a PanicResult, we remove the panic wrapper when returning the ret values
         // And handle the panics returning an error, so we need to add it here
@@ -1233,15 +1233,12 @@ mod tests {
         let output_builtin_segment = vm
             .get_continuous_range((2, 0).into(), return_values.len())
             .unwrap();
+        // While this test can make sure that the return values are the same as the output segment values, as the code that fetches return values
+        // takes them from the output segment we can't be sure that these return values are correct, for this we use the integration tests in the main.rs file
         assert_eq!(output_builtin_segment, return_values, "{}", filename);
         // Just for consistency, we will check that there are no values in the output segment after the return values
         assert!(vm
             .get_maybe(&Relocatable::from((2_isize, return_values.len())))
             .is_none());
-
-        // Check that cairo_pie can be outputted when not running in proof_mode
-        if !proof_mode {
-            assert!(runner.get_cairo_pie(&vm).is_ok())
-        }
     }
 }

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -1170,24 +1170,24 @@ mod tests {
         compile_prepared_db(&mut db, main_crate_ids, compiler_config).unwrap()
     }
 
-    fn return_value_size(sierra_program: &SierraProgram) -> i16 {
-        let sierra_program_registry =
-            ProgramRegistry::<CoreType, CoreLibfunc>::new(sierra_program).unwrap();
-        let type_sizes =
-            get_type_size_map(sierra_program, &sierra_program_registry).unwrap_or_default();
+    fn main_hash_panic_result(sierra_program: &SierraProgram) -> bool {
         let main_func = find_function(sierra_program, "::main").unwrap();
         main_func
             .signature
             .ret_types
             .last()
-            .and_then(|ty| type_sizes.get(ty).map(|i| *i))
+            .and_then(|rt| {
+                rt.debug_name
+                    .as_ref()
+                    .map(|n| n.as_ref().starts_with("core::panics::PanicResult::"))
+            })
             .unwrap_or_default()
     }
 
     #[rstest]
     #[case("../cairo_programs/cairo-1-programs/array_append.cairo")]
     #[case("../cairo_programs/cairo-1-programs/array_get.cairo")]
-    // TODO: skipped due to bug #[case("../cairo_programs/cairo-1-programs/dictionaries.cairo")]
+    #[case("../cairo_programs/cairo-1-programs/dictionaries.cairo")]
     #[case("../cairo_programs/cairo-1-programs/enum_flow.cairo")]
     #[case("../cairo_programs/cairo-1-programs/enum_match.cairo")]
     #[case("../cairo_programs/cairo-1-programs/factorial.cairo")]
@@ -1217,29 +1217,26 @@ mod tests {
             ..Default::default()
         };
         // Run program
-        let (runner, vm, _, _) = cairo_run_program(&sierra_program, cairo_run_config).unwrap();
-        let return_value_size = return_value_size(&sierra_program);
-        // Check that the output segment contains the same return values as the execution segment
+        let (runner, vm, return_values, _) =
+            cairo_run_program(&sierra_program, cairo_run_config).unwrap();
+        // When the return type is a PanicResult, we remove the panic wrapper when returning the ret values
+        // And handle the panics returning an error, so we need to add it here
+        let return_values = if main_hash_panic_result(&sierra_program) {
+            let mut rv = vec![Felt252::ZERO.into(), Felt252::ZERO.into()];
+            rv.extend_from_slice(&return_values);
+            rv
+        } else {
+            return_values
+        };
+        // Check that the output segment contains the return values
         // The output builtin will always be the first builtin, so we know it's segment is 2
-        println!("{}", vm.segments);
         let output_builtin_segment = vm
-            .get_continuous_range((2, 0).into(), return_value_size as usize)
+            .get_continuous_range((2, 0).into(), return_values.len())
             .unwrap();
-        let builtin_count = runner.get_program_builtins().len();
-        let execution_segment_last_values = vm
-            .get_continuous_range(
-                (vm.get_ap() - (return_value_size as usize + builtin_count)).unwrap(),
-                return_value_size as usize,
-            )
-            .unwrap();
-        assert_eq!(
-            output_builtin_segment, execution_segment_last_values,
-            "{}",
-            filename
-        );
+        assert_eq!(output_builtin_segment, return_values, "{}", filename);
         // Just for consistency, we will check that there are no values in the output segment after the return values
         assert!(vm
-            .get_maybe(&Relocatable::from((2_isize, return_value_size as usize)))
+            .get_maybe(&Relocatable::from((2_isize, return_values.len())))
             .is_none());
 
         // Check that cairo_pie can be outputted when not running in proof_mode

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -339,7 +339,7 @@ mod tests {
         let filename = format!("../cairo_programs/cairo-1-programs/{}", program);
         args.push(&filename);
         args.extend_from_slice(&common_flags);
-        args.extend_from_slice(&extra_flags);
+        args.extend_from_slice(extra_flags);
         if let Some(inputs) = inputs {
             args.extend_from_slice(&["--args", inputs])
         }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -326,7 +326,7 @@ mod tests {
     )]
         extra_flags: &[&str],
     ) {
-        let common_flags = vec![
+        let common_flags = &[
             "--print_output",
             "--trace_file",
             "/dev/null",
@@ -338,7 +338,7 @@ mod tests {
         let mut args = vec!["cairo1-run"];
         let filename = format!("../cairo_programs/cairo-1-programs/{}", program);
         args.push(&filename);
-        args.extend_from_slice(&common_flags);
+        args.extend_from_slice(common_flags);
         args.extend_from_slice(extra_flags);
         if let Some(inputs) = inputs {
             args.extend_from_slice(&["--args", inputs])

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -261,158 +261,6 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/fibonacci.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/fibonacci.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_fibonacci_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "89");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/factorial.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/factorial.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_factorial_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "3628800");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bitwise.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bitwise.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_bitwise_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "11772");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/array_get.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/array_get.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_array_get_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "3");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/enum_flow.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/enum_flow.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_enum_flow_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "300");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/enum_match.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/enum_match.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_enum_match_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "10 3618502788666131213697322783095070105623107215331596699973092056135872020471");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/hello.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/hello.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_hello_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1234");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/ops.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/ops.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_ops_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "6");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/print.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/print.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_print_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res.is_empty());
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/recursion.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/recursion.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_recursion_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1154076154663935037074198317650845438095734251249125412074882362667803016453");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/sample.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/sample.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_sample_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "5050");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/poseidon.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/poseidon.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_poseidon_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1099385018355113290651252669115094675591288647745213771718157553170111442461");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/poseidon_pedersen.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/poseidon_pedersen.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_poseidon_pedersen_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1036257840396636296853154602823055519264738423488122322497453114874087006398");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/pedersen_example.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/pedersen_example.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_pedersen_example_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1089549915800264549621536909767699778745926517555586332772759280702396009108");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/simple.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/simple.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_simple_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "true");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/simple_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/simple_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_simple_struct_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "100");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dictionaries.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dictionaries.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_dictionaries(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1024");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "0"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "0"].as_slice())]
-    fn test_run_branching_0(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "17"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "96"].as_slice())]
-    fn test_run_branching_not_0(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "0");
-    }
-
-    #[rstest]
     #[case("tensor_new.cairo", "[1 2] [1 false 1 true]", None)]
     #[case("bytes31_ret.cairo", "123", None)]
     #[case("null_ret.cairo", "null", None)]
@@ -426,6 +274,47 @@ mod tests {
     #[case("struct_span_return.cairo", "[[4 3] [2 1]]", None)]
     #[case("null_ret.cairo", "null", None)]
     #[case("with_input/tensor.cairo", "1", Some("[2 2] [1 2 3 4]"))]
+    #[case("with_input/array_input_sum.cairo", "12", Some("2 [1 2 3 4] 0 [9 8]"))]
+    #[case("with_input/branching.cairo", "0", Some("17"))]
+    #[case("with_input/branching.cairo", "1", Some("0"))]
+    #[case("dictionaries.cairo", "1024", None)]
+    #[case("simple_struct.cairo", "100", None)]
+    #[case("simple.cairo", "true", None)]
+    #[case(
+        "pedersen_example.cairo",
+        "1089549915800264549621536909767699778745926517555586332772759280702396009108",
+        None
+    )]
+    #[case(
+        "poseidon_pedersen.cairo",
+        "1036257840396636296853154602823055519264738423488122322497453114874087006398",
+        None
+    )]
+    #[case(
+        "poseidon.cairo",
+        "1099385018355113290651252669115094675591288647745213771718157553170111442461",
+        None
+    )]
+    #[case("sample.cairo", "5050", None)]
+    #[case(
+        "recursion.cairo",
+        "1154076154663935037074198317650845438095734251249125412074882362667803016453",
+        None
+    )]
+    #[case("print.cairo", "", None)]
+    #[case("ops.cairo", "6", None)]
+    #[case("hello.cairo", "1234", None)]
+    #[case(
+        "enum_match.cairo",
+        "10 3618502788666131213697322783095070105623107215331596699973092056135872020471",
+        None
+    )]
+    #[case("enum_flow.cairo", "300", None)]
+    #[case("array_get.cairo", "3", None)]
+    #[case("bitwise.cairo", "11772", None)]
+    #[case("factorial.cairo", "3628800", None)]
+    #[case("fibonacci.cairo", "89", None)]
+
     fn test_run_progarm(
         #[case] program: &str,
         #[case] expected_output: &str,
@@ -456,22 +345,6 @@ mod tests {
         }
         let args = args.iter().cloned().map(String::from);
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output, "Program {} failed with flags {}", program, extra_flags.concat());
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
-    fn test_tensor_with_input(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
-    fn test_array_input_sum(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "12");
     }
 
     #[rstest]

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -413,139 +413,23 @@ mod tests {
     }
 
     #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--proof_mode"].as_slice())]
-    fn test_run_branching_no_args(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Err(Error::ArgumentsSizeMismatch { expected, actual }) if expected == 1 && actual == 0);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo","--args", "1 2 3"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--proof_mode", "--args", "1 2 3"].as_slice())]
-    fn test_run_branching_too_many_args(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Err(Error::ArgumentsSizeMismatch { expected, actual }) if expected == 1 && actual == 3);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
-    fn test_array_input_sum(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "12");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/struct_span_return.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/struct_span_return.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_struct_span_return(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "[[4 3] [2 1]]");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
-    fn test_tensor(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res == "1");
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/nullable_dict.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/nullable_dict.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_nullable_dict_ok(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        assert_matches!(run(args), Ok(Some(res)) if res.is_empty());
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_felt_dict(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "{66675: [8 9 10 11] 66676: [1 2 3]}";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_span.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_span.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_felt_span(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "[8 9 10 11]";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/array_integer_tuple.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/array_integer_tuple.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_array_integer_tuple(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "[1] 1";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/nullable_box_vec.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/nullable_box_vec.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_nullable_box_vec(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "{0: 10 1: 20 2: 30} 3";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dict_with_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/dict_with_struct.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_dict_with_struct(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "{0: 1 true 1: 1 false 2: 1 true}";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict_squash.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/felt_dict_squash.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_felt_dict_squash(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "{66675: [4 5 6] 66676: [1 2 3]}";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/null_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/null_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_null_ret(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "null";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bytes31_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/bytes31_ret.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_bytes31_ret(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "123";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/tensor_new.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
-    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/tensor_new.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"].as_slice())]
-    fn test_run_tensor_new(#[case] args: &[&str]) {
-        let args = args.iter().cloned().map(String::from);
-        let expected_output = "[1 2] [1 false 1 true]";
-        assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
-    }
-
-    #[rstest]
-    #[case("tensor_new.cairo", "[1 2] [1 false 1 true]")]
+    #[case("tensor_new.cairo", "[1 2] [1 false 1 true]", None)]
+    #[case("bytes31_ret.cairo", "123", None)]
+    #[case("null_ret.cairo", "null", None)]
+    #[case("felt_dict_squash.cairo", "{66675: [4 5 6] 66676: [1 2 3]}", None)]
+    #[case("dict_with_struct.cairo", "{0: 1 true 1: 1 false 2: 1 true}", None)]
+    #[case("nullable_box_vec.cairo", "{0: 10 1: 20 2: 30} 3", None)]
+    #[case("array_integer_tuple.cairo", "[1] 1", None)]
+    #[case("felt_dict.cairo", "{66675: [8 9 10 11] 66676: [1 2 3]}", None)]
+    #[case("felt_span.cairo", "[8 9 10 11]", None)]
+    #[case("nullable_dict.cairo", "", None)]
+    #[case("struct_span_return.cairo", "[[4 3] [2 1]]", None)]
+    #[case("null_ret.cairo", "null", None)]
+    #[case("with_input/tensor.cairo", "1", Some("[2 2] [1 2 3 4]"))]
     fn test_run_progarm(
         #[case] program: &str,
         #[case] expected_output: &str,
+        #[case] inputs: Option<&str>,
         #[values(
         &["--cairo_pie_output", "/dev/null"],
         &["--cairo_pie_output", "/dev/null", "--append_return_values"],
@@ -567,7 +451,42 @@ mod tests {
         args.push(&filename);
         args.extend_from_slice(&common_flags);
         args.extend_from_slice(&extra_flags);
+        if let Some(inputs) = inputs {
+            args.extend_from_slice(&["--args", inputs])
+        }
         let args = args.iter().cloned().map(String::from);
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output, "Program {} failed with flags {}", program, extra_flags.concat());
+    }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/tensor.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "[2 2] [1 2 3 4]"].as_slice())]
+    fn test_tensor_with_input(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Ok(Some(res)) if res == "1");
+    }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/array_input_sum.cairo", "--print_output", "--trace_file", "/dev/null", "--memory_file", "/dev/null", "--layout", "all_cairo", "--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null", "--args", "2 [1 2 3 4] 0 [9 8]"].as_slice())]
+    fn test_array_input_sum(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Ok(Some(res)) if res == "12");
+    }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--cairo_pie_output", "/dev/null"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--proof_mode"].as_slice())]
+    fn test_run_branching_no_args(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Err(Error::ArgumentsSizeMismatch { expected, actual }) if expected == 1 && actual == 0);
+    }
+
+    #[rstest]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo","--args", "1 2 3"].as_slice())]
+    #[case(["cairo1-run", "../cairo_programs/cairo-1-programs/with_input/branching.cairo", "--layout", "all_cairo", "--proof_mode", "--args", "1 2 3"].as_slice())]
+    fn test_run_branching_too_many_args(#[case] args: &[&str]) {
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Err(Error::ArgumentsSizeMismatch { expected, actual }) if expected == 1 && actual == 3);
     }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -540,4 +540,34 @@ mod tests {
         let expected_output = "[1 2] [1 false 1 true]";
         assert_matches!(run(args), Ok(Some(res)) if res == expected_output);
     }
+
+    #[rstest]
+    #[case("tensor_new.cairo", "[1 2] [1 false 1 true]")]
+    fn test_run_progarm(
+        #[case] program: &str,
+        #[case] expected_output: &str,
+        #[values(
+        &["--cairo_pie_output", "/dev/null"],
+        &["--cairo_pie_output", "/dev/null", "--append_return_values"],
+        &["--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"],
+    )]
+        extra_flags: &[&str],
+    ) {
+        let common_flags = vec![
+            "--print_output",
+            "--trace_file",
+            "/dev/null",
+            "--memory_file",
+            "/dev/null",
+            "--layout",
+            "all_cairo",
+        ];
+        let mut args = vec!["cairo1-run"];
+        let filename = format!("../cairo_programs/cairo-1-programs/{}", program);
+        args.push(&filename);
+        args.extend_from_slice(&common_flags);
+        args.extend_from_slice(&extra_flags);
+        let args = args.iter().cloned().map(String::from);
+        assert_matches!(run(args), Ok(Some(res)) if res == expected_output, "Program {} failed with flags {}", program, extra_flags.concat());
+    }
 }

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -320,9 +320,9 @@ mod tests {
         #[case] expected_output: &str,
         #[case] inputs: Option<&str>,
         #[values(
-        &["--cairo_pie_output", "/dev/null"],
-        &["--cairo_pie_output", "/dev/null", "--append_return_values"],
-        &["--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"],
+        &["--cairo_pie_output", "/dev/null"], // Non proof-mode
+        &["--cairo_pie_output", "/dev/null", "--append_return_values"], // Non proof-mode & appending return values to ouput
+        &["--proof_mode", "--air_public_input", "/dev/null", "--air_private_input", "/dev/null"], // Proof mode
     )]
         extra_flags: &[&str],
     ) {


### PR DESCRIPTION
After PR #1686 the return values are now fetched from the output segment instead of the execution segment when either the `append_return_values` or `proof_mode` flags are enabled, this makes our `check_append_ret_values_to_output_segment` not as useful as it no longer checks that the correct values are being copied to the output segment.
A way to fix it would be to instead compare the values from the execution segment to the ones on the output segment, but after PR #1721 when the segment arena is used the execution segment now contains the values produced by the arena validation where the return values used to be found, so we can no longer use it for comparison.
As a result of these two changes, the best way to test that the correct values are copied to the output segment are to 1: test that the output segment indeed has the return values outputted and no more values after them (current behaviour), and 2: test that the return values outputted when running with `--append_return_values` match the ones outputted by a normal run (this can be accomplished by adding a third case with `--append_return_values`  enabled to our in integration tests.
This PR adds this third test case and also refactors the integration tests to into one test with multiple cases & values so adding new checks and argument combinations is easier.

