### PR TITLE
Skip_pedersen_comparison_when_checking_pie_compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+* fix: [#1855](https://github.com/lambdaclass/cairo-vm/pull/1855):
+  * Adds logic to skip pedersen additional data comparison when checking pie compatibility.
 
 * feat(BREAKING): [#1824](https://github.com/lambdaclass/cairo-vm/pull/1824)[#1838](https://github.com/lambdaclass/cairo-vm/pull/1838):
     * Add support for dynamic layout

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -289,6 +289,10 @@ impl CairoPie {
             return Err(CairoPieValidationError::DiffAdditionalData);
         }
         for (name, data) in self.additional_data.0.iter() {
+            // As documented above, we skip the pedersen field when comparing.
+            if *name == BuiltinName::pedersen {
+                continue;
+            }
             if !pie.additional_data.0.get(name).is_some_and(|d| d == data) {
                 return Err(CairoPieValidationError::DiffAdditionalDataForBuiltin(*name));
             }


### PR DESCRIPTION
# TITLE
Skip_pedersen_comparison_when_checking_pie_compatibility

## Description
As stated in the doc describing the `check_pie_compatibility` func, we should skip the comparison of additional_data[pedersen]. This adds the needed logic.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

