### PR TITLE
feat: load Cairo PIE from bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * fix: make MemorySegmentManager.finalize() public [#1771](https://github.com/lambdaclass/cairo-vm/pull/1771)
 
+* feat: load Cairo PIE from bytes [#1773](https://github.com/lambdaclass/cairo-vm/pull/1773)
+
 * feat(BREAKING): Serialize `Array<Felt252>` return value into output segment in cairo1-run crate:
   * Checks that only `PanicResult<Array<Felt252>>` or `Array<Felt252>` can be returned by the program when running with either `--proof_mode` or `--append_return_values`.
   * Serializes return values into the output segment under the previous conditions following the format:

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -268,12 +268,10 @@ impl CairoPie {
     }
 
     #[cfg(feature = "std")]
-    pub fn read_zip_file(file_path: &Path) -> Result<CairoPie, std::io::Error> {
+    pub fn from_zip_archive<R: std::io::Read + std::io::Seek>(
+        mut zip_reader: zip::ZipArchive<R>,
+    ) -> Result<CairoPie, std::io::Error> {
         use std::io::Read;
-        use zip::ZipArchive;
-
-        let file = File::open(file_path)?;
-        let mut zip_reader = ZipArchive::new(file)?;
 
         let reader = std::io::BufReader::new(zip_reader.by_name("version.json")?);
         let version: CairoPieVersion = serde_json::from_reader(reader)?;
@@ -299,6 +297,22 @@ impl CairoPie {
             additional_data,
             version,
         })
+    }
+
+    #[cfg(feature = "std")]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, std::io::Error> {
+        let reader = std::io::Cursor::new(bytes);
+        let zip_archive = zip::ZipArchive::new(reader)?;
+
+        Self::from_zip_archive(zip_archive)
+    }
+
+    #[cfg(feature = "std")]
+    pub fn read_zip_file(path: &Path) -> Result<Self, std::io::Error> {
+        let file = File::open(path)?;
+        let zip = zip::ZipArchive::new(file)?;
+
+        Self::from_zip_archive(zip)
     }
 }
 


### PR DESCRIPTION
Context: bootloader support.

Like for programs, it is convenient to be able to load Cairo PIEs directly from bytes. Added a `from_bytes()` method to `CairoPie`. This method shares most of its code with `read_from_file()`.

# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

