### PR TITLE
[Cairo 1] Improve arg handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Upcoming Changes
 
+* refactor + bugfix: Improve arg handling for cairo1-run [#1782](https://github.com/lambdaclass/cairo-vm/pull/1782)
+  * Now uses ascii whitespace as separator, preventing errors when using newlines in args file
+  * No longer gets stuck on improperly-formatted arrays
+  * Returns an informative clap error upon invalid felt strings instead of unwrapping
+
 * refactor: Add boolean method Cairo1RunConfig::copy_to_output + Update Doc [#1778](https://github.com/lambdaclass/cairo-vm/pull/1778)
 
 * feat: Filter implicit arguments from return value in cairo1-run crate [#1775](https://github.com/lambdaclass/cairo-vm/pull/1775)

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -67,7 +67,7 @@ struct FuncArgs(Vec<FuncArg>);
 // and returning the array [f1, f2,.., fn] where fi = Felt::from_dec_str(si)
 fn process_array<'a>(iter:&mut impl Iterator<Item = &'a str>) -> FuncArg {
     let mut array = vec![];
-    while let Some(value) = iter.next() {
+    for value in iter {
         match value {
             "]" => break,
             _ => array.push(Felt252::from_dec_str(value).unwrap()),
@@ -79,9 +79,6 @@ fn process_array<'a>(iter:&mut impl Iterator<Item = &'a str>) -> FuncArg {
 // Parses a string of ascii whitespace separated values, containing either numbers or series of numbers wrapped in brackets
 // Returns an array of felts and felt arrays
 fn process_args(value: &str) -> Result<FuncArgs, String> {
-    if value.is_empty() {
-        return Ok(FuncArgs::default());
-    }
     let mut args = Vec::new();
     // Split input string into numbers and array delimiters
     let mut input = value.split_ascii_whitespace().flat_map(|mut x| {
@@ -96,10 +93,8 @@ fn process_args(value: &str) -> Result<FuncArgs, String> {
                 res.push(val)
             }
             res.push("]")
-        } else {
-            if !x.is_empty() {
-                res.push(x)
-            }
+        } else if !x.is_empty() {
+            res.push(x)
         }
         res
     });

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -63,8 +63,8 @@ struct Args {
 #[derive(Debug, Clone, Default)]
 struct FuncArgs(Vec<FuncArg>);
 
-// Processes an iterator of format [s1, s2,.., sn, "]", ...], stopping at the first "]" string
-// and returning the array [f1, f2,.., fn] where fi = Felt::from_dec_str(si)
+/// Processes an iterator of format [s1, s2,.., sn, "]", ...], stopping at the first "]" string
+/// and returning the array [f1, f2,.., fn] where fi = Felt::from_dec_str(si)
 fn process_array<'a>(iter: &mut impl Iterator<Item = &'a str>) -> Result<FuncArg, String> {
     let mut array = vec![];
     for value in iter {
@@ -79,8 +79,8 @@ fn process_array<'a>(iter: &mut impl Iterator<Item = &'a str>) -> Result<FuncArg
     Ok(FuncArg::Array(array))
 }
 
-// Parses a string of ascii whitespace separated values, containing either numbers or series of numbers wrapped in brackets
-// Returns an array of felts and felt arrays
+/// Parses a string of ascii whitespace separated values, containing either numbers or series of numbers wrapped in brackets
+/// Returns an array of felts and felt arrays
 fn process_args(value: &str) -> Result<FuncArgs, String> {
     let mut args = Vec::new();
     // Split input string into numbers and array delimiters


### PR DESCRIPTION
Fixes:
* Now uses ascii whitespace as separator, preventing errors when using newlines in args file
* No longer gets stuck on improperly-formatted arrays
* Returns an informative clap error upon invalid felt strings instead of unwrapping
