### PR TITLE
Compare all contracts with dynamic layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Upcoming Changes
 
+* test: [#1840](https://github.com/lambdaclass/cairo-vm/pull/1840/files):
+  * Adds scripts and recipes to compare dynamic layout features with the Python VM
+
 * feat(BREAKING): [#1824](https://github.com/lambdaclass/cairo-vm/pull/1824):
     * Add support for dynamic layout
     * CLI change(BREAKING): The flag `cairo_layout_params_file` must be specified when using dynamic layout.

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,26 @@ $(BAD_TEST_DIR)/%.json: $(BAD_TEST_DIR)/%.cairo
 $(PRINT_TEST_DIR)/%.json: $(PRINT_TEST_DIR)/%.cairo
 	cairo-compile $< --output $@
 
+# =======================
+# Run with dynamic layout
+# =======================
+
+CAIRO_DYN_MEM_PROOF:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.dyn.memory, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_TRACE_PROOF:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.dyn.trace, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_AIR_PUBLIC_INPUT:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.dyn.air_public_input, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_AIR_PRIVATE_INPUT:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.dyn.air_private_input, $(COMPILED_PROOF_TESTS))
+
+CAIRO_DYN_RS_MEM_PROOF:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.dyn.memory, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_RS_TRACE_PROOF:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.dyn.trace, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_RS_AIR_PUBLIC_INPUT:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.dyn.air_public_input, $(COMPILED_PROOF_TESTS))
+CAIRO_DYN_RS_AIR_PRIVATE_INPUT:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.dyn.air_private_input, $(COMPILED_PROOF_TESTS))
+
+$(TEST_PROOF_DIR)/%.rs.dyn.trace $(TEST_PROOF_DIR)/%.rs.dyn.memory $(TEST_PROOF_DIR)/%.rs.dyn.air_public_input $(TEST_PROOF_DIR)/%.rs.dyn.air_private_input: $(TEST_PROOF_DIR)/%.json $(RELBIN)
+	cargo run -p cairo-vm-cli --release -- --layout dynamic --proof_mode $< --trace_file $(@D)/$(*F).rs.dyn.trace --memory_file $(@D)/$(*F).rs.dyn.memory --air_public_input $(@D)/$(*F).rs.dyn.air_public_input --air_private_input $(@D)/$(*F).rs.dyn.air_private_input --cairo_layout_params_file cairo_layout_params_file.json
+
+$(TEST_PROOF_DIR)/%.dyn.trace $(TEST_PROOF_DIR)/%.dyn.memory $(TEST_PROOF_DIR)/%.dyn.air_public_input $(TEST_PROOF_DIR)/%.dyn.air_private_input: $(TEST_PROOF_DIR)/%.json cairo_layout_params_file.json
+	cairo-run --layout dynamic --proof_mode --program $< --trace_file $(@D)/$(*F).dyn.trace  --air_public_input $(@D)/$(*F).dyn.air_public_input --memory_file $(@D)/$(*F).dyn.memory --air_private_input $(@D)/$(*F).dyn.air_private_input --cairo_layout_params_file cairo_layout_params_file.json
+
 # ======================
 # Test Cairo 1 Contracts
 # ======================
@@ -331,6 +351,9 @@ compare_pie: $(CAIRO_RS_PIE) $(CAIRO_PIE)
 
 compare_all_pie_outputs: $(CAIRO_RS_PIE)
 	cd vm/src/tests; ./compare_all_pie_outputs.sh
+
+compare_all_proof_dyn: $(COMPILED_DYN_PROOF_TESTS) $(CAIRO_DYN_RS_TRACE_PROOF) $(CAIRO_DYN_TRACE_PROOF) $(CAIRO_DYN_RS_MEM_PROOF) $(CAIRO_DYN_MEM_PROOF) $(CAIRO_DYN_RS_AIR_PUBLIC_INPUT) $(CAIRO_DYN_AIR_PUBLIC_INPUT) $(CAIRO_DYN_RS_AIR_PRIVATE_INPUT) $(CAIRO_DYN_AIR_PRIVATE_INPUT)
+	cd vm/src/tests; ./compare_vm_state_dyn.sh trace memory proof_mode air_public_input air_private_input
 
 # Run with nightly enable the `doc_cfg` feature wich let us provide clear explaination about which parts of the code are behind a feature flag
 docs:

--- a/vm/src/tests/compare_vm_state_dyn.sh
+++ b/vm/src/tests/compare_vm_state_dyn.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env sh
+
+# move to the directory where the script is located
+cd $(dirname "$0")
+
+tests_path="../../../cairo_programs"
+proof_tests_path="${tests_path}/proof_programs"
+exit_code=0
+trace=false
+memory=false
+air_public_input=false
+air_private_input=false
+passed_tests=0
+failed_tests=0
+
+for i in $@; do
+    case $i in
+        "trace") trace=true
+        echo "Requested trace comparison"
+        ;;
+        "memory") memory=true
+        echo "Requested memory comparison"
+        ;;
+        "proof_mode") tests_path=$proof_tests_path
+        echo "Requested proof mode usage"
+        ;;
+        "air_public_input") air_public_input=true
+        echo "Requested air_public_input comparison"
+        ;;
+        "air_private_input") air_private_input=true
+        echo "Requested air_private_input comparison"
+        ;;
+        *)
+        ;;
+    esac
+done
+
+if $air_public_input; then
+    if [ $tests_path != $proof_tests_path ]; then
+        echo "Can't compare air_public_input without proof_mode"
+        exit 1
+    fi
+fi
+
+files=$(ls $tests_path)
+EXIT_CODE=$?
+if [ ${EXIT_CODE} != 0 ]; then
+    exit ${EXIT_CODE}
+fi
+
+for file in $(ls $tests_path | grep .cairo$ | sed -E 's/\.cairo$//'); do
+    path_file="$tests_path/$file"
+
+    if $trace; then
+        if ! diff -q $path_file.dyn.trace $path_file.rs.dyn.trace; then
+            echo "Traces for $file differ"
+            exit_code=1
+            failed_tests=$((failed_tests + 1))
+        else
+            passed_tests=$((passed_tests + 1))
+        fi
+    fi
+
+    if $memory; then
+        if ! ./memory_comparator.py $path_file.dyn.memory $path_file.rs.dyn.memory; then
+            echo "Memory differs for $file"
+            exit_code=1
+            failed_tests=$((failed_tests + 1))
+        else
+            passed_tests=$((passed_tests + 1))
+        fi
+    fi
+
+    if $air_public_input; then
+        if ! ./air_public_input_comparator.py $path_file.dyn.air_public_input $path_file.rs.dyn.air_public_input; then
+            echo "Air Public Input differs for $file"
+            exit_code=1
+            failed_tests=$((failed_tests + 1))
+        else
+            passed_tests=$((passed_tests + 1))
+        fi
+    fi
+
+    if $air_private_input; then
+        if ! ./air_private_input_comparator.py $path_file.dyn.air_private_input $path_file.rs.dyn.air_private_input; then
+            echo "Air Private Input differs for $file"
+            exit_code=1
+            failed_tests=$((failed_tests + 1))
+        else
+            passed_tests=$((passed_tests + 1))
+        fi
+    fi
+done
+
+if test $failed_tests != 0; then
+    echo "Comparisons: $failed_tests failed, $passed_tests passed, $((failed_tests + passed_tests)) total"
+elif test $passed_tests = 0; then
+    echo "No tests ran!"
+    exit_code=2
+else
+    echo "All $passed_tests tests passed; no discrepancies found"
+fi
+
+exit "${exit_code}"


### PR DESCRIPTION
# Compare all contracts with dynamic layout

Originally in #1824, but I moved it to another PR to reduce its size

## Description

Adds Makefile recipes and script to compare all contracts with dynamic layouts. Should not be added to the CI, but can be used to manually test the dynamic layouts feature thoroughly.

I don't see a reason for merging these changes, as there is now a better way to test dynamic layouts. Maybe we should close this PR.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

