### PR TITLE
fix: Deserialization of negative numbers in scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Fixed deserialization of negative numbers in scientific notation [#1804](https://github.com/lambdaclass/cairo-vm/pull/1804)
+
 #### [1.0.0-rc4] - 2024-07-05
 
 * chore: bump `cairo-lang-` dependencies to 2.6.4 [#1799](https://github.com/lambdaclass/cairo-vm/pull/1799)


### PR DESCRIPTION
Fix deserialization of negative numbers in scientific notation.

Instead of BigUInt::from_str_radix, it uses BigInt::from_str_radix. This is only relevant when parsing, as modulo is applied so the resulting number is positive anyway, and then converted to Felt.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

