### PR TITLE
Add_missing_builtins_to_pie_metadata_serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+* fix: [#1868](https://github.com/lambdaclass/cairo-vm/pull/1855):
+  * Adds logic to include the 3 new builtins in `builtin_segments` when serializing the output cairo pie's metadata.
+
 * fix: [#1855](https://github.com/lambdaclass/cairo-vm/pull/1855):
   * Adds logic to skip pedersen additional data comparison when checking pie compatibility.
 

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -763,6 +763,9 @@ pub(super) mod serde_impl {
             BuiltinName::ec_op,
             BuiltinName::keccak,
             BuiltinName::poseidon,
+            BuiltinName::range_check96,
+            BuiltinName::add_mod,
+            BuiltinName::mul_mod,
         ];
 
         for name in BUILTIN_ORDERED_LIST {


### PR DESCRIPTION
# TITLE
Add_missing_builtins_to_pie_metadata_serialization - BUGFIX
## Description

Description of the pull request changes and motivation.
Currently, the new 3 builtins' segments are not being serialized to the output pie's metadata. This PR fixes that issue by adding them to the serializing func.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

