### PR TITLE
Fix WASM32 compilation for Cairo1-run and cairo-vm

### DIFF
--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -141,6 +141,10 @@ pub fn cairo_run_program(
 
     let main_func = find_function(sierra_program, "::main")?;
 
+    #[cfg(target_pointer_width = "32")]
+    let initial_gas = 999999999_usize;
+
+    #[cfg(not(target_pointer_width = "32"))]
     let initial_gas = 9999999999999_usize;
 
     // Fetch return type data

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -37,7 +37,7 @@ test_utils = ["std", "dep:arbitrary", "starknet-types-core/arbitrary", "starknet
 extensive_hints = []
 
 [dependencies]
-zip = {version = "0.6.6", optional = true }
+zip = {version = "0.6.6", optional = true, default_features = false, features=["deflate"] }
 num-bigint = { workspace = true }
 rand = { workspace = true }
 num-traits = { workspace = true }
@@ -67,8 +67,6 @@ bitvec = { workspace = true }
 cairo-lang-starknet = { workspace = true, optional = true }
 cairo-lang-starknet-classes = { workspace = true, optional = true }
 cairo-lang-casm = { workspace = true, optional = true }
-
-# TODO: check these dependencies for wasm compatibility
 ark-ff = { workspace = true, optional = true }
 ark-std = { workspace = true, optional = true }
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(warnings)]
 #![forbid(unsafe_code)]
-#![cfg_attr(any(target_arch = "wasm32", not(feature = "std")), no_std)]
+#![cfg_attr(any(not(feature = "std")), no_std)]
 
 #[cfg(feature = "std")]
 include!("./with_std.rs");

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -373,7 +373,7 @@ pub(super) mod serde_impl {
 
     use super::CAIRO_PIE_VERSION;
     use super::{CairoPieMemory, Pages, PublicMemoryPage, SegmentInfo};
-    #[cfg(any(target_arch = "wasm32", no_std, not(feature = "std")))]
+    #[cfg(any(no_std, not(feature = "std")))]
     use crate::alloc::string::ToString;
     use crate::stdlib::prelude::{String, Vec};
     use crate::{


### PR DESCRIPTION
# Fix WASM32 compilation for Cairo1-run and cairo-vm

## Description

Running the following fails on `main`:
```cargo build --bin cairo1-run --target wasm32-unknown-unknown --release --no-default-features```

There are 4 issues:
 - `zip` is not wasm-compatible by default. This can be circumvented with appropriate feature flags.
 - `cairo1-run/src/cairo_run.rs` sets an initial gas to 9999999999999_usize which is bigger than `usize` on 32 bit platforms.  I'm _not_ sure it's actually safe to downgrade this to merely `999999999`.
 - Two lines in `vm/src/lib.rs` and `vm/src/vm/runners/cairo_pie.rs` pessimistically assume `wasm <=> no_std`,  when the former works just fine - we can be more precise.

I also remove a comment to check WASM compatibility with some libraries, as they are indeed compatible.

This PR fixes both `cairo1-run` and `cairo-vm` for WASM targets.