### PR TITLE
[Cairo1] Use a cheatcode to relocate all dicts + Make temporary segment usage configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 #### Upcoming Changes
 
+* feat(BREAKING): Use a cheatcode to relocate all dicts + Make temporary segment usage configurable [#1776](https://github.com/lambdaclass/cairo-vm/pull/1776)
+  * Add the flags `segment_arena_validation` & `use_temporary_segments` to the `Cairo1HintProcessor` & `DictManagerExecScope` respectively. These flags will determine if real segments or temporary segments will be used when creating dictionaries.
+  * `DictManagerExecScope::finalize_segment` no longer performs relocation and is ignored if `use_temporary_segments` is set to false.
+  * Add method `DictManagerExecScope::relocate_all_dictionaries` that adds relocation rules for all tracked dictionaries, relocating them one next to the other in a new segment.
+  * Add cheatcode `RelocateAllDictionaries` to the `Cairo1HintProcessor`, which calls the aforementioned method.
+  * Add casm instruction to call the aforementioned cheatcode in `create_entry_code` if either `proof_mode` or `append_return_values` are set to true, and segment arena is present.
+
 * feat(BREAKING): Serialize inputs into output segment in cairo1-run crate:
   * Checks that only `Array<Felt252>` can be received by the program main function when running with with either `--proof_mode` or `--append_return_values`.
   * Copies the input value to the output segment right after the output in the format `[array_len, arr[0], arr[1],.., arr[n]]`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "clap",
  "itertools 0.11.0",
  "mimalloc",
+ "num-bigint",
  "num-traits 0.2.18",
  "rstest",
  "serde_json",

--- a/cairo1-run/Cargo.toml
+++ b/cairo1-run/Cargo.toml
@@ -29,6 +29,7 @@ assert_matches = "1.5.0"
 rstest = "0.17.0"
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
 num-traits = { version = "0.2", default-features = false }
+num-bigint.workspace = true
 
 [features]
 default = ["with_mimalloc"]

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -736,7 +736,7 @@ fn create_entry_code(
                     selector: BigIntAsHex {
                         value: BigInt::from_bytes_be(
                             Sign::Plus,
-                            "FinalizeDictionarySegments".as_bytes(),
+                            "RelocateAllDictionaries".as_bytes(),
                         ),
                     },
                     input_start: ignored_in.clone(),

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -726,10 +726,10 @@ fn create_entry_code(
         let local = ctx.add_var(CellExpression::Deref(deref!([fp])));
         casm_build_extend!(ctx, assert local = output_ptr;);
         if got_segment_arena {
-        // We re-scoped when serializing the output so we have to create a var for the segment arena
-        // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0
-        let off = 2 * builtins.len() + 2;
-        let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([fp + off as i16])));
+            // We re-scoped when serializing the output so we have to create a var for the segment arena
+            // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0
+            let off = 2 * builtins.len() + 2;
+            let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([fp + off as i16])));
             // Call the hint that will relocate all dictionaries
             ctx.add_hint(
                 |[ignored_in], [ignored_out]| StarknetHint::Cheatcode {

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -181,7 +181,7 @@ pub fn cairo_run_program(
 
     let (processor_hints, program_hints) = build_hints_vec(instructions.clone());
 
-    let mut hint_processor = Cairo1HintProcessor::new(&processor_hints, RunResources::default());
+    let mut hint_processor = Cairo1HintProcessor::new(&processor_hints, RunResources::default(), cairo_run_config.append_return_values || cairo_run_config.proof_mode);
 
     let data: Vec<MaybeRelocatable> = instructions
         .flat_map(|inst| inst.assemble().encode())

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -181,7 +181,11 @@ pub fn cairo_run_program(
 
     let (processor_hints, program_hints) = build_hints_vec(instructions.clone());
 
-    let mut hint_processor = Cairo1HintProcessor::new(&processor_hints, RunResources::default(), cairo_run_config.append_return_values || cairo_run_config.proof_mode);
+    let mut hint_processor = Cairo1HintProcessor::new(
+        &processor_hints,
+        RunResources::default(),
+        cairo_run_config.append_return_values || cairo_run_config.proof_mode,
+    );
 
     let data: Vec<MaybeRelocatable> = instructions
         .flat_map(|inst| inst.assemble().encode())
@@ -725,6 +729,7 @@ fn create_entry_code(
         let output_ptr = ctx.add_var(CellExpression::Deref(deref!([ap - 1])));
         let local = ctx.add_var(CellExpression::Deref(deref!([fp])));
         casm_build_extend!(ctx, assert local = output_ptr;);
+
         if got_segment_arena {
             // We re-scoped when serializing the output so we have to create a var for the segment arena
             // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -233,6 +233,7 @@ pub fn cairo_run_program(
         cairo_run_config.trace_enabled,
     )?;
     let end = runner.initialize(cairo_run_config.proof_mode)?;
+    load_arguments(&mut runner, &cairo_run_config, main_func)?;
 
     // Run it until the end / infinite loop in proof_mode
     runner.run_until_pc(end, &mut hint_processor)?;

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -4,7 +4,7 @@ use cairo_lang_casm::{
     casm, casm_build_extend,
     cell_expression::CellExpression,
     deref, deref_or_immediate,
-    hints::Hint,
+    hints::{Hint, StarknetHint},
     inline::CasmContext,
     instructions::{Instruction, InstructionBody},
 };
@@ -31,7 +31,9 @@ use cairo_lang_sierra_to_casm::{
     metadata::calc_metadata_ap_change_only,
 };
 use cairo_lang_sierra_type_size::get_type_size_map;
-use cairo_lang_utils::{casts::IntoOrPanic, unordered_hash_map::UnorderedHashMap};
+use cairo_lang_utils::{
+    bigint::BigIntAsHex, casts::IntoOrPanic, unordered_hash_map::UnorderedHashMap,
+};
 use cairo_vm::{
     hint_processor::cairo_1_hint_processor::hint_processor::Cairo1HintProcessor,
     math_utils::signed_felt,
@@ -48,6 +50,7 @@ use cairo_vm::{
     Felt252,
 };
 use itertools::{chain, Itertools};
+use num_bigint::{BigInt, Sign};
 use num_traits::{cast::ToPrimitive, Zero};
 use std::{collections::HashMap, iter::Peekable};
 
@@ -230,7 +233,6 @@ pub fn cairo_run_program(
         cairo_run_config.trace_enabled,
     )?;
     let end = runner.initialize(cairo_run_config.proof_mode)?;
-    load_arguments(&mut runner, &cairo_run_config, main_func)?;
 
     // Run it until the end / infinite loop in proof_mode
     runner.run_until_pc(end, &mut hint_processor)?;
@@ -722,12 +724,28 @@ fn create_entry_code(
         let output_ptr = ctx.add_var(CellExpression::Deref(deref!([ap - 1])));
         let local = ctx.add_var(CellExpression::Deref(deref!([fp])));
         casm_build_extend!(ctx, assert local = output_ptr;);
-
         if got_segment_arena {
-            // We re-scoped when serializing the output so we have to create a var for the segment arena
-            // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0
-            let off = 2 * builtins.len() + 2;
-            let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([fp + off as i16])));
+        // We re-scoped when serializing the output so we have to create a var for the segment arena
+        // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0
+        let off = 2 * builtins.len() + 2;
+        let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([fp + off as i16])));
+            // Call the hint that will relocate all dictionaries
+            ctx.add_hint(
+                |[ignored_in], [ignored_out]| StarknetHint::Cheatcode {
+                    selector: BigIntAsHex {
+                        value: BigInt::from_bytes_be(
+                            Sign::Plus,
+                            "FinalizeDictionarySegments".as_bytes(),
+                        ),
+                    },
+                    input_start: ignored_in.clone(),
+                    input_end: ignored_in,
+                    output_start: ignored_out,
+                    output_end: ignored_out,
+                },
+                [segment_arena_ptr],
+                [segment_arena_ptr],
+            );
             // Validating the segment arena's segments are one after the other.
             casm_build_extend! {ctx,
                 tempvar n_segments = segment_arena_ptr[-2];

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -25,7 +25,7 @@ pub struct DictManagerExecScope {
     segment_to_tracker: HashMap<isize, usize>,
     /// The actual trackers of the dictionaries, in the order of allocation.
     trackers: Vec<DictTrackerExecScope>,
-    // If set to true, dictionaries will be created on temporary segments and will then be relocated into a single segment by the end of the run
+    // If set to true, dictionaries will be created on temporary segments which can then be relocated into a single segment by the end of the run
     // If set to false, each dictionary will use a single real segment
     use_temporary_segments: bool,
 }

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -60,10 +60,15 @@ impl DictManagerExecScope {
             vm.add_memory_segment()
         };
         let tracker = DictTrackerExecScope::new(dict_segment);
-        assert!(self
+        if self
             .segment_to_tracker
             .insert(dict_segment.segment_index, self.trackers.len())
-            .is_none());
+            .is_some()
+        {
+            return Err(HintError::CantCreateDictionaryOnTakenSegment(
+                dict_segment.segment_index,
+            ));
+        }
 
         self.trackers.push(tracker);
         Ok(dict_segment)

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -124,7 +124,7 @@ impl DictManagerExecScope {
             let mut prev_end = vm.add_memory_segment();
             for tracker in &self.trackers {
                 vm.add_relocation_rule(tracker.start, prev_end)?;
-                prev_end += (tracker.end.unwrap() - tracker.start)?;
+                prev_end += (tracker.end.unwrap_or_default() - tracker.start)?;
                 prev_end += 1;
             }
         }

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -79,7 +79,7 @@ impl DictManagerExecScope {
 
     /// Finalizes a segment of a dictionary.
     pub fn finalize_segment(&mut self, dict_end: Relocatable) -> Result<(), HintError> {
-        let tracker_idx = self.get_dict_infos_index(dict_end).unwrap();
+        let tracker_idx = self.get_dict_infos_index(dict_end)?;
         let tracker = &mut self.trackers[tracker_idx];
         if let Some(prev) = tracker.end {
             return Err(HintError::CustomHint(
@@ -94,8 +94,8 @@ impl DictManagerExecScope {
         Ok(())
     }
 
-    /// Finalizes all segments of dictionaries by adding relocation rules to merge them.
-    pub fn finalize_all_segments(&mut self, vm: &mut VirtualMachine) -> Result<(), HintError> {
+    /// Relocates all dictionaries into a single segment
+    pub fn relocate_all_dictionaries(&mut self, vm: &mut VirtualMachine) -> Result<(), HintError> {
         let mut prev_end = vm.add_memory_segment();
         for tracker in &self.trackers {
             vm.add_relocation_rule(tracker.start, prev_end)?;

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -60,7 +60,11 @@ pub struct Cairo1HintProcessor {
 }
 
 impl Cairo1HintProcessor {
-    pub fn new(hints: &[(usize, Vec<Hint>)], run_resources: RunResources, segment_arena_validations: bool) -> Self {
+    pub fn new(
+        hints: &[(usize, Vec<Hint>)],
+        run_resources: RunResources,
+        segment_arena_validations: bool,
+    ) -> Self {
         Self {
             hints: hints.iter().cloned().collect(),
             run_resources,

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -272,10 +272,10 @@ impl Cairo1HintProcessor {
                     HintError::CustomHint(Box::from("failed to parse selector".to_string()))
                 })?;
                 match selector {
-                    "FinalizeDictionarySegments" => {
+                    "RelocateAllDictionaries" => {
                         let dict_manager_exec_scope = exec_scopes
                             .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")?;
-                        dict_manager_exec_scope.finalize_all_segments(vm)
+                        dict_manager_exec_scope.relocate_all_dictionaries(vm)
                     }
                     _ => Err(HintError::UnknownHint(selector.into())),
                 }

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -54,6 +54,7 @@ fn get_beta() -> Felt252 {
 pub struct Cairo1HintProcessor {
     hints: HashMap<usize, Vec<Hint>>,
     run_resources: RunResources,
+    segment_arena_validations: bool,
 }
 
 impl Cairo1HintProcessor {
@@ -61,6 +62,7 @@ impl Cairo1HintProcessor {
         Self {
             hints: hints.iter().cloned().collect(),
             run_resources,
+            segment_arena_validations: false,
         }
     }
     // Runs a single Hint
@@ -166,7 +168,7 @@ impl Cairo1HintProcessor {
             })) => self.linear_split(vm, value, scalar, max_x, x, y),
 
             Hint::Core(CoreHintBase::Core(CoreHint::AllocFelt252Dict { segment_arena_ptr })) => {
-                self.alloc_felt_256_dict(vm, segment_arena_ptr, exec_scopes)
+                self.alloc_felt_252_dict(vm, segment_arena_ptr, exec_scopes)
             }
 
             Hint::Core(CoreHintBase::Core(CoreHint::AssertLeFindSmallArcs {
@@ -562,7 +564,7 @@ impl Cairo1HintProcessor {
         Err(HintError::KeyNotFound)
     }
 
-    fn alloc_felt_256_dict(
+    fn alloc_felt_252_dict(
         &self,
         vm: &mut VirtualMachine,
         segment_arena_ptr: &ResOperand,
@@ -591,7 +593,7 @@ impl Cairo1HintProcessor {
                 Err(_) => {
                     exec_scopes.assign_or_update_variable(
                         "dict_manager_exec_scope",
-                        Box::<DictManagerExecScope>::default(),
+                        Box::new(DictManagerExecScope::new(self.segment_arena_validations)),
                     );
                     exec_scopes.get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")?
                 }

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -54,15 +54,17 @@ fn get_beta() -> Felt252 {
 pub struct Cairo1HintProcessor {
     hints: HashMap<usize, Vec<Hint>>,
     run_resources: RunResources,
+    /// If set to true, uses a single segment for dictionaries to aid in segment arena validations
+    /// WARNING: The program must call the "RelocateAllDictionaries" Cheatcode if the flag is enabled
     segment_arena_validations: bool,
 }
 
 impl Cairo1HintProcessor {
-    pub fn new(hints: &[(usize, Vec<Hint>)], run_resources: RunResources) -> Self {
+    pub fn new(hints: &[(usize, Vec<Hint>)], run_resources: RunResources, segment_arena_validations: bool) -> Self {
         Self {
             hints: hints.iter().cloned().collect(),
             run_resources,
-            segment_arena_validations: false,
+            segment_arena_validations,
         }
     }
     // Runs a single Hint

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -268,7 +268,7 @@ impl Cairo1HintProcessor {
             ),
             Hint::Starknet(StarknetHint::Cheatcode { selector, .. }) => {
                 let selector = &selector.value.to_bytes_be().1;
-                let selector = std::str::from_utf8(selector).map_err(|_| {
+                let selector = crate::stdlib::str::from_utf8(selector).map_err(|_| {
                     HintError::CustomHint(Box::from("failed to parse selector".to_string()))
                 })?;
                 match selector {

--- a/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/vm/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -604,7 +604,7 @@ fn fibonacci_with_run_resources_ok() {
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
-        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(621));
+        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(621), false);
     assert_matches!(
         run_cairo_1_entrypoint_with_run_resources(
             serde_json::from_slice(program_data.as_slice()).unwrap(),
@@ -625,7 +625,7 @@ fn fibonacci_with_run_resources_2_ok() {
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
-        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(1000));
+        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(1000), false);
     assert_matches!(
         run_cairo_1_entrypoint_with_run_resources(
             contract_class,
@@ -648,7 +648,7 @@ fn fibonacci_with_run_resources_error() {
     let contract_class: CasmContractClass = serde_json::from_slice(program_data).unwrap();
     // Program takes 621 steps
     let mut hint_processor =
-        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(100));
+        Cairo1HintProcessor::new(&contract_class.hints, RunResources::new(100), false);
     assert!(run_cairo_1_entrypoint_with_run_resources(
         contract_class,
         0,

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -108,7 +108,7 @@ fn run_cairo_1_entrypoint(
 ) {
     let contract_class: CasmContractClass = serde_json::from_slice(program_content).unwrap();
     let mut hint_processor =
-        Cairo1HintProcessor::new(&contract_class.hints, RunResources::default());
+        Cairo1HintProcessor::new(&contract_class.hints, RunResources::default(), false);
 
     let mut runner = CairoRunner::new(
         &(contract_class.clone().try_into().unwrap()),


### PR DESCRIPTION
Includes commits from #1767 

- Add the flags `segment_arena_validation` & `use_temporary_segments` to the `Cairo1HintProcessor` & `DictManagerExecScope` respectively. These flags will determine if real segments or temporary segments will be used when creating dictionaries
- `DictManagerExecScope::finalize_segment` no longer performs relocation and is ignored if `use_temporary_segments` is set to false
- Add method `DictManagerExecScope::relocate_all_dictionaries`  that adds relocation rules for all tracked dictionaries, relocating them one next to the other in a new segment.
- Add cheatcode `RelocateAllDictionaries` to the `Cairo1HintProcessor`, which calls the aforementioned method
- Add casm instruction to call the aforementioned cheatcode in `create_entry_code` if either `proof_mode` or `append_return_values` are set to true, and segment arena is present

TLDR: 

- Add a flag to allow choosing weather real or temporary segments will be used for dictionaries
- Add a cheatcode to relocate all dictionaries by the end of the program, instead of relocating while squashing

