### PR TITLE
fix typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can install all of the required and optional dependencies by running the scr
 
 In order to compile programs you need to install the cairo-lang package.
 
-Running the  `make deps` (or the `make deps-macos`  if you are runnning in MacOS) command will create a virtual environment with all the required dependencies.
+Running the  `make deps` (or the `make deps-macos`  if you are running in MacOS) command will create a virtual environment with all the required dependencies.
 
 You can then activate this environment by running
  ```bash


### PR DESCRIPTION
# Fix typo in `README.md`

## Description
This pull request corrects a typo in the `README.md` file:  
- Fixed "runnning" to "running" for improved clarity and accuracy.

