### PR TITLE
Fix grammatical typos in documentation

### DIFF
--- a/docs/hint_processor/builtin_hint_processor/README.md
+++ b/docs/hint_processor/builtin_hint_processor/README.md
@@ -101,7 +101,7 @@ These last two structures are used by helper functions to manage variables from 
 ### Helper functions
 There are many helper functions available [here](../../../src/hint_processor/builtin_hint_processor/hint_utils.rs), that will allow you to easily manage cairo variables:
 
-* **get_integer_from_var_name**: gets the value from memory of a integer variable.
+* **get_integer_from_var_name**: gets the value from memory of an integer variable.
 * **get_ptr_from_var_name**: gets the value from memory of a pointer variable. 
 * **compute_addr_from_var_name**: gets the address of a given variable.
 * **insert_value_from_var_name**: assigns a value to a Cairo variable. 

--- a/docs/hint_processor/hint_design.md
+++ b/docs/hint_processor/hint_design.md
@@ -129,7 +129,7 @@ We went through the code in the starknet folder looking for hints, seeing what t
 * **builtins.cairo**: There are no hints here but there is a dependency on builtins from the Cairo common library that we have not currently implemented:
     * EcOpBuiltin (it is implemented)
     * SignatureBuiltin
-* **state.cairo (4 hints)**: Uses the patricia module from the Cairo common library. Hints use a object `global_state_storage` and methods associated to it.
+* **state.cairo (4 hints)**: Uses the patricia module from the Cairo common library. Hints use an object `global_state_storage` and methods associated to it.
 * **block_context.cairo (5 hints)**: All hints are used with the `nondet` keyword. Also, the hints use the `sycall_handler` already mentioned and a new object, `os_input`.
 * **transactions.cairo (46 hints)**: Has a dependency with the `builtin_selection` module of the Cairo library, a module with hints that we didn´t implement. Lots of syscalls in the hints.
 * **output.cairo (1 hint)**: Just one big hint of regular Python code for the exception of the usage of the output_builtin as an object (I'm not sure if this appeared before)


### PR DESCRIPTION
This pull request addresses grammatical issues in two documentation files:

1. **`hint_design.md`**: Updated the phrase to replace "a object" with "an object" for correctness.
2. **`README.md`**: Corrected the phrase "a integer variable" to "an integer variable."
