### PR TITLE
[Cairo 1] Handle `BoundedInt` variant in `serialize_output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: Handle `BoundedInt` variant in `serialize_output`, `cairo1-run` crate  [#1768](https://github.com/lambdaclass/cairo-vm/pull/1768)
+
 * feat: Load arguments into VM instead of creating them via instructions in cairo1-run [#1759](https://github.com/lambdaclass/cairo-vm/pull/1759)
 
 #### [1.0.0-rc3] - 2024-05-14

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -957,6 +957,7 @@ fn serialize_output_inner<'a>(
             unimplemented!("Not supported in the current version")
         },
         cairo_lang_sierra::extensions::core::CoreTypeConcrete::Felt252(_)
+        | cairo_lang_sierra::extensions::core::CoreTypeConcrete::BoundedInt(_)
         // Only unsigned integer values implement Into<Bytes31>
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Bytes31(_)
         | cairo_lang_sierra::extensions::core::CoreTypeConcrete::Uint8(_)


### PR DESCRIPTION
Handles `BoundedInt` as integer value when serializing
