### PR TITLE
Runner: include data from constants segment to the bytecode when assembling program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### [2.0.0-rc0] - 2024-10-22
 
+* fix: [#1864](https://github.com/lambdaclass/cairo-vm/pull/1864):
+    * Runner: include data from constants segment to the bytecode when assembling program
+
 * chore: bump `cairo-lang-` dependencies to 2.9.0-dev.0 [#1858](https://github.com/lambdaclass/cairo-vm/pull/1858/files)
 
 * chore: update Rust required version to 1.81.0 [#1857](https://github.com/lambdaclass/cairo-vm/pull/1857)

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -204,10 +204,14 @@ pub fn cairo_run_program(
         cairo_run_config.copy_to_output(),
     );
 
-    let data: Vec<MaybeRelocatable> = instructions
-        .flat_map(|inst| inst.assemble().encode())
-        .map(|x| Felt252::from(&x))
-        .map(MaybeRelocatable::from)
+    // The bytecode includes all program instructions plus entry/footer,
+    // plus data from the constants segments.
+    let data: Vec<MaybeRelocatable> = casm_program
+        .assemble_ex(&entry_code.instructions, &libfunc_footer)
+        .bytecode
+        .into_iter()
+        .map(Into::<Felt252>::into)
+        .map(Into::<MaybeRelocatable>::into)
         .collect();
 
     let program = if cairo_run_config.proof_mode {


### PR DESCRIPTION
## Description

Fixes #1852 

This PR changes the way program bytecode is assembled when `cairo1-run` is executed: an existing `CairoProgram::assemble_ex` method is used which combines program instructions, entry/footer, and constants segments (if any).

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

