### PR TITLE
Fix ensure-no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 #### Upcoming Changes
 
-* Fix CI: [#1825](https://github.com/lambdaclass/cairo-vm/pull/1825):
-    * Pins wasm-bindgen version to fix CI
-
 #### [1.0.1] - 2024-08-12
 
 * fix(BREAKING): [#1818](https://github.com/lambdaclass/cairo-vm/pull/1818): 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### Upcoming Changes
 
-* dummy change
+* Fix CI: [#1825](https://github.com/lambdaclass/cairo-vm/pull/1825):
+    * Pins wasm-bindgen version to fix CI
 
 #### [1.0.1] - 2024-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* dummy change
+
 #### [1.0.1] - 2024-08-12
 
 * fix(BREAKING): [#1818](https://github.com/lambdaclass/cairo-vm/pull/1818): 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "starknet-crypto",
  "starknet-types-core",
  "thiserror-no-std",
+ "wasm-bindgen",
  "wasm-bindgen-test",
  "zip",
 ]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -78,6 +78,10 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # Used to derive clap traits for CLIs
 clap = { version = "4.3.10", features = ["derive"], optional = true}
 
+# Pin wasm-bindgen version to fix ensure-no_std CI workflow
+# It's not used directly
+wasm-bindgen = { version = "= 0.2.92" }
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 rstest = { version = "0.17.0", default-features = false }


### PR DESCRIPTION
# Fix `ensure-no_std`

## Description

The `wasm-bindgen` crate was automatically updated by a dependency, and version `0.2.93` is no longer no-std compatible. I pinned the version `0.2.92` in Cargo.toml to fix this.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

