### PR TITLE
Update pip cairo-lang to 0.13.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ bitarray==2.7.3
 fastecdsa==2.3.0
 sympy==1.11.1
 typeguard==2.13.3
-cairo-lang==0.13.2
+cairo-lang==0.13.3


### PR DESCRIPTION
Bump pip cairo-lang to 0.13.2

We need to implement a data availability hint and need to bump to version 0.13.3 for parity with the SECP hints.

## Related PRs
https://github.com/starkware-libs/cairo-lang/issues/198

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

