### PR TITLE
Fix memory holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * fix(BREAKING): [#1818](https://github.com/lambdaclass/cairo-vm/pull/1818): 
     * Fix `MemorySegmentManager::add_zero_segment` function when resizing a segment
-    * Signature change: `MemorySegmentManager::get_memory_holes` now receives  `builtin_segment_indexes: HashSet<usize>`
+    * Signature change(BREAKING): `MemorySegmentManager::get_memory_holes` now receives `builtin_segment_indexes: HashSet<usize>`
 
 * fix(BREAKING): Replace `CairoRunner` method `initialize_all_builtins` with `initialize_program_builtins`. Now it only initializes program builtins instead of all of them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * fix(BREAKING): [#1818](https://github.com/lambdaclass/cairo-vm/pull/1818): 
     * Fix `MemorySegmentManager::add_zero_segment` function when resizing a segment
-    * Signature change: `MemorySegmentManager::get_memory_holes` now recibes  `builtin_segment_indexes: HashSet<usize>`
+    * Signature change: `MemorySegmentManager::get_memory_holes` now receives  `builtin_segment_indexes: HashSet<usize>`
 
 * fix(BREAKING): Replace `CairoRunner` method `initialize_all_builtins` with `initialize_program_builtins`. Now it only initializes program builtins instead of all of them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Upcoming Changes
 
+* fix(BREAKING): [#1818](https://github.com/lambdaclass/cairo-vm/pull/1818): 
+    * Fix `MemorySegmentManager::add_zero_segment` function when resizing a segment
+    * Signature change: `MemorySegmentManager::get_memory_holes` now recibes  `builtin_segment_indexes: HashSet<usize>`
+
 * fix(BREAKING): Replace `CairoRunner` method `initialize_all_builtins` with `initialize_program_builtins`. Now it only initializes program builtins instead of all of them
 
 #### [1.0.0] - 2024-08-01

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -791,6 +791,7 @@ impl CairoRunner {
 
     /// Count the number of holes present in the segments.
     pub fn get_memory_holes(&self) -> Result<usize, MemoryError> {
+        // Grab builtin segment indexes, except for the output builtin
         let builtin_segment_indexes: HashSet<usize> = self
             .vm
             .builtin_runners

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -791,14 +791,15 @@ impl CairoRunner {
 
     /// Count the number of holes present in the segments.
     pub fn get_memory_holes(&self) -> Result<usize, MemoryError> {
-        let output_builtin_index = self
+        let builtin_segment_indexes: HashSet<usize> = self
             .vm
             .builtin_runners
             .iter()
-            .position(|b| b.name() == BuiltinName::output);
-        self.vm
-            .segments
-            .get_memory_holes(self.vm.builtin_runners.len(), output_builtin_index)
+            .filter(|b| b.name() != BuiltinName::output)
+            .map(|b| b.base())
+            .collect();
+
+        self.vm.segments.get_memory_holes(builtin_segment_indexes)
     }
 
     /// Check if there are enough trace cells to fill the entire diluted checks.

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -1005,4 +1005,42 @@ mod tests {
             Ok(x) if x == mayberelocatable!(2, 0)
         );
     }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_add_zero_segment() {
+        // Create MemorySegmentManager with program and execution segments
+        let mut memory_segment_manager = MemorySegmentManager::new();
+        memory_segment_manager.add();
+        memory_segment_manager.add();
+
+        // Add zero segment
+        memory_segment_manager.add_zero_segment(3);
+        assert_eq!(memory_segment_manager.zero_segment_index, 2);
+        assert_eq!(memory_segment_manager.zero_segment_size, 3);
+        assert_eq!(
+            &memory_segment_manager.memory.data[2],
+            &Vec::from([
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0))
+            ])
+        );
+
+        // Resize zero segment
+        memory_segment_manager.add_zero_segment(5);
+        assert_eq!(memory_segment_manager.zero_segment_index, 2);
+        assert_eq!(memory_segment_manager.zero_segment_size, 5);
+
+        assert_eq!(
+            &memory_segment_manager.memory.data[2],
+            &Vec::from([
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0)),
+                MemoryCell::new(MaybeRelocatable::from(0))
+            ])
+        );
+    }
 }

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -293,13 +293,18 @@ impl MemorySegmentManager {
         if self.zero_segment_index.is_zero() {
             self.zero_segment_index = self.add().segment_index as usize;
         }
+
+        let updated_zero_segment_size = max(self.zero_segment_size, size);
         // Fil zero segment with zero values until size is reached
-        for _ in 0..self.zero_segment_size.saturating_sub(size) {
+        for _ in 0..self
+            .zero_segment_size
+            .saturating_sub(updated_zero_segment_size - self.zero_segment_size)
+        {
             // As zero_segment_index is only accessible to the segment manager
             // we can asume that it is always valid and index direcly into it
             self.memory.data[self.zero_segment_index].push(MemoryCell::new(Felt252::ZERO.into()))
         }
-        self.zero_segment_size = max(self.zero_segment_size, size);
+        self.zero_segment_size = updated_zero_segment_size;
         self.zero_segment_index
     }
 

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -225,14 +225,11 @@ impl MemorySegmentManager {
             }
             let accessed_amount =
                 // Instead of marking the values in the zero segment until zero_segment_size as accessed we use zero_segment_size as accessed_amount
-                if !self.zero_segment_index.is_zero() && i == self.zero_segment_index {
-                    self.zero_segment_size
-                } else {
                     match self.memory.get_amount_of_accessed_addresses_for_segment(i) {
                         Some(accessed_amount) if accessed_amount > 0 => accessed_amount,
                         _ => continue,
-                    }
-                };
+                    };
+
             let segment_size = self
                 .get_segment_size(i)
                 .ok_or(MemoryError::MissingSegmentUsedSizes)?;

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -201,7 +201,8 @@ impl MemorySegmentManager {
     }
 
     /// Counts the memory holes (aka unaccessed memory cells) in memory
-    /// Receives the amount of builtins in the vm and the position of the output builtin within the builtins list if present
+    /// # Parameters
+    /// - `builtin_segment_indexes`: Set representing the segments indexes of the builtins initialized in the VM, except for the output builtin.
     pub fn get_memory_holes(
         &self,
         builtin_segment_indexes: HashSet<usize>,

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -282,17 +282,13 @@ impl MemorySegmentManager {
             self.zero_segment_index = self.add().segment_index as usize;
         }
 
-        let updated_zero_segment_size = max(self.zero_segment_size, size);
         // Fil zero segment with zero values until size is reached
-        for _ in 0..self
-            .zero_segment_size
-            .saturating_sub(updated_zero_segment_size - self.zero_segment_size)
-        {
+        for _ in 0..(size.saturating_sub(self.zero_segment_size)) {
             // As zero_segment_index is only accessible to the segment manager
             // we can asume that it is always valid and index direcly into it
             self.memory.data[self.zero_segment_index].push(MemoryCell::new(Felt252::ZERO.into()))
         }
-        self.zero_segment_size = updated_zero_segment_size;
+        self.zero_segment_size = max(self.zero_segment_size, size);
         self.zero_segment_index
     }
 

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -216,11 +216,14 @@ impl MemorySegmentManager {
             }
             let accessed_amount =
                 // Instead of marking the values in the zero segment until zero_segment_size as accessed we use zero_segment_size as accessed_amount
+                if !self.zero_segment_index.is_zero() && i == self.zero_segment_index {
+                    self.zero_segment_size
+                } else {
                     match self.memory.get_amount_of_accessed_addresses_for_segment(i) {
                         Some(accessed_amount) if accessed_amount > 0 => accessed_amount,
                         _ => continue,
-                    };
-
+                    }
+                };
             let segment_size = self
                 .get_segment_size(i)
                 .ok_or(MemoryError::MissingSegmentUsedSizes)?;

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -1,6 +1,6 @@
+use crate::stdlib::collections::HashSet;
 use core::cmp::max;
 use core::fmt;
-use std::collections::HashSet;
 
 use crate::vm::runners::cairo_pie::CairoPieMemory;
 use crate::Felt252;


### PR DESCRIPTION
# Fix `MemorySegmentManager::add_zero_segment`

* Fix `MemorySegmentManager::add_zero_segment` function when resizing a segment
* Signature change: `MemorySegmentManager::get_memory_holes` now receives  `builtin_segment_indexes: HashSet<usize>`

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

