### PR TITLE
Move dict finalization to `FinalizeDict` Hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,8 +483,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d9c31baeb6b52586b5adc88f01e90f86389d63d94363c562de5c79352e545b"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -497,8 +496,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7148cb2d72a3db24a6d2ef2b2602102cc5099cb9f6b913e5047fb009cb3a22a1"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -520,8 +518,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a761eb8e31ea65a2dd45f729c74f1770315f97124dad93d1f6853a10d460c6b"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-utils",
 ]
@@ -529,8 +526,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-defs"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d60bc5d72fe7a95ba34e041dcbdf1cf3bfccb87008a515514b74913fa8ff05"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -546,8 +542,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356089e1b0a0ba9e115566191745613b3806a20259ad76764df82ab534d5412a"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -558,8 +553,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc43246cc2e5afd5a028bcdd63876ac3f8b1f4fb3ff785daaa0f0fbb51c9d906"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -568,8 +562,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcb9a4a40e53fa099774bd08bbcc3430f51213cc7fb1b50c2e9d01155731798"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -582,8 +575,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba60e1e2477aa0f610ccf29189097d580464607c94b51741e1c18e64d6cee5f"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -607,8 +599,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16ba1535e0cc5e79c2eff6592859bbdac03dc53d4dcdd26dbdbc04a77c3f5c"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -627,8 +618,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c8cf6e0ee3d6b19429cc1663738b22f1ecea7d51bf7452e8e1086f08798baf"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -646,8 +636,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f9da66325ce7ed6c002360f26106fe79deb9f8a2fca30abdbb8d388da7bb46"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -657,8 +646,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e198af1ab3d05c7fb8b6a9a7a2e9bce245a6c855df5f770b751d29874a23b152"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -671,8 +659,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7df81521c2125e3e95b683cc99374db1aebd7ddb317c5ca3dd92a235a9eb13"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -696,8 +683,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da3ca1434c62a7cc7cd77d2941ef47a1c23b37325781b59407b78d8c61d863"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -722,8 +708,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122c9055eb609a511178e3dce577de061819fd4c4c6b7452804557f76ca43bbf"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -737,8 +722,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf049d9aea65c6e38da219a3700c72f78795d11449d9adcec28047ef8d63bd23"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -752,8 +736,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d75e0830279ca1bd0189e3326720d6e081225f7d81ed060bbd22c6b37e980"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -775,8 +758,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3c3be88c8562fbf93b0803c186e7282f6daad93576c07f61b04a591fde468f"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -796,8 +778,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-type-size"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38da6f98c6b16945c89d2ae351c82d636ed38d3e6eb02f7c8679e3e03a63988"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -806,8 +787,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9ffa8b3b8c47138c36b1907cebb5047dfc4de29ec10ece5bd6d6853243ec50"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -837,8 +817,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet-classes"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c64ae2bb00173e3a88760128bf72de356fa80eb19fa47602479063648b4003"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-felt",
  "cairo-lang-casm",
@@ -862,8 +841,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8262c426a57e1e5ec297db24278464841500613445e2cb1c43d5f71ad91ee8d6"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -878,8 +856,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e2d692eae4bb4179a4a1148fd5eb738a91653d86750c813658ffad4a99fa97"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "genco",
  "xshell",
@@ -888,8 +865,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf733a7cdc4166d0baf0ed8a98d9ada827daee6653b37d9326e334e53481c6d3"
+source = "git+https://github.com/lambdaclass/cairo.git?branch=finalize-dict-hint-sierra-v1.5.0#e3e205512306c87aebeb0d350a7e21d6b6431468"
 dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,15 +66,15 @@ thiserror-no-std = { version = "2.0.2", default-features = false }
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 
 # Dependencies for cairo-1-hints feature
-cairo-lang-starknet = { version = "2.6.3", default-features = false }
-cairo-lang-casm = { version = "2.6.3", default-features = false }
+cairo-lang-starknet = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-casm = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
 
-cairo-lang-starknet-classes = { version = "2.6.3", default-features = false }
-cairo-lang-compiler = { version = "2.6.3", default-features = false }
-cairo-lang-sierra-to-casm = { version = "2.6.3", default-features = false }
-cairo-lang-sierra = { version = "2.6.3", default-features = false }
-cairo-lang-runner = { version = "2.6.3", default-features = false }
-cairo-lang-utils = { version = "2.6.3", default-features = false }
+cairo-lang-starknet-classes = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-compiler = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-sierra-to-casm = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-sierra = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-runner = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-utils = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
 
 # TODO: check these dependencies for wasm compatibility
 ark-ff = { version = "0.4.2", default-features = false }

--- a/cairo1-run/Cargo.toml
+++ b/cairo1-run/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 cairo-vm = {workspace = true, features = ["std", "cairo-1-hints", "clap"]}
 serde_json = { workspace = true }
 
-cairo-lang-sierra-type-size = { version = "2.6.3", default-features = false }
-cairo-lang-sierra-ap-change = { version = "2.6.3", default-features = false }
-cairo-lang-sierra-gas = { version = "2.6.3", default-features = false }
+cairo-lang-sierra-type-size = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-sierra-ap-change = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
+cairo-lang-sierra-gas = { git = "https://github.com/lambdaclass/cairo.git", branch = "finalize-dict-hint-sierra-v1.5.0", default-features = false }
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
 cairo-lang-compiler.workspace = true

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -92,7 +92,7 @@ impl DictManagerExecScope {
         vm: &mut VirtualMachine,
         dict_end: Relocatable,
     ) -> Result<(), HintError> {
-        let tracker_idx = self.get_dict_infos_index(dict_end).unwrap();
+        let tracker_idx = self.get_dict_infos_index(dict_end)?;
         if self.trackers[tracker_idx].start.segment_index >= 0 {
             // The dict is already on a real segment so we don't need to relocate it
             // This is the case of the first dictionary

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -52,7 +52,7 @@ impl DictManagerExecScope {
                 .next_start
                 .unwrap_or_else(|| vm.add_temporary_segment()),
         };
-        let tracker: DictTrackerExecScope = DictTrackerExecScope::new(dict_segment);
+        let tracker = DictTrackerExecScope::new(dict_segment);
         // Not checking if overriding - since overriding is allowed.
         self.segment_to_tracker
             .insert(dict_segment.segment_index, self.trackers.len());

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -96,7 +96,7 @@ impl DictManagerExecScope {
         if self.trackers[tracker_idx].start.segment_index >= 0 {
             // The dict is already on a real segment so we don't need to relocate it
             // This is the case of the first dictionary
-            self.trackers[tracker_idx].next_start = (dict_end + 1u32).ok();
+            self.trackers[tracker_idx].next_start = Some(dict_end);
         } else {
             // Finalize & relocate the dictionary
             // The first dictionary will always be on a real segment so we can be sure that a previous dictionary exists here

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -97,6 +97,16 @@ impl DictManagerExecScope {
             // The dict is already on a real segment so we don't need to relocate it
             // This is the case of the first dictionary
             self.trackers[tracker_idx].next_start = Some(dict_end);
+
+            // Check if the next dict has been finalized but not relocated
+            if let Some(next_dict) = self.trackers.get(tracker_idx + 1) {
+                // Has been finalized but not relocated
+                if next_dict.next_start.is_some_and(|r| r.segment_index < 0) {
+                    // As the next dict has already been finalized and the current one has been relocated
+                    // we know that this call will relocate the next dict
+                    self.finalize_segment(vm, next_dict.next_start.unwrap())?;
+                }
+            }
         } else {
             // Finalize & relocate the dictionary
             // The first dictionary will always be on a real segment so we can be sure that a previous dictionary exists here
@@ -121,7 +131,7 @@ impl DictManagerExecScope {
                 }
                 _ => {
                     // Store the temporary next_start so we can properly finalize it later
-                    self.trackers[tracker_idx].next_start = (dict_end + 1_u32).ok();
+                    self.trackers[tracker_idx].next_start = Some(dict_end);
                 }
             }
         }


### PR DESCRIPTION
This changes depend on the compiler changes in fork branch https://github.com/lambdaclass/cairo/tree/finalize-dict-hint-sierra-v1.5.0
Modifies `DictManager.finalize_segment` so that it relocates the current dictionary instead of relocating the next one.
Implements the new `FinalizeDict` hint

