### PR TITLE
Sort_ecdsa_and_mod_builtins_private_inputs_by_idx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Upcoming Changes
 
+* fix: [#1851](https://github.com/lambdaclass/cairo-vm/pull/1851):
+  * Fix unsorted signature and mod builtin outputs in air_private_input.
+
 * feat(BREAKING): [#1824](https://github.com/lambdaclass/cairo-vm/pull/1824)[#1838](https://github.com/lambdaclass/cairo-vm/pull/1838):
     * Add support for dynamic layout
     * CLI change(BREAKING): The flag `cairo_layout_params_file` must be specified when using dynamic layout.

--- a/vm/src/vm/runners/builtin_runner/modulo.rs
+++ b/vm/src/vm/runners/builtin_runner/modulo.rs
@@ -263,6 +263,8 @@ impl ModBuiltinRunner {
             });
         }
 
+        instances.sort_by_key(|input| input.index);
+
         vec![PrivateInput::Mod(ModInput {
             instances,
             zero_value_address: relocation_table

--- a/vm/src/vm/runners/builtin_runner/signature.rs
+++ b/vm/src/vm/runners/builtin_runner/signature.rs
@@ -238,6 +238,10 @@ impl SignatureBuiltinRunner {
                 }))
             }
         }
+        private_inputs.sort_by_key(|input| match input {
+            PrivateInput::Signature(sig) => sig.index,
+            _ => unreachable!(),
+        });
         private_inputs
     }
 }


### PR DESCRIPTION
# TITLE
Sort_ecdsa_and_mod_builtins_private_inputs_by_idx

## Description
Making sure to sort the resulted list of those builtins in the air_private_input_file by index, so it is aligned with the python vm's outputs.


Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

