### PR TITLE
refactor: Add boolean method `Cairo1RunConfig::copy_to_output` + Update Doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* refactor: Add boolean method Cairo1RunConfig::copy_to_output + Update Doc [#1778](https://github.com/lambdaclass/cairo-vm/pull/1778)
+
 * feat: Filter implicit arguments from return value in cairo1-run crate [#1775](https://github.com/lambdaclass/cairo-vm/pull/1775)
 
 * feat(BREAKING): Serialize inputs into output segment in cairo1-run crate:

--- a/cairo1-run/README.md
+++ b/cairo1-run/README.md
@@ -61,7 +61,7 @@ The cairo1-run cli supports the following optional arguments:
 
 * `--memory_file <MEMORY_FILE>`: Receives the name of a file and outputs the relocated memory into it
 
-* `--proof_mode`: Runs the program in proof_mode. Only allows `Array<felt252>` as return value.
+* `--proof_mode`: Runs the program in proof_mode. Only allows `Array<felt252>` as return and input value.
 
 * `--air_public_input <AIR_PUBLIC_INPUT>`: Receives the name of a file and outputs the AIR public inputs into it. Can only be used if proof_mode is also enabled.
 
@@ -69,7 +69,7 @@ The cairo1-run cli supports the following optional arguments:
 
 * `--cairo_pie_output <CAIRO_PIE_OUTPUT>`: Receives the name of a file and outputs the Cairo PIE into it. Can only be used if proof_mode, is not enabled.
 
-* `--append_return_values`: Adds extra instructions to the program in order to append the return values to the output builtin's segment. This is the default behaviour for proof_mode. Only allows `Array<felt252>` as return value.
+* `--append_return_values`: Adds extra instructions to the program in order to append the return and input values to the output builtin's segment. This is the default behaviour for proof_mode. Only allows `Array<felt252>` as return and input value.
 
 # Running scarb projects
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -109,7 +109,7 @@ impl Default for Cairo1RunConfig<'_> {
 }
 
 impl Cairo1RunConfig<'_> {
-    // Returns true if the flags in the config enable adding the output builtin and 
+    // Returns true if the flags in the config enable adding the output builtin and
     // copying input and output values into it's segment
     fn copy_to_output(&self) -> bool {
         self.append_return_values || self.proof_mode

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -89,7 +89,7 @@ pub struct Cairo1RunConfig<'a> {
     /// Should be true if either air_public_input or cairo_pie_output are needed
     /// Sets builtins stop_ptr by calling `final_stack` on each builtin
     pub finalize_builtins: bool,
-    /// Appends return values to the output segment. This is performed by default when running in proof_mode
+    /// Appends the return and input values to the output segment. This is performed by default when running in proof_mode
     pub append_return_values: bool,
 }
 

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -109,15 +109,17 @@ impl Default for Cairo1RunConfig<'_> {
 }
 
 impl Cairo1RunConfig<'_> {
+    // Returns true if the flags in the config enable adding the output builtin and 
+    // copying input and output values into it's segment
     fn copy_to_output(&self) -> bool {
         self.append_return_values || self.proof_mode
     }
 }
 
-// Runs a Cairo 1 program
-// Returns the runner after execution + the return values + the serialized return values (if serialize_output is enabled)
-// The return values will contain the memory values just as they appear in the VM, after removing the PanicResult enum (if present).
-// Except if either the flag append_return_values or proof_mode are enabled, in which case the return values will consist of its serialized form: [array_len, array[0], array[1], ..., array[array_len -1]]
+/// Runs a Cairo 1 program
+/// Returns the runner after execution + the return values + the serialized return values (if serialize_output is enabled)
+/// The return values will contain the memory values just as they appear in the VM, after removing the PanicResult enum (if present).
+/// Except if either the flag append_return_values or proof_mode are enabled, in which case the return values will consist of its serialized form: [array_len, array[0], array[1], ..., array[array_len -1]]
 pub fn cairo_run_program(
     sierra_program: &SierraProgram,
     cairo_run_config: Cairo1RunConfig,


### PR DESCRIPTION
Replaces instances of `cairo_run_config.proof_mode || cairo_run_config.append_return_values` with `cairo_run_config.copy_to_output()`
Updates Documentation to reflect previous changes
