### PR TITLE
fix: make MemorySegmentManager.finalize() public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: make MemorySegmentManager.finalize() public [#1771](https://github.com/lambdaclass/cairo-vm/pull/1771)
+
 * feat(BREAKING): Serialize `Array<Felt252>` return value into output segment in cairo1-run crate:
   * Checks that only `PanicResult<Array<Felt252>>` or `Array<Felt252>` can be returned by the program when running with either `--proof_mode` or `--append_return_values`.
   * Serializes return values into the output segment under the previous conditions following the format:

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -270,7 +270,7 @@ impl MemorySegmentManager {
     // * size - The size of the segment (to be used in relocate_segments).
     // * public_memory - A list of offsets for memory cells that will be considered as public
     // memory.
-    pub(crate) fn finalize(
+    pub fn finalize(
         &mut self,
         size: Option<usize>,
         segment_index: usize,


### PR DESCRIPTION
Context: this method is used in some of the bootloader hints, see [here](https://github.com/starkware-libs/cairo-lang/blob/351e92a4ea5010e19f9da8e1d01b4eb06d37cf27/src/starkware/cairo/bootloaders/simple_bootloader/execute_task.cairo#L89).

We are currently taking out the bootloader hints out of our fork of `cairo-vm` so we need this method to be public. This is among the last changes required to get this done and use upstream `cairo-vm` (probably one more change related to the initial value of `exec_scopes` but that's it).

Alternative solutions:
1. Implement this hint in cairo-vm directly: this hint comes with quite a lot of code that is specific to the bootloader. I think it's simpler to make `finalize()` public, maybe with a disclaimer explaining why it's public to avoid mistakes.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

