### PR TITLE
refeactor cairo1-run to use no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,7 @@ dependencies = [
  "rstest",
  "serde_json",
  "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -2593,11 +2594,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2839,18 +2840,18 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3433,7 +3434,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3447,17 +3448,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -3466,7 +3456,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -3803,6 +3793,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-demo-cairo1"
+version = "1.0.1"
+dependencies = [
+ "cairo-vm",
+ "cairo1-run",
+ "console_error_panic_hook",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,15 +3992,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "vm",
     "hint_accountant",
     "examples/wasm-demo",
+    "examples/wasm-demo-cairo1",
     "cairo1-run",
     "cairo-vm-tracer",
     "examples/hyper_threading"
@@ -29,6 +30,7 @@ keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
 cairo-vm = { path = "./vm", version = "1.0.1", default-features = false }
+cairo1-run = { path = "./cairo1-run", version = "1.0.1", default-features = false }
 cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "1.0.1", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
@@ -90,6 +92,10 @@ opt-level = 2
 lto = "fat"
 
 [profile.release.package.wasm-demo]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+
+[profile.release.package.wasm-demo-cairo1]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
 

--- a/cairo1-run/Cargo.toml
+++ b/cairo1-run/Cargo.toml
@@ -23,7 +23,8 @@ cairo-lang-utils.workspace = true
 cairo-lang-casm.workspace = true
 itertools = "0.11.0"
 clap = { version = "4.3.10", features = ["derive"] }
-thiserror = { version = "1.0.40" }
+thiserror = { version = "1.0.40", optional = true }
+thiserror-no-std = { workspace = true }
 bincode.workspace = true
 assert_matches = "1.5.0"
 rstest = "0.17.0"
@@ -32,5 +33,11 @@ num-traits = { version = "0.2", default-features = false }
 num-bigint.workspace = true
 
 [features]
-default = ["with_mimalloc"]
+default = ["with_mimalloc", "cli"]
 with_mimalloc = ["dep:mimalloc"]
+cli = ["dep:thiserror"]
+
+[[bin]]
+name = "cairo1-run"
+path = "./src/main.rs"
+required-features = ["cli"]

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -47,11 +47,11 @@ use cairo_vm::{
         vm_core::VirtualMachine,
     },
     Felt252,
+    stdlib::{collections::HashMap, iter::Peekable, cmp, prelude::*}
 };
 use itertools::{chain, Itertools};
 use num_bigint::{BigInt, Sign};
 use num_traits::{cast::ToPrimitive, Zero};
-use std::{collections::HashMap, iter::Peekable};
 
 /// Representation of a cairo argument
 /// Can consist of a single Felt or an array of Felts
@@ -140,7 +140,7 @@ pub fn cairo_run_program(
 
     let main_func = find_function(sierra_program, "::main")?;
 
-    let initial_gas = 9999999999999_usize;
+    let initial_gas = 9_usize;//9999999999999_usize;
 
     // Fetch return type data
     let return_type_id = match main_func.signature.ret_types.last() {
@@ -1384,7 +1384,7 @@ fn serialize_output_inner<'a>(
             let mut max_variant_size = 0;
             for variant in &info.variants {
                 let variant_size = type_sizes.get(variant).unwrap();
-                max_variant_size = std::cmp::max(max_variant_size, *variant_size)
+                max_variant_size = cmp::max(max_variant_size, *variant_size)
             }
             for _ in 0..max_variant_size - type_sizes.get(variant_type_id).unwrap() {
                 // Remove padding

--- a/cairo1-run/src/error.rs
+++ b/cairo1-run/src/error.rs
@@ -10,12 +10,16 @@ use cairo_vm::{
     },
     Felt252,
 };
+#[cfg(feature = "cli")]
 use thiserror::Error;
+#[cfg(not(feature = "cli"))]
+use thiserror_no_std::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Invalid arguments")]
     Cli(#[from] clap::Error),
+    #[cfg(feature = "cli")]
     #[error("Failed to interact with the file system")]
     IO(#[from] std::io::Error),
     #[error(transparent)]

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -10,6 +10,7 @@ use cairo_vm::{
 };
 use clap::{Parser, ValueHint};
 use itertools::Itertools;
+use cairo_vm::stdlib::prelude::*;
 use std::{
     io::{self, Write},
     path::PathBuf,

--- a/examples/wasm-demo-cairo1/Cargo.toml
+++ b/examples/wasm-demo-cairo1/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wasm-demo-cairo1"
+description = "A demo using cairo-vm in a WASM environment"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+serde_json.workspace = true
+wasm-bindgen = "0.2.87"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.6", optional = true }
+
+cairo1-run = { workspace = true }
+cairo-vm = { workspace = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"

--- a/examples/wasm-demo-cairo1/README.md
+++ b/examples/wasm-demo-cairo1/README.md
@@ -1,0 +1,48 @@
+# Demo of `cairo-vm` on WebAssembly
+
+While cairo-vm is compatible with WebAssembly, it doesn't implement any bindings to it.
+Instead, create a new WebAssembly crate with cairo-vm as a dependency and implement the required functionality there.
+
+Since mimalloc is not automatically compilable to WebAssembly, the cairo-vm dependency should disable the default features, which will in turn disable mimalloc.
+
+A working example is provided in this repository.
+
+## Dependencies
+
+To compile and run the example you need:
+
+- a Cairo 0 compiler
+- the _wasm-pack_ crate
+- some HTTP server (for example: the `live-server` npm module)
+
+> **Note**
+> The first two dependencies can be installed via the repository's installation script (see ["Installation script"](../../README.md#installation-script))
+
+## Building
+
+To build the example, first compile your Cairo program:
+
+```sh
+cairo-compile ../../cairo_programs/array_sum.cairo --no_debug_info --output ../../cairo_programs/array_sum.json
+```
+
+And then the WebAssembly package:
+
+```sh
+wasm-pack build --target=web
+```
+
+This will generate a javascript module that is directly loadable by the browser.
+
+## Running
+
+To run the example webpage, you need to run an HTTP server.
+For example, using the _live-server_ npm module:
+
+```sh
+# while in <repo>/examples/wasm-demo
+npx live-server
+```
+
+> **Warning**
+> Trying to run `index.html` directly (i.e. URL starts with `file://`) will result in a CORS error.

--- a/examples/wasm-demo-cairo1/index.html
+++ b/examples/wasm-demo-cairo1/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>Cairo WebAssembly Demo</title>
+
+    <script type="module">
+        import init, { runCairoProgram } from './pkg/wasm_demo.js';
+
+        // Initialize WebAssembly module.
+        // Note: This calls the `start()` function automatically.
+        await init();
+
+        // Run cairo-rs through our proxy function.
+        const value = await runCairoProgram();
+
+        // Display the result.
+        document.getElementById('result').innerHTML += value;
+    </script>
+</head>
+
+<body>
+    <p id="result">Result: </p>
+</body>
+
+</html>

--- a/examples/wasm-demo-cairo1/src/bitwise.cairo
+++ b/examples/wasm-demo-cairo1/src/bitwise.cairo
@@ -1,0 +1,13 @@
+fn main() {
+    let a = 1234_u128;
+    let b = 5678_u128;
+
+    let c0 = a & b;
+    let c1 = a ^ b;
+    let c2 = a | b;
+
+    let c3 = c0 + c1 + c2;
+    println!("{}", c3);
+
+    return c3;
+}

--- a/examples/wasm-demo-cairo1/src/lib.rs
+++ b/examples/wasm-demo-cairo1/src/lib.rs
@@ -1,0 +1,51 @@
+mod utils;
+
+use cairo1_run::{cairo_run_program, Cairo1RunConfig};
+use cairo_vm::types::layout_name::LayoutName;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(msg: &str);
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    crate::utils::set_panic_hook();
+}
+
+// TODO: check why this is needed. Seems wasm-bindgen expects us to use
+// `std::error::Error` even if it's not yet in `core`
+macro_rules! wrap_error {
+    ($xp: expr) => {
+        $xp.map_err(|e| JsError::new(e.to_string().as_str()))
+    };
+}
+
+#[wasm_bindgen(js_name = runCairoProgram)]
+pub fn run_cairo_program() -> Result<String, JsError> {
+    const PROGRAM: &[u8] = include_bytes!("../bitwise.sierra");
+
+    let cairo_run_config = Cairo1RunConfig {
+        layout: LayoutName::all_cairo,
+        relocate_mem: true,
+        trace_enabled: true,
+        ..Default::default()
+    };
+
+    let sierra_program = serde_json::from_slice(PROGRAM)?;
+
+    let (mut runner, _, _) = wrap_error!(cairo_run_program(
+        &sierra_program,
+        cairo_run_config,
+    ))?;
+
+    let mut buffer = String::new();
+
+    wrap_error!(runner.vm.write_output(&mut buffer))?;
+
+    log(buffer.as_str());
+
+    Ok(buffer)
+}

--- a/examples/wasm-demo-cairo1/src/utils.rs
+++ b/examples/wasm-demo-cairo1/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -18,7 +18,7 @@ std = [
     "starknet-crypto/std",
     "dep:num-prime",
     "thiserror-no-std/std",
-    "dep:zip",
+    "dep:zip"
 ]
 cairo-1-hints = [
     "dep:cairo-lang-starknet",


### PR DESCRIPTION
# Wasm with Cairo 1

## Description

This PR adds the ability to run cairo 1 programs with wasm. The crate cairo1-run has been refactored in order for it to stop depending on the rust native standard library. 

## Checklist
- [X] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [X] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

