### PR TITLE
Fix: make coverage command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 #### Upcoming Changes
 
-* fix: change make coverage to execute cargo llvm-cov --html --workspace --features "test_utils, cairo-1-hints" [#1797](https://github.com/lambdaclass/cairo-vm/pull/1797)
-
 * fix: Remove validation of CairoPie memory values [#1783](https://github.com/lambdaclass/cairo-vm/pull/1783)
 
 * fix: Handle `GasBuiltin` in cairo1-run crate [#1789](https://github.com/lambdaclass/cairo-vm/pull/1789)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: change make coverage to execute cargo llvm-cov --html --workspace --features "test_utils, cairo-1-hints" [#1797](https://github.com/lambdaclass/cairo-vm/pull/1797)
+
 * fix: Remove validation of CairoPie memory values [#1783](https://github.com/lambdaclass/cairo-vm/pull/1783)
 
 * fix: Handle `GasBuiltin` in cairo1-run crate [#1789](https://github.com/lambdaclass/cairo-vm/pull/1789)

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ clippy:
 	cargo clippy --manifest-path fuzzer/Cargo.toml --all-targets
 
 coverage:
-	cargo llvm-cov report --lcov --output-path lcov.info
+	cargo llvm-cov --html --workspace --features "test_utils, cairo-1-hints"
 
 coverage-clean:
 	cargo llvm-cov clean

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ clippy:
 	cargo clippy --workspace --all-features --benches --examples --tests -- -D warnings
 	cargo clippy --manifest-path fuzzer/Cargo.toml --all-targets
 
-coverage:
+coverage: cairo_proof_programs cairo_test_programs cairo_1_test_contracts cairo_2_test_contracts
 	cargo llvm-cov --html --workspace --features "test_utils, cairo-1-hints"
 
 coverage-clean:


### PR DESCRIPTION
# Change coverage command

## Description

This PR changes make coverage command so that it executes the following command: 

`cargo llvm-cov --html --workspace --features "test_utils, cairo-1-hints"`

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.