### PR TITLE
Change macos-12 to macos-13

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Install on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Install on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Install on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Install on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Change macos-12 to macos-13

## Description

Since macos-12 has been deprecated, this PR changes the workflows to use macos-latest.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

