### PR TITLE
Bump pip cairo-lang to 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* chore: bump pip `cairo-lang` 0.13.2 [#1827](https://github.com/lambdaclass/cairo-vm/pull/1827)
+
 * chore: bump `cairo-lang-` dependencies to 2.7.1 [#1823](https://github.com/lambdaclass/cairo-vm/pull/1823)
 
 #### [1.0.1] - 2024-08-12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ bitarray==2.7.3
 fastecdsa==2.3.0
 sympy==1.11.1
 typeguard==2.13.3
-cairo-lang==0.13.1
+cairo-lang==0.13.2


### PR DESCRIPTION
Bump pip cairo-lang to 0.13.2

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

