### PR TITLE
perf: Change `CairoRunError::VmException` to `Box<VmException>` 

### DIFF
--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -72,7 +72,13 @@ pub fn cairo_run_program(
 
     cairo_runner
         .run_until_pc(end, &mut vm, hint_executor)
-        .map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
+        .map_err(|err| {
+            CairoRunError::VmException(Box::new(VmException::from_vm_error(
+                &cairo_runner,
+                &vm,
+                err,
+            )))
+        })?;
 
     if cairo_run_config.proof_mode {
         cairo_runner.run_for_steps(1, &mut vm, hint_executor)?;
@@ -153,7 +159,13 @@ pub fn cairo_run_pie(
 
     cairo_runner
         .run_until_pc(end, &mut vm, hint_processor)
-        .map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
+        .map_err(|err| {
+            CairoRunError::VmException(Box::new(VmException::from_vm_error(
+                &cairo_runner,
+                &vm,
+                err,
+            )))
+        })?;
 
     cairo_runner.end_run(
         cairo_run_config.disable_trace_padding,
@@ -209,7 +221,13 @@ pub fn cairo_run_fuzzed_program(
         res => res,
     };
 
-    res.map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
+    res.map_err(|err| {
+        CairoRunError::VmException(Box::new(VmException::from_vm_error(
+            &cairo_runner,
+            &vm,
+            err,
+        )))
+    })?;
 
     cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 

--- a/vm/src/vm/errors/cairo_run_errors.rs
+++ b/vm/src/vm/errors/cairo_run_errors.rs
@@ -21,7 +21,7 @@ pub enum CairoRunError {
     #[error(transparent)]
     MemoryError(#[from] MemoryError),
     #[error(transparent)]
-    VmException(#[from] Box<VmException>),
+    VmException(Box<VmException>),
     #[error("Cairo Pie validation failed: {0}")]
     CairoPieValidation(#[from] CairoPieValidationError),
 }

--- a/vm/src/vm/errors/cairo_run_errors.rs
+++ b/vm/src/vm/errors/cairo_run_errors.rs
@@ -21,7 +21,19 @@ pub enum CairoRunError {
     #[error(transparent)]
     MemoryError(#[from] MemoryError),
     #[error(transparent)]
-    VmException(#[from] VmException),
+    VmException(#[from] Box<VmException>),
     #[error("Cairo Pie validation failed: {0}")]
     CairoPieValidation(#[from] CairoPieValidationError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Test to catch possible enum size regressions
+    fn test_cairo_run_error_size() {
+        let size = crate::stdlib::mem::size_of::<CairoRunError>();
+        assert!(size <= 32, "{size}")
+    }
 }

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1141,8 +1141,9 @@ impl CairoRunner {
 
         self.initialize_vm(vm)?;
 
-        self.run_until_pc(end, vm, hint_processor)
-            .map_err(|err| VmException::from_vm_error(self, vm, err))?;
+        self.run_until_pc(end, vm, hint_processor).map_err(|err| {
+            CairoRunError::VmException(Box::new(VmException::from_vm_error(self, vm, err)))
+        })?;
         self.end_run(true, false, vm, hint_processor)?;
 
         if verify_secure {


### PR DESCRIPTION
PR #1720 Added a small error variant to the `CairoRunError` which brought a huge performance regression. This is due to the `VmException` variant having a big size, making all other variants equally as big. This PR solves this issue by wrapping the `VmException` contained in its corresponding variant, and adds a test to ensure that the size of CairoRunError doesn't surpass 32 bytes