### PR TITLE
Convert relocation table to HashMap<usize, MaybeRelocatable>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### [2.0.0-rc0] - 2024-10-22
 
+* fix: [#1862](https://github.com/lambdaclass/cairo-vm/pull/1862):
+  * Use MaybeRelocatable for relocation table
+
 * chore: bump `cairo-lang-` dependencies to 2.9.0-dev.0 [#1858](https://github.com/lambdaclass/cairo-vm/pull/1858/files)
 
 * chore: update Rust required version to 1.81.0 [#1857](https://github.com/lambdaclass/cairo-vm/pull/1857)

--- a/vm/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/segments.rs
@@ -19,7 +19,10 @@ pub fn relocate_segment(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let src_ptr = get_ptr_from_var_name("src_ptr", vm, ids_data, ap_tracking)?;
+    #[cfg(not(feature = "extensive_hints"))]
     let dest_ptr = get_ptr_from_var_name("dest_ptr", vm, ids_data, ap_tracking)?;
+    #[cfg(feature = "extensive_hints")]
+    let dest_ptr = crate::hint_processor::builtin_hint_processor::hint_utils::get_maybe_relocatable_from_var_name("dest_ptr", vm, ids_data, ap_tracking)?;
 
     vm.add_relocation_rule(src_ptr, dest_ptr)
         .map_err(HintError::Memory)?;

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -126,7 +126,7 @@ impl DictManagerExecScope {
         if self.use_temporary_segments {
             let mut prev_end = vm.add_memory_segment();
             for tracker in &self.trackers {
-                vm.add_relocation_rule(tracker.start, prev_end)?;
+                vm.add_relocation_rule(tracker.start, prev_end.into())?;
                 prev_end += (tracker.end.unwrap_or_default() - tracker.start)?;
                 prev_end += 1;
             }

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1012,6 +1012,20 @@ impl VirtualMachine {
         self.segments.memory.add_relocation_rule(src_ptr, dst_ptr)
     }
 
+    /// Add a new relocation rule.
+    ///
+    /// Will return an error if any of the following conditions are not met:
+    ///   - Source address's segment must be negative (temporary).
+    ///   - Source address's offset must be zero.
+    ///   - There shouldn't already be relocation at the source segment.
+    pub fn add_relocation_rule_maybe_relocatable(
+        &mut self,
+        src_ptr: Relocatable,
+        dst: MaybeRelocatable,
+    ) -> Result<(), MemoryError> {
+        self.segments.memory.add_relocation_rule_maybe_relocatable(src_ptr, dst)
+    }
+
     pub fn gen_arg(&mut self, arg: &dyn Any) -> Result<MaybeRelocatable, MemoryError> {
         self.segments.gen_arg(arg)
     }

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1012,7 +1012,11 @@ impl VirtualMachine {
         self.segments.memory.add_relocation_rule(src_ptr, dst_ptr)
     }
 
-    /// Add a new relocation rule.
+    /// Add a new relocation rule, allowing for dst to be a `MaybeRelocatable`.
+    ///
+    /// Relocating memory to anything other than a `Relocatable` is generally not useful, but it
+    /// does make the implementation consistent with the pythonic version. In most cases it is
+    /// advisable to use `add_relocation_rule()`, which only accepts a Relocatable.
     ///
     /// Will return an error if any of the following conditions are not met:
     ///   - Source address's segment must be negative (temporary).

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1011,10 +1011,8 @@ impl VirtualMachine {
     pub fn add_relocation_rule(
         &mut self,
         src_ptr: Relocatable,
-        #[cfg(not(feature = "extensive_hints"))]
-        dst_ptr: Relocatable,
-        #[cfg(feature = "extensive_hints")]
-        dst_ptr: MaybeRelocatable,
+        #[cfg(not(feature = "extensive_hints"))] dst_ptr: Relocatable,
+        #[cfg(feature = "extensive_hints")] dst_ptr: MaybeRelocatable,
     ) -> Result<(), MemoryError> {
         self.segments.memory.add_relocation_rule(src_ptr, dst_ptr)
     }

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1000,6 +1000,10 @@ impl VirtualMachine {
 
     /// Add a new relocation rule.
     ///
+    /// When using feature "extensive_hints" the destination is allowed to be an Integer (via
+    /// MaybeRelocatable). Relocating memory to anything other than a `Relocatable` is generally
+    /// not useful, but it does make the implementation consistent with the pythonic version.
+    ///
     /// Will return an error if any of the following conditions are not met:
     ///   - Source address's segment must be negative (temporary).
     ///   - Source address's offset must be zero.
@@ -1007,27 +1011,12 @@ impl VirtualMachine {
     pub fn add_relocation_rule(
         &mut self,
         src_ptr: Relocatable,
+        #[cfg(not(feature = "extensive_hints"))]
         dst_ptr: Relocatable,
+        #[cfg(feature = "extensive_hints")]
+        dst_ptr: MaybeRelocatable,
     ) -> Result<(), MemoryError> {
         self.segments.memory.add_relocation_rule(src_ptr, dst_ptr)
-    }
-
-    /// Add a new relocation rule, allowing for dst to be a `MaybeRelocatable`.
-    ///
-    /// Relocating memory to anything other than a `Relocatable` is generally not useful, but it
-    /// does make the implementation consistent with the pythonic version. In most cases it is
-    /// advisable to use `add_relocation_rule()`, which only accepts a Relocatable.
-    ///
-    /// Will return an error if any of the following conditions are not met:
-    ///   - Source address's segment must be negative (temporary).
-    ///   - Source address's offset must be zero.
-    ///   - There shouldn't already be relocation at the source segment.
-    pub fn add_relocation_rule_maybe_relocatable(
-        &mut self,
-        src_ptr: Relocatable,
-        dst: MaybeRelocatable,
-    ) -> Result<(), MemoryError> {
-        self.segments.memory.add_relocation_rule_maybe_relocatable(src_ptr, dst)
     }
 
     pub fn gen_arg(&mut self, arg: &dyn Any) -> Result<MaybeRelocatable, MemoryError> {

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -757,6 +757,7 @@ impl<'a> RelocateValue<'a, &'a MaybeRelocatable, Cow<'a, MaybeRelocatable>> for 
         Ok(match value {
             MaybeRelocatable::Int(_) => Cow::Borrowed(value),
             MaybeRelocatable::RelocatableValue(addr) => {
+                #[allow(clippy::useless_conversion)]
                 Cow::Owned(self.relocate_value(*addr)?.into())
             }
         })

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -337,6 +337,10 @@ impl Memory {
 
     /// Add a new relocation rule.
     ///
+    /// Relocating memory to anything other than a `Relocatable` is generally not useful, but it
+    /// does make the implementation consistent with the pythonic version. In most cases it is
+    /// advisable to use `add_relocation_rule()`, which only accepts a Relocatable.
+    ///
     /// Will return an error if any of the following conditions are not met:
     ///   - Source address's segment must be negative (temporary).
     ///   - Source address's offset must be zero.

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -1700,13 +1700,14 @@ mod memory_tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(feature = "extensive_hints")]
     fn relocate_address_to_integer() {
         let mut memory = Memory::new();
         memory
-            .add_relocation_rule_maybe_relocatable((-1, 0).into(), 0.into())
+            .add_relocation_rule((-1, 0).into(), 0.into())
             .unwrap();
         memory
-            .add_relocation_rule_maybe_relocatable((-2, 0).into(), 42.into())
+            .add_relocation_rule((-2, 0).into(), 42.into())
             .unwrap();
 
         assert_eq!(
@@ -1721,17 +1722,18 @@ mod memory_tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(feature = "extensive_hints")]
     fn relocate_address_integer_no_duplicates() {
         let mut memory = Memory::new();
         memory
-            .add_relocation_rule_maybe_relocatable((-1, 0).into(), 1.into())
+            .add_relocation_rule((-1, 0).into(), 1.into())
             .unwrap();
         assert_eq!(
-            memory.add_relocation_rule_maybe_relocatable((-1, 0).into(), 42.into()),
+            memory.add_relocation_rule((-1, 0).into(), 42.into()),
             Err(MemoryError::DuplicatedRelocation(-1))
         );
         assert_eq!(
-            memory.add_relocation_rule_maybe_relocatable((-1, 0).into(), (2, 0).into()),
+            memory.add_relocation_rule((-1, 0).into(), (2, 0).into()),
             Err(MemoryError::DuplicatedRelocation(-1))
         );
 
@@ -1741,10 +1743,10 @@ mod memory_tests {
         );
 
         memory
-            .add_relocation_rule_maybe_relocatable((-2, 0).into(), (3, 0).into())
+            .add_relocation_rule((-2, 0).into(), (3, 0).into())
             .unwrap();
         assert_eq!(
-            memory.add_relocation_rule_maybe_relocatable((-2, 0).into(), 1.into()),
+            memory.add_relocation_rule((-2, 0).into(), 1.into()),
             Err(MemoryError::DuplicatedRelocation(-2))
         );
 

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -316,7 +316,7 @@ impl Memory {
                     MaybeRelocatable::RelocatableValue(addr) => addr,
                     MaybeRelocatable::Int(_) => {
                         continue;
-                    },
+                    }
                 };
 
                 // Insert the to-be relocated segment into the real memory
@@ -734,7 +734,7 @@ impl RelocateValue<'_, Relocatable, MaybeRelocatable> for Memory {
                 return Ok(match x {
                     MaybeRelocatable::RelocatableValue(r) => {
                         (*r + addr.offset).map_err(MemoryError::Math)?.into()
-                    },
+                    }
                     MaybeRelocatable::Int(i) => i.into(),
                 });
             }

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -757,8 +757,12 @@ impl<'a> RelocateValue<'a, &'a MaybeRelocatable, Cow<'a, MaybeRelocatable>> for 
         Ok(match value {
             MaybeRelocatable::Int(_) => Cow::Borrowed(value),
             MaybeRelocatable::RelocatableValue(addr) => {
-                #[allow(clippy::useless_conversion)]
-                Cow::Owned(self.relocate_value(*addr)?.into())
+                #[cfg(not(feature = "extensive_hints"))]
+                let v = self.relocate_value(*addr)?.into();
+                #[cfg(feature = "extensive_hints")]
+                let v = self.relocate_value(*addr)?;
+
+                Cow::Owned(v)
             }
         })
     }


### PR DESCRIPTION
# Convert the relocation table to `MaybeRelocatable`s in order to support ints

## Description

Fixes #1860.

This PR converts the relocation table from a `HashMap<usize, Relocatable>` to a `HashMap<usize, MaybeRelocatable>` in order to support integers.

The original `add_relocation_rule` fns have been left untouched so that they still only support `Relocatable`s and a new `fn add_relocation_rule_maybe_relocatable()` has been added to support using a `MaybeRelocatable`. This should prevent this change from affecting most users.

See #1860 for more details on the motivation for this change.

Description of the pull request changes and motivation.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

