### PR TITLE
Fix scientific notation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
-* fix: [#1878](https://github.com/lambdaclass/cairo-vm/pull/1878)
-  * Fix test `test_felt_from_number_with_scientific_notation`
 * fix: [#1873](https://github.com/lambdaclass/cairo-vm/pull/1873)
   * Fix broken num-prime `is_prime` call
 * fix: [#1868](https://github.com/lambdaclass/cairo-vm/pull/1855):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+* fix: [#1878](https://github.com/lambdaclass/cairo-vm/pull/1878)
+  * Fix test `test_felt_from_number_with_scientific_notation`
 * fix: [#1873](https://github.com/lambdaclass/cairo-vm/pull/1873)
   * Fix broken num-prime `is_prime` call
 * fix: [#1868](https://github.com/lambdaclass/cairo-vm/pull/1855):

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -1492,8 +1492,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_felt_from_number_with_scientific_notation() {
-        let n = Number::deserialize(serde_json::Value::from(1000000000000000000000000000_u128))
-            .unwrap();
+        let n = Number::deserialize(serde_json::Value::from(1e27)).unwrap();
         assert_eq!(n.to_string(), "1e27".to_owned());
 
         assert_matches!(


### PR DESCRIPTION
# Fix scientific notation test

Fixes test `test_felt_from_number_with_scientific_notation` inside `vm/src/serde/deserialize_program.rs:`, which is not working as expected

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

