### PR TITLE
[Cairo 1] Fix handling of return values wrapped in `PanicResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* bugifix: Fix handling of return values wrapped in `PanicResult` in cairo1-run crate [#1763](https://github.com/lambdaclass/cairo-vm/pull/1763)
+
 * refactor(BREAKING): Move the VM back to the CairoRunner [#1743](https://github.com/lambdaclass/cairo-vm/pull/1743)
   * `CairoRunner` has a new public field `vm: VirtualMachine`
   * `CairoRunner` no longer derives `Debug`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* bugifix: Fix handling of return values wrapped in `PanicResult` in cairo1-run crate [#1763](https://github.com/lambdaclass/cairo-vm/pull/1763)
+* bugfix: Fix handling of return values wrapped in `PanicResult` in cairo1-run crate [#1763](https://github.com/lambdaclass/cairo-vm/pull/1763)
 
 * refactor(BREAKING): Move the VM back to the CairoRunner [#1743](https://github.com/lambdaclass/cairo-vm/pull/1743)
   * `CairoRunner` has a new public field `vm: VirtualMachine`

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -683,7 +683,7 @@ fn result_inner_type_size(
         })
         .unwrap_or_default()
     {
-        let return_type_info = get_info(&sierra_program_registry, return_type_id.as_ref().unwrap());
+        let return_type_info = get_info(sierra_program_registry, return_type_id.as_ref().unwrap());
         let inner_type_size = *match return_type_info {
             Some(info) => {
                 // We already know info.long_id.generic_args[0] contains the Panic variant

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -683,20 +683,15 @@ fn result_inner_type_size(
         })
         .unwrap_or_default()
     {
-        let return_type_info = get_info(sierra_program_registry, return_type_id.as_ref().unwrap());
-        let inner_type_size = *match return_type_info {
-            Some(info) => {
-                // We already know info.long_id.generic_args[0] contains the Panic variant
-                let inner_args = &info.long_id.generic_args[1];
-                let inner_type = match inner_args {
-                    GenericArg::Type(type_id) => type_id,
-                    _ => unreachable!(),
-                };
-                type_sizes.get(inner_type).unwrap()
-            }
+        let return_type_info =
+            get_info(sierra_program_registry, return_type_id.as_ref().unwrap()).unwrap();
+        // We already know info.long_id.generic_args[0] contains the Panic variant
+        let inner_args = &return_type_info.long_id.generic_args[1];
+        let inner_type = match inner_args {
+            GenericArg::Type(type_id) => type_id,
             _ => unreachable!(),
         };
-        Some(inner_type_size)
+        type_sizes.get(inner_type).copied()
     } else {
         None
     }


### PR DESCRIPTION
Now properly accounts for PanicResult enum padding when fetching return values. Removes workaround used to handle this bug in the specific case of array/span returns

