### PR TITLE
fix: revert breaking change on public input serialization

### DIFF
--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -34,7 +34,7 @@ mod mem_value_serde {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         if let Some(value) = value {
-            serializer.serialize_str(&format!("{:x}", value))
+            serializer.serialize_str(&format!("0x{:x}", value))
         } else {
             serializer.serialize_none()
         }
@@ -66,6 +66,7 @@ mod mem_value_serde {
         where
             E: de::Error,
         {
+            let value = value.strip_prefix("0x").unwrap_or(value);
             Felt252::from_hex(value)
                 .map_err(de::Error::custom)
                 .map(Some)


### PR DESCRIPTION
Problem: The 0x prefix was removed from public memory hex values in fe72ee0e95cf9f1761cfdc0759af12a68294c081. This is incompatible with the Stone prover and causes an exception.

Solution: revert the change.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

