### PR TITLE
fix: make `OutputBuiltinState` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * feat: Handle `BoundedInt` variant in `serialize_output`, `cairo1-run` crate  [#1768](https://github.com/lambdaclass/cairo-vm/pull/1768)
 
+* fix: make `OutputBuiltinState` public [#1769](https://github.com/lambdaclass/cairo-vm/pull/1769)
+
 * feat: Load arguments into VM instead of creating them via instructions in cairo1-run [#1759](https://github.com/lambdaclass/cairo-vm/pull/1759)
 
 #### [1.0.0-rc3] - 2024-05-14

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -48,7 +48,7 @@ pub use hash::HashBuiltinRunner;
 pub use keccak::KeccakBuiltinRunner;
 pub use modulo::ModBuiltinRunner;
 use num_integer::div_floor;
-pub use output::OutputBuiltinRunner;
+pub use output::{OutputBuiltinRunner, OutputBuiltinState};
 pub use poseidon::PoseidonBuiltinRunner;
 pub use range_check::RangeCheckBuiltinRunner;
 pub use segment_arena::SegmentArenaBuiltinRunner;


### PR DESCRIPTION
The output state related functions (ex: `set_state`) are unusable if this struct is private.

Context: Cairo bootloader support.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

