### PR TITLE
Update docs, cairo-lang-runner references

### DIFF
--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -366,6 +366,8 @@ fn build_hints_vec<'b>(
     (hints, program_hints)
 }
 
+// Function derived from the cairo-lang-runner crate.
+// https://github.com/starkware-libs/cairo/blob/40a7b60687682238f7f71ef7c59c986cc5733915/crates/cairo-lang-runner/src/lib.rs#L551-L552
 /// Finds first function ending with `name_suffix`.
 fn find_function<'a>(
     sierra_program: &'a SierraProgram,
@@ -384,6 +386,8 @@ fn find_function<'a>(
         .ok_or_else(|| RunnerError::MissingMain)
 }
 
+// Function derived from the cairo-lang-runner crate.
+// https://github.com/starkware-libs/cairo/blob/40a7b60687682238f7f71ef7c59c986cc5733915/crates/cairo-lang-runner/src/lib.rs#L750
 /// Creates a list of instructions that will be appended to the program's bytecode.
 fn create_code_footer() -> Vec<Instruction> {
     casm! {
@@ -527,6 +531,8 @@ fn load_arguments(
     Ok(())
 }
 
+// Function derived from the cairo-lang-runner crate.
+// https://github.com/starkware-libs/cairo/blob/40a7b60687682238f7f71ef7c59c986cc5733915/crates/cairo-lang-runner/src/lib.rs#L703
 /// Returns the instructions to add to the beginning of the code to successfully call the main
 /// function, as well as the builtins required to execute the program.
 fn create_entry_code(
@@ -869,6 +875,8 @@ fn create_entry_code(
     ))
 }
 
+// Function derived from the cairo-lang-runner crate.
+// https://github.com/starkware-libs/cairo/blob/40a7b60687682238f7f71ef7c59c986cc5733915/crates/cairo-lang-runner/src/lib.rs#L577
 fn get_info<'a>(
     sierra_program_registry: &'a ProgramRegistry<CoreType, CoreLibfunc>,
     ty: &'a cairo_lang_sierra::ids::ConcreteTypeId,

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -1,3 +1,6 @@
+// Most of the structs and implementations of these Dictionaries are based on the `cairo-lang-runner` crate.
+// Reference: https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+
 use num_traits::One;
 
 use crate::stdlib::collections::HashMap;

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -1,6 +1,3 @@
-// The majority of the `CoreHint` implementations are derived from the `cairo-lang-runner` crate.
-// https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/casm_run/mod.rs
-
 use super::dict_manager::DictManagerExecScope;
 use super::hint_processor_utils::*;
 use crate::any_box;
@@ -74,7 +71,9 @@ impl Cairo1HintProcessor {
             segment_arena_validations,
         }
     }
-    // Runs a single Hint
+    // Most of the Hints implementations are derived from the `cairo-lang-runner` crate.
+    // https://github.com/starkware-libs/cairo/blob/40a7b60687682238f7f71ef7c59c986cc5733915/crates/cairo-lang-runner/src/casm_run/mod.rs#L1681
+    /// Runs a single Hint
     pub fn execute(
         &self,
         vm: &mut VirtualMachine,

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -1,3 +1,6 @@
+// Most of the `HintCore` implementation is derived from the cairo-lang-runner crate.
+// https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/casm_run/mod.rs
+
 use super::dict_manager::DictManagerExecScope;
 use super::hint_processor_utils::*;
 use crate::any_box;

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -1,4 +1,4 @@
-// Most of the `HintCore` implementation is derived from the cairo-lang-runner crate.
+// The majority of the `CoreHint` implementations are derived from the `cairo-lang-runner` crate.
 // https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/casm_run/mod.rs
 
 use super::dict_manager::DictManagerExecScope;


### PR DESCRIPTION
# Update docs

Specify that the implementation of certain Cairo 1 functions are inspired by the `cairo-lang-runner` crate.

Reference:
- [`cairo-lang-runner`](https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/)

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

