### PR TITLE
CairoPieValidation to #[error(transparent)]

### DIFF
--- a/vm/src/vm/errors/cairo_run_errors.rs
+++ b/vm/src/vm/errors/cairo_run_errors.rs
@@ -7,7 +7,9 @@ use crate::types::errors::program_errors::ProgramError;
 use crate::vm::errors::{
     runner_errors::RunnerError, trace_errors::TraceError, vm_errors::VirtualMachineError,
 };
-
+// In case you need to add a CairoRunError enum variant
+// Add it with #[error(transparent)]
+// If not it can cause some performance regressions, like in https://github.com/lambdaclass/cairo-vm/pull/1720
 #[derive(Debug, Error)]
 pub enum CairoRunError {
     #[error(transparent)]

--- a/vm/src/vm/errors/cairo_run_errors.rs
+++ b/vm/src/vm/errors/cairo_run_errors.rs
@@ -22,6 +22,6 @@ pub enum CairoRunError {
     MemoryError(#[from] MemoryError),
     #[error(transparent)]
     VmException(#[from] VmException),
-    #[error("Cairo Pie validation failed: {0}")]
+    #[error(transparent)]
     CairoPieValidation(#[from] CairoPieValidationError),
 }


### PR DESCRIPTION
# Chage CairoPieValidation to  #[error(transparent)]
Change  CairoPieValidation to #[error(transparent)], to revert performance regretions in #1720

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

