### PR TITLE
Only initialize program builtins (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix(BREAKING): Only initialize program builtins instead of a preset list
+
 #### [1.0.0] - 2024-08-01
 
 * chore: bump `cairo-lang-` dependencies to 2.7.0 [#1813](https://github.com/lambdaclass/cairo-vm/pull/1813)


### PR DESCRIPTION
# Only initialize program builtins

closes #1814

## Description

Replace initialize_all_builtins for initialize_program_builtins

It also removes/changes tests that used the former function to comply with the new function

## Checklist
- [x] Linked to Github Issue