### PR TITLE
Fix typo Update README.md

### DIFF
--- a/docs/python_vm/README.md
+++ b/docs/python_vm/README.md
@@ -194,7 +194,7 @@ First it will try to obtain dst, op0 and op1 by computing their addresses (`comp
 ## How does [decode_instruction](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/vm/vm_core.py#L371) work?
 </a>
 
-This function calls decode_instruction at comiler/encode.py, where `flags`, and the encoded offsets are obtained from calling decode_instruction_values (this function is defined under the Instruction class) on the encoded instruction (an int). This encoded offsets will then become the instruction's offsets after subtracting a constant value, and all other values of the Instruction will be determined by "reading" `flags`, by checking specific bits (ie: `flags >> OPCODE_CALL_BIT) & 1` will determine if opcode will be set Instruction.Opcode.CALL).
+This function calls decode_instruction at compiler/encode.py, where `flags`, and the encoded offsets are obtained from calling decode_instruction_values (this function is defined under the Instruction class) on the encoded instruction (an int). This encoded offsets will then become the instruction's offsets after subtracting a constant value, and all other values of the Instruction will be determined by "reading" `flags`, by checking specific bits (ie: `flags >> OPCODE_CALL_BIT) & 1` will determine if opcode will be set Instruction.Opcode.CALL).
 Some register updates will also be assigned based on the determined opcode: ap_update will be set to ADD2 if the opcode is CALL (ADD2 won't be assigned by reading `flag`, instead, this will be REGULAR), and the fp_update will be determined solely based on the opcode (without using `flag`). `imm` will be set to None unless op1_addr is IMM.
 
 # What is an Operands?


### PR DESCRIPTION
# Fix Typo in README.md

## Description:

This pull request fixes a typographical error in the `README.md` file. The word "comiler" was corrected to "compiler."

## Changes:
- Corrected "comiler" to "compiler" in the `README.md`.

## File(s) Modified:
- `docs/python_vm/README.md`

## Justification:

Correcting typographical errors in documentation ensures clarity and prevents confusion for users reading through the setup or explanation.

## Checklist:
- [x] Typographical error corrected.
- [x] Documentation is accurate and readable.

## Related Issues:
- N/A

## Additional Notes:
This fix only involves a documentation update and does not affect the functionality of the code.
