### PR TITLE
Typo Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ We will then take care of the issue as soon as possible.
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](docs/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](docs/). If you are looking for support, you might want to check [this section](#i-have-a-question).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:


### PR DESCRIPTION
## Description

**Fix Typo: Remove Extra Parenthesis in Support Section**

I found a small typo in the text under the section "I Have a Question". Specifically, there is an extra closing parenthesis at the end of this sentence:

> "If you are looking for support, you might want to check [this section](#i-have-a-question))"

The extra parenthesis was not needed and could cause confusion when reading the markdown.

**Corrected version:**

> "If you are looking for support, you might want to check [this section](#i-have-a-question)."

This fix is important as it ensures the link to the support section works properly and maintains the clarity of the documentation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

