### PR TITLE
Merged hint temporary segments by cheatcode hint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "clap",
  "itertools 0.11.0",
  "mimalloc",
+ "num-bigint",
  "num-traits 0.2.18",
  "rstest",
  "serde_json",

--- a/cairo1-run/Cargo.toml
+++ b/cairo1-run/Cargo.toml
@@ -29,6 +29,7 @@ assert_matches = "1.5.0"
 rstest = "0.17.0"
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
 num-traits = { version = "0.2", default-features = false }
+num-bigint.workspace = true
 
 [features]
 default = ["with_mimalloc"]


### PR DESCRIPTION
# Proper Segment Arena parts handling.

## Description

Added a finalization part for the dictionaries manager, that adds the relocation rules.
Calling it from a cheat code call by the cairo1 runner.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

