### PR TITLE
Fix ambiguous keccak import in some external scenarios (v1.0.0-rc6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: ambiguous keccak module name use on external contexts
+
 #### [1.0.0-rc6] - 2024-07-22
 
 * chore: bump `cairo-lang-` dependencies to 2.7.0-rc.3 [#1807](https://github.com/lambdaclass/cairo-vm/pull/1807)
@@ -258,7 +260,7 @@
 * BREAKING: Remove `CairoRunner::add_additional_hash_builtin` & `VirtualMachine::disable_trace`[#1658](https://github.com/lambdaclass/cairo-vm/pull/1658)
 
 * feat: output builtin add_attribute method [#1691](https://github.com/lambdaclass/cairo-vm/pull/1691)
- 
+
 * feat: add a method to retrieve the output builtin from the VM [#1690](https://github.com/lambdaclass/cairo-vm/pull/1690)
 
 * feat: Add zero segment [#1668](https://github.com/lambdaclass/cairo-vm/pull/1668)

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -40,12 +40,12 @@ mod range_check;
 mod segment_arena;
 mod signature;
 
+pub use self::keccak::KeccakBuiltinRunner;
 pub(crate) use self::range_check::{RC_N_PARTS_96, RC_N_PARTS_STANDARD};
 use self::segment_arena::ARENA_BUILTIN_SIZE;
 pub use bitwise::BitwiseBuiltinRunner;
 pub use ec_op::EcOpBuiltinRunner;
 pub use hash::HashBuiltinRunner;
-pub use keccak::KeccakBuiltinRunner;
 pub use modulo::ModBuiltinRunner;
 use num_integer::div_floor;
 pub use output::{OutputBuiltinRunner, OutputBuiltinState};


### PR DESCRIPTION
The keccak pub module use can be ambiguous if a library consumer has a dependency with the same name.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

