### PR TITLE
implement blake opcode in runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
           cairo_bench_programs,
           cairo_proof_programs,
           cairo_test_programs,
+          cairo_stwo_exclusive_programs,
           cairo_1_test_contracts,
           cairo_2_test_contracts,
         ]
@@ -123,6 +124,12 @@ jobs:
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
+        fail-on-cache-miss: true
+    - name: Fetch cairo stwo exclusive programs
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ env.CAIRO_PROGRAMS_PATH }}
+        key: cairo_stwo_exclusive_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch proof programs
       uses: actions/cache/restore@v3
@@ -484,6 +491,9 @@ jobs:
           programs-dir: cairo_programs/proof_programs
           extra-args: '--proof_mode --air_public_input {program}.rs.air_public_input --air_private_input {program}.rs.air_private_input '
         - program-target: cairo_test_programs
+          programs-dir: cairo_programs
+          extra-args: '--cairo_pie_output {program}.rs.pie.zip'
+        - program-target: cairo_stwo_exclusive_programs
           programs-dir: cairo_programs
           extra-args: '--cairo_pie_output {program}.rs.pie.zip'
     name: Compute memory and execution traces with cairo-vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: implement `Blake2s` and `Blake2sLastBlock` opcodes in VM [#1924](https://github.com/lambdaclass/cairo-vm/pull/1924)
+
 #### [2.0.0-rc4] - 2025-01-23
 
 * feat: implement `kzg` data availability hints [#1887](https://github.com/lambdaclass/cairo-vm/pull/1887)

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ CAIRO_RS_MEM:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.memory, $(COMPILED
 CAIRO_RS_TRACE:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.trace, $(COMPILED_TESTS))
 CAIRO_RS_PIE:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.pie.zip, $(COMPILED_TESTS))
 
+STWO_EXCLUSIVE_DIR=cairo_programs/stwo_exclusive_programs
+STWO_EXCLUSIVE_FILES:=$(wildcard $(STWO_EXCLUSIVE_DIR)/*.cairo)
+COMPILED_STWO_EXCLUSIVE_TESTS:=$(patsubst $(STWO_EXCLUSIVE_DIR)/%.cairo, $(STWO_EXCLUSIVE_DIR)/%.json, $(STWO_EXCLUSIVE_FILES))
+
 BENCH_DIR=cairo_programs/benchmarks
 BENCH_FILES:=$(wildcard $(BENCH_DIR)/*.cairo)
 COMPILED_BENCHES:=$(patsubst $(BENCH_DIR)/%.cairo, $(BENCH_DIR)/%.json, $(BENCH_FILES))
@@ -249,6 +253,7 @@ check:
 
 cairo_test_programs: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS) $(COMPILED_PRINT_TESTS) $(COMPILED_MOD_BUILTIN_TESTS) $(COMPILED_SECP_CAIRO0_HINTS) $(COMPILED_KZG_DA_CAIRO0_HINTS)
 cairo_proof_programs: $(COMPILED_PROOF_TESTS) $(COMPILED_MOD_BUILTIN_PROOF_TESTS)
+cairo_stwo_exclusive_programs: $(COMPILED_STWO_EXCLUSIVE_TESTS)
 cairo_bench_programs: $(COMPILED_BENCHES)
 cairo_1_test_contracts: $(CAIRO_1_COMPILED_CASM_CONTRACTS)
 cairo_2_test_contracts: $(CAIRO_2_COMPILED_CASM_CONTRACTS)

--- a/cairo-vm-tracer/src/tracer_data.rs
+++ b/cairo-vm-tracer/src/tracer_data.rs
@@ -143,7 +143,7 @@ impl TracerData {
             let (instruction_encoding, _) =
                 get_instruction_encoding(entry.pc, &memory, program.prime())?;
 
-            let instruction_encoding = instruction_encoding.to_u64();
+            let instruction_encoding = instruction_encoding.to_u128();
             if instruction_encoding.is_none() {
                 return Err(TraceDataError::FailedToConvertInstructionEncoding);
             }

--- a/cairo_programs/stwo_exclusive_programs/blake2s_block_opcode_test.cairo
+++ b/cairo_programs/stwo_exclusive_programs/blake2s_block_opcode_test.cairo
@@ -1,0 +1,139 @@
+%builtins range_check
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_blake2s.blake2s import blake2s_inner, INPUT_BLOCK_BYTES, STATE_SIZE_FELTS, INPUT_BLOCK_FELTS
+
+const COUNTER = 128;
+
+// Tests the Blake2s opcode runner using a preexisting implementation within the repo as reference.
+// The initial state, a random message of 68 bytes and counter are used as input.
+// Both the opcode and the reference implementation are run on said inputs and outputs are compared.
+// Before comparing the outputs, it is verified that the opcode runner has written the output to the correct location.
+func main{range_check_ptr}() {
+    alloc_locals;
+
+    let (local random_message) = alloc();
+    assert random_message[0] =  930933030;
+    assert random_message[1] =  1766240503;
+    assert random_message[2] =  3660871006;
+    assert random_message[3] =  388409270;
+    assert random_message[4] =  1948594622;
+    assert random_message[5] =  3119396969;
+    assert random_message[6] =  3924579183;
+    assert random_message[7] =  2089920034;
+    assert random_message[8] =  3857888532;
+    assert random_message[9] =  929304360;
+    assert random_message[10] =  1810891574;
+    assert random_message[11] =  860971754;
+    assert random_message[12] =  1822893775;
+    assert random_message[13] =  2008495810;
+    assert random_message[14] =  2958962335;
+    assert random_message[15] =  2340515744;
+    assert random_message[16] =  1111307871;
+
+    let (local blake2s_ptr_start) = alloc();
+    let blake2s_ptr = blake2s_ptr_start;
+    // Set the initial state to IV (IV[0] is modified).
+    assert blake2s_ptr[0] = 0x6B08E647;  // IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+    assert blake2s_ptr[1] = 0xBB67AE85;
+    assert blake2s_ptr[2] = 0x3C6EF372;
+    assert blake2s_ptr[3] = 0xA54FF53A;
+    assert blake2s_ptr[4] = 0x510E527F;
+    assert blake2s_ptr[5] = 0x9B05688C;
+    assert blake2s_ptr[6] = 0x1F83D9AB;
+    assert blake2s_ptr[7] = 0x5BE0CD19;
+    static_assert STATE_SIZE_FELTS == 8;
+    let blake2s_ptr = blake2s_ptr + STATE_SIZE_FELTS;
+
+    let (cairo_output) = blake2s_inner{range_check_ptr=range_check_ptr, blake2s_ptr=blake2s_ptr}(data=random_message, n_bytes=INPUT_BLOCK_BYTES+4, counter=COUNTER);
+
+    let (local initial_state) = alloc();
+    assert initial_state[0] = 0x6B08E647; 
+    assert initial_state[1] = 0xBB67AE85;
+    assert initial_state[2] = 0x3C6EF372;
+    assert initial_state[3] = 0xA54FF53A;
+    assert initial_state[4] = 0x510E527F;
+    assert initial_state[5] = 0x9B05688C;
+    assert initial_state[6] = 0x1F83D9AB;
+    assert initial_state[7] = 0x5BE0CD19;
+    assert initial_state[8] = COUNTER;
+
+    let (local vm_output_start) = alloc();
+
+    force_blake2s_non_last_block_opcode(
+        dst=vm_output_start,
+        op0=initial_state,
+        op1=random_message,
+    );
+
+    tempvar check_nonempty = vm_output_start[0];
+    tempvar check_nonempty = vm_output_start[1];
+    tempvar check_nonempty = vm_output_start[2];
+    tempvar check_nonempty = vm_output_start[3];
+    tempvar check_nonempty = vm_output_start[4];
+    tempvar check_nonempty = vm_output_start[5];
+    tempvar check_nonempty = vm_output_start[6];
+    tempvar check_nonempty = vm_output_start[7];
+    tempvar check_nonempty = vm_output_start[8];
+
+    let relevant_output_start = blake2s_ptr_start+INPUT_BLOCK_FELTS+2+STATE_SIZE_FELTS;
+
+    assert vm_output_start[0] = relevant_output_start[0];
+    assert vm_output_start[1] = relevant_output_start[1];
+    assert vm_output_start[2] = relevant_output_start[2];
+    assert vm_output_start[3] = relevant_output_start[3];
+    assert vm_output_start[4] = relevant_output_start[4];
+    assert vm_output_start[5] = relevant_output_start[5];
+    assert vm_output_start[6] = relevant_output_start[6];
+    assert vm_output_start[7] = relevant_output_start[7];
+    assert vm_output_start[8] = [relevant_output_start-2];
+
+    return ();
+}
+
+// Forces the runner to execute the Blake2s with the given operands.
+// op0 is a pointer to an array of 9 felts, 8 as u32 integers of the state and 1 as a u32 of the counter.
+// op1 is a pointer to an array of 16 felts as u32 integers of the messsage.
+// dst is a pointer to an array of 9 felts, 8 as u32 integers of the output state and 1 as a u32 of the updated counter.
+// The values of said pointers are stored within addresses fp-5, fp-4 and fp-3 respectively.
+// An instruction encoding is built from offsets -5, -4, -3 and flags which are all 0 except for
+// those denoting uses of fp as the base for operand addresses and flag_opcode_blake (16th flag).
+// The instruction is then written to [pc] and the runner is forced to execute Blake2s.
+func force_blake2s_non_last_block_opcode(
+    dst: felt*,
+    op0: felt*,
+    op1: felt*,
+) {
+    let offset0 = (2**15)-5;
+    let offset1 = (2**15)-4;
+    let offset2 = (2**15)-3;
+
+    static_assert dst == [fp -5];
+    static_assert op0 == [fp -4];
+    static_assert op1 == [fp -3];
+
+    let flag_dst_base_fp = 1;
+    let flag_op0_base_fp = 1;
+    let flag_op1_imm = 0;
+    let flag_op1_base_fp = 1;
+    let flag_op1_base_ap = 0;
+    let flag_res_add = 0;
+    let flag_res_mul = 0;
+    let flag_PC_update_jump = 0;
+    let flag_PC_update_jump_rel = 0;
+    let flag_PC_update_jnz = 0;
+    let flag_ap_update_add = 0;
+    let flag_ap_update_add_1 = 0;
+    let flag_opcode_call = 0;
+    let flag_opcode_ret = 0;
+    let flag_opcode_assert_eq = 0;
+    let flag_opcode_blake2s = 1;
+    let flag_opcode_blake2s_last_block = 0;
+
+    let flag_num = flag_dst_base_fp+flag_op0_base_fp*(2**1)+flag_op1_imm*(2**2)+flag_op1_base_fp*(2**3)+flag_opcode_blake2s*(2**15)+flag_opcode_blake2s_last_block*(2**16);
+    let instruction_num = offset0 + offset1*(2**16) + offset2*(2**32) + flag_num*(2**48);
+    static_assert instruction_num==9226608988349300731;
+    dw 9226608988349300731;
+    return ();
+}
+

--- a/cairo_programs/stwo_exclusive_programs/blake2s_last_block_opcode_test.cairo
+++ b/cairo_programs/stwo_exclusive_programs/blake2s_last_block_opcode_test.cairo
@@ -1,0 +1,134 @@
+%builtins range_check
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_blake2s.blake2s import blake2s_last_block, INPUT_BLOCK_BYTES, STATE_SIZE_FELTS
+
+const COUNTER = 128;
+
+// Tests the Blake2sLastBlock opcode runner using a preexisting implementation within the repo as reference.
+// The initial state, a random message of 56 bytes (the zeros are treated as padding) and counter are used as input.
+// Both the opcode and the reference implementation are run on said inputs and outputs are compared.
+// Before comparing the outputs, it is verified that the opcode runner has written the output to the correct location.
+func main{range_check_ptr}() {
+    alloc_locals;
+
+    let (local random_message) = alloc();
+    assert random_message[0] = 2064419414;
+    assert random_message[1] = 827054614;
+    assert random_message[2] = 909720013;
+    assert random_message[3] = 2388254362;
+    assert random_message[4] = 2102761495;
+    assert random_message[5] = 3057501890;
+    assert random_message[6] = 3153385271;
+    assert random_message[7] = 2052550804;
+    assert random_message[8] = 1117201254;
+    assert random_message[9] = 1365353504;
+    assert random_message[10] = 3040233373;
+    assert random_message[11] = 1533241351;
+    assert random_message[12] = 2146580218;
+    assert random_message[13] = 1141362435;
+    assert random_message[14] = 3342861606;
+    assert random_message[15] = 1541788056;
+
+    let (local blake2s_ptr_start) = alloc();
+    let blake2s_ptr = blake2s_ptr_start;
+    // Set the initial state to IV (IV[0] is modified).
+    assert blake2s_ptr[0] = 0x6B08E647;  // IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+    assert blake2s_ptr[1] = 0xBB67AE85;
+    assert blake2s_ptr[2] = 0x3C6EF372;
+    assert blake2s_ptr[3] = 0xA54FF53A;
+    assert blake2s_ptr[4] = 0x510E527F;
+    assert blake2s_ptr[5] = 0x9B05688C;
+    assert blake2s_ptr[6] = 0x1F83D9AB;
+    assert blake2s_ptr[7] = 0x5BE0CD19;
+    static_assert STATE_SIZE_FELTS == 8;
+    let blake2s_ptr = blake2s_ptr + STATE_SIZE_FELTS;
+
+    let (cairo_output) = blake2s_last_block{range_check_ptr=range_check_ptr, blake2s_ptr=blake2s_ptr}(data=random_message, n_bytes=INPUT_BLOCK_BYTES, counter=COUNTER);
+
+    let (local initial_state) = alloc();
+    assert initial_state[0] = 0x6B08E647;
+    assert initial_state[1] = 0xBB67AE85;
+    assert initial_state[2] = 0x3C6EF372;
+    assert initial_state[3] = 0xA54FF53A;
+    assert initial_state[4] = 0x510E527F;
+    assert initial_state[5] = 0x9B05688C;
+    assert initial_state[6] = 0x1F83D9AB;
+    assert initial_state[7] = 0x5BE0CD19;
+    assert initial_state[8] = COUNTER;
+
+    let (local vm_output_start) = alloc();
+
+    force_blake2s_last_block_opcode(
+        dst=vm_output_start,
+        op0=initial_state,
+        op1=random_message,
+    );
+
+    tempvar check_nonempty = vm_output_start[0];
+    tempvar check_nonempty = vm_output_start[1];
+    tempvar check_nonempty = vm_output_start[2];
+    tempvar check_nonempty = vm_output_start[3];
+    tempvar check_nonempty = vm_output_start[4];
+    tempvar check_nonempty = vm_output_start[5];
+    tempvar check_nonempty = vm_output_start[6];
+    tempvar check_nonempty = vm_output_start[7];
+
+    assert vm_output_start[0] = cairo_output[0];
+    assert vm_output_start[1] = cairo_output[1];
+    assert vm_output_start[2] = cairo_output[2];
+    assert vm_output_start[3] = cairo_output[3];
+    assert vm_output_start[4] = cairo_output[4];
+    assert vm_output_start[5] = cairo_output[5];
+    assert vm_output_start[6] = cairo_output[6];
+    assert vm_output_start[7] = cairo_output[7];
+
+    return ();
+}
+
+// Forces the runner to execute the Blake2sLastBlock with the given operands.
+// op0 is a pointer to an array of 9 felts, 8 as u32 integers of the state and 1 as a u32 of the counter.
+// op1 is a pointer to an array of 16 felts as u32 integers of the messsage.
+// dst is a pointer to an array of 9 felts, 8 as u32 integers of the output state and 1 as a u32 of the updated counter.
+// The values of said pointers are stored within addresses fp-5, fp-4 and fp-3 respectively.
+// An instruction encoding is built from offsets -5, -4, -3 and flags which are all 0 except for
+// those denoting uses of fp as the base for operand addresses and flag_opcode_blake (16th flag).
+// The instruction is then written to [pc] and the runner is forced to execute Blake2sLastBlock.
+func force_blake2s_last_block_opcode(
+    dst: felt*,
+    op0: felt*,
+    op1: felt*,
+) {
+    let offset0 = (2**15)-5;
+    let offset1 = (2**15)-4;
+    let offset2 = (2**15)-3;
+
+    static_assert dst == [fp -5];
+    static_assert op0 == [fp -4];
+    static_assert op1 == [fp -3];
+
+    let flag_dst_base_fp = 1;
+    let flag_op0_base_fp = 1;
+    let flag_op1_imm = 0;
+    let flag_op1_base_fp = 1;
+    let flag_op1_base_ap = 0;
+    let flag_res_add = 0;
+    let flag_res_mul = 0;
+    let flag_PC_update_jump = 0;
+    let flag_PC_update_jump_rel = 0;
+    let flag_PC_update_jnz = 0;
+    let flag_ap_update_add = 0;
+    let flag_ap_update_add_1 = 0;
+    let flag_opcode_call = 0;
+    let flag_opcode_ret = 0;
+    let flag_opcode_assert_eq = 0;
+    let flag_opcode_blake2s = 0;
+    let flag_opcode_blake2s_last_block = 1;
+
+    let flag_num = flag_dst_base_fp+flag_op0_base_fp*(2**1)+flag_op1_imm*(2**2)+flag_op1_base_fp*(2**3)+flag_opcode_blake2s*(2**15)+flag_opcode_blake2s_last_block*(2**16);
+    let instruction_num = offset0 + offset1*(2**16) + offset2*(2**32) + flag_num*(2**48);
+    static_assert instruction_num==18449981025204076539;
+    dw 18449981025204076539;
+    return ();
+}
+

--- a/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
+++ b/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
@@ -1,0 +1,157 @@
+%builtins range_check
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_blake2s.blake2s import blake2s_inner, INPUT_BLOCK_BYTES, STATE_SIZE_FELTS, INPUT_BLOCK_FELTS
+
+const COUNTER = 128;
+
+// Tests the Blake2s opcode runner using a preexisting implementation within the repo as reference.
+// The initial state, a random message of 68 bytes and counter are used as input.
+// Both the opcode and the reference implementation are run on said inputs and outputs are compared.
+// Before comparing the outputs, it is verified that the opcode runner has written the output to the correct location.
+func main{range_check_ptr}() {
+    alloc_locals;
+
+    let (local random_message) = alloc();
+    assert random_message[0] =  930933030;
+    assert random_message[1] =  1766240503;
+    assert random_message[2] =  3660871006;
+    assert random_message[3] =  388409270;
+    assert random_message[4] =  1948594622;
+    assert random_message[5] =  3119396969;
+    assert random_message[6] =  3924579183;
+    assert random_message[7] =  2089920034;
+    assert random_message[8] =  3857888532;
+    assert random_message[9] =  929304360;
+    assert random_message[10] =  1810891574;
+    assert random_message[11] =  860971754;
+    assert random_message[12] =  1822893775;
+    assert random_message[13] =  2008495810;
+    assert random_message[14] =  2958962335;
+    assert random_message[15] =  2340515744;
+    assert random_message[16] =  1111307871;
+
+    let (local blake2s_ptr_start) = alloc();
+    let blake2s_ptr = blake2s_ptr_start;
+    // Set the initial state to IV (IV[0] is modified).
+    assert blake2s_ptr[0] = 0x6B08E647;  // IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+    assert blake2s_ptr[1] = 0xBB67AE85;
+    assert blake2s_ptr[2] = 0x3C6EF372;
+    assert blake2s_ptr[3] = 0xA54FF53A;
+    assert blake2s_ptr[4] = 0x510E527F;
+    assert blake2s_ptr[5] = 0x9B05688C;
+    assert blake2s_ptr[6] = 0x1F83D9AB;
+    assert blake2s_ptr[7] = 0x5BE0CD19;
+    static_assert STATE_SIZE_FELTS == 8;
+    let blake2s_ptr = blake2s_ptr + STATE_SIZE_FELTS;
+
+    let (cairo_output) = blake2s_inner{range_check_ptr=range_check_ptr, blake2s_ptr=blake2s_ptr}(data=random_message, n_bytes=INPUT_BLOCK_BYTES+4, counter=COUNTER);
+
+    let (local initial_state) = alloc();
+    assert initial_state[0] = 0x6B08E647;  // IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+    assert initial_state[1] = 0xBB67AE85;
+    assert initial_state[2] = 0x3C6EF372;
+    assert initial_state[3] = 0xA54FF53A;
+    assert initial_state[4] = 0x510E527F;
+    assert initial_state[5] = 0x9B05688C;
+    assert initial_state[6] = 0x1F83D9AB;
+    assert initial_state[7] = 0x5BE0CD19;
+    assert initial_state[8] = COUNTER;
+
+    let (local vm_output_start) = alloc();
+
+    force_blake2s_non_last_block_opcode(
+        dst=vm_output_start,
+        op0=initial_state,
+        op1=random_message,
+    );
+
+    tempvar check_nonempty = vm_output_start[0];
+    tempvar check_nonempty = vm_output_start[1];
+    tempvar check_nonempty = vm_output_start[2];
+    tempvar check_nonempty = vm_output_start[3];
+    tempvar check_nonempty = vm_output_start[4];
+    tempvar check_nonempty = vm_output_start[5];
+    tempvar check_nonempty = vm_output_start[6];
+    tempvar check_nonempty = vm_output_start[7];
+    tempvar check_nonempty = vm_output_start[8];
+
+    let relevant_output_start = blake2s_ptr_start+INPUT_BLOCK_FELTS+2+STATE_SIZE_FELTS;
+
+    assert vm_output_start[0] = relevant_output_start[0];
+    assert vm_output_start[1] = relevant_output_start[1];
+    assert vm_output_start[2] = relevant_output_start[2];
+    assert vm_output_start[3] = relevant_output_start[3];
+    assert vm_output_start[4] = relevant_output_start[4];
+    assert vm_output_start[5] = relevant_output_start[5];
+    assert vm_output_start[6] = relevant_output_start[6];
+    assert vm_output_start[7] = relevant_output_start[7];
+    assert vm_output_start[8] = [relevant_output_start-2];
+
+    return ();
+}
+
+// pub const FLAG_DST_BASE_FP_INDEX: usize = 0;
+// pub const FLAG_OP0_BASE_FP_INDEX: usize = 1;
+// pub const FLAG_OP1_IMM_INDEX: usize = 2;
+// pub const FLAG_OP1_BASE_FP_INDEX: usize = 3;
+// pub const FLAG_OP1_BASE_AP_INDEX: usize = 4;
+// pub const FLAG_RES_ADD_INDEX: usize = 5;
+// pub const FLAG_RES_MUL_INDEX: usize = 6;
+// pub const FLAG_PC_UPDATE_JUMP_INDEX: usize = 7;
+// pub const FLAG_PC_UPDATE_JUMP_REL_INDEX: usize = 8;
+// pub const FLAG_PC_UPDATE_JNZ_INDEX: usize = 9;
+// pub const FLAG_AP_UPDATE_ADD_INDEX: usize = 10;
+// pub const FLAG_AP_UPDATE_ADD_1_INDEX: usize = 11;
+// pub const FLAG_OPCODE_CALL_INDEX: usize = 12;
+// pub const FLAG_OPCODE_RET_INDEX: usize = 13;
+// pub const FLAG_OPCODE_ASSERT_EQ_INDEX: usize = 14;
+// pub const FLAG_OPCODE_BLAKE2S_INDEX: usize = 15;
+// pub const FLAG_OPCODE_BLAKE2S_LAST_BLOCK_INDEX: usize = 16;
+
+// Forces the runner to execute the Blake2s with the given operands.
+// op0 is a pointer to an array of 9 felts, 8 as u32 integers of the state and 1 as a u32 of the counter.
+// op1 is a pointer to an array of 16 felts as u32 integers of the messsage.
+// dst is a pointer to an array of 9 felts, 8 as u32 integers of the output state and 1 as a u32 of the updated counter.
+// The values of said pointers are stored within addresses fp-5, fp-4 and fp-3 respectively.
+// An instruction encoding is built from offsets -5, -4, -3 and flags which are all 0 except for
+// those denoting uses of fp as the base for operand addresses and flag_opcode_blake (16th flag).
+// The instruction is then written to [pc] and the runner is forced to execute Blake2s.
+func force_blake2s_non_last_block_opcode(
+    dst: felt*,
+    op0: felt*,
+    op1: felt*,
+) {
+    let offset0 = (2**15)-5;
+    let offset1 = (2**15)-4;
+    let offset2 = (2**15)-3;
+
+    static_assert dst == [fp -5];
+    static_assert op0 == [fp -4];
+    static_assert op1 == [fp -3];
+
+    let flag_dst_base_fp = 1;
+    let flag_op0_base_fp = 1;
+    let flag_op1_imm = 0;
+    let flag_op1_base_fp = 1;
+    let flag_op1_base_ap = 0;
+    let flag_res_add = 0;
+    let flag_res_mul = 0;
+    let flag_PC_update_jump = 0;
+    let flag_PC_update_jump_rel = 0;
+    let flag_PC_update_jnz = 0;
+    let flag_ap_update_add = 0;
+    let flag_ap_update_add_1 = 0;
+    let flag_opcode_call = 0;
+    let flag_opcode_ret = 0;
+    let flag_opcode_assert_eq = 0;
+    let flag_opcode_blake2s = 1;
+    let flag_opcode_blake2s_last_block = 0;
+
+    let flag_num = flag_dst_base_fp+flag_op0_base_fp*(2**1)+flag_op1_imm*(2**2)+flag_op1_base_fp*(2**3)+flag_opcode_blake2s*(2**15)+flag_opcode_blake2s_last_block*(2**16);
+    let instruction_num = offset0 + offset1*(2**16) + offset2*(2**32) + flag_num*(2**48);
+    static_assert instruction_num==9226608988349300731;
+    dw 9226608988349300731;
+    return ();
+}
+

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -570,6 +570,23 @@ fn blake2s_integration_tests() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn blake2s_opcode_test() {
+    let program_data =
+        include_bytes!("../../../cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.json");
+    run_program_simple(program_data.as_slice());
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn blake2s_last_block_opcode_test() {
+    let program_data = include_bytes!(
+        "../../../cairo_programs/stwo_exclusive_programs/blake2s_last_block_opcode_test.json"
+    );
+    run_program_simple(program_data.as_slice());
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments.json");
     run_program_simple(program_data.as_slice());

--- a/vm/src/types/instruction.rs
+++ b/vm/src/types/instruction.rs
@@ -74,6 +74,8 @@ pub enum Opcode {
     AssertEq,
     Call,
     Ret,
+    Blake2s,
+    Blake2sLastBlock,
 }
 
 impl Instruction {
@@ -87,11 +89,11 @@ impl Instruction {
 
 // Returns True if the given instruction looks like a call instruction
 pub(crate) fn is_call_instruction(encoded_instruction: &Felt252) -> bool {
-    let encoded_i64_instruction = match encoded_instruction.to_u64() {
+    let encoded_u128_instruction = match encoded_instruction.to_u128() {
         Some(num) => num,
         None => return false,
     };
-    let instruction = match decode_instruction(encoded_i64_instruction) {
+    let instruction = match decode_instruction(encoded_u128_instruction) {
         Ok(inst) => inst,
         Err(_) => return false,
     };
@@ -134,7 +136,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn instruction_size() {
         let encoded_instruction = Felt252::from(1226245742482522112_i64);
-        let instruction = decode_instruction(encoded_instruction.to_u64().unwrap()).unwrap();
+        let instruction = decode_instruction(encoded_instruction.to_u128().unwrap()).unwrap();
         assert_eq!(instruction.size(), 2);
     }
 }

--- a/vm/src/vm/decoding/decoder.rs
+++ b/vm/src/vm/decoding/decoder.rs
@@ -5,36 +5,36 @@ use crate::{
     vm::errors::vm_errors::VirtualMachineError,
 };
 
-//  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-// 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+//          0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+//  31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
 
-/// Decodes an instruction. The encoding is little endian, so flags go from bit 63 to 48.
-pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMachineError> {
-    const HIGH_BIT: u64 = 1u64 << 63;
-    const DST_REG_MASK: u64 = 0x0001;
-    const DST_REG_OFF: u64 = 0;
-    const OP0_REG_MASK: u64 = 0x0002;
-    const OP0_REG_OFF: u64 = 1;
-    const OP1_SRC_MASK: u64 = 0x001C;
-    const OP1_SRC_OFF: u64 = 2;
-    const RES_LOGIC_MASK: u64 = 0x0060;
-    const RES_LOGIC_OFF: u64 = 5;
-    const PC_UPDATE_MASK: u64 = 0x0380;
-    const PC_UPDATE_OFF: u64 = 7;
-    const AP_UPDATE_MASK: u64 = 0x0C00;
-    const AP_UPDATE_OFF: u64 = 10;
-    const OPCODE_MASK: u64 = 0x7000;
-    const OPCODE_OFF: u64 = 12;
+/// Decodes an instruction. The encoding is little endian, so flags go from bit 64 to 48.
+pub fn decode_instruction(encoded_instr: u128) -> Result<Instruction, VirtualMachineError> {
+    const HIGH_BITS: u128 = ((1 << 127) - (1 << 64)) << 1; //63
+    const DST_REG_MASK: u128 = 0x0001;
+    const DST_REG_OFF: u128 = 0;
+    const OP0_REG_MASK: u128 = 0x0002;
+    const OP0_REG_OFF: u128 = 1;
+    const OP1_SRC_MASK: u128 = 0x001C;
+    const OP1_SRC_OFF: u128 = 2;
+    const RES_LOGIC_MASK: u128 = 0x0060;
+    const RES_LOGIC_OFF: u128 = 5;
+    const PC_UPDATE_MASK: u128 = 0x0380;
+    const PC_UPDATE_OFF: u128 = 7;
+    const AP_UPDATE_MASK: u128 = 0x0C00;
+    const AP_UPDATE_OFF: u128 = 10;
+    const OPCODE_MASK: u128 = 0x1F000; // 5 bits
+    const OPCODE_OFF: u128 = 12;
 
     // Flags start on the 48th bit.
-    const FLAGS_OFFSET: u64 = 48;
-    const OFF0_OFF: u64 = 0;
-    const OFF1_OFF: u64 = 16;
-    const OFF2_OFF: u64 = 32;
-    const OFFX_MASK: u64 = 0xFFFF;
+    const FLAGS_OFFSET: u128 = 48;
+    const OFF0_OFF: u128 = 0;
+    const OFF1_OFF: u128 = 16;
+    const OFF2_OFF: u128 = 32;
+    const OFFX_MASK: u128 = 0xFFFF;
 
-    if encoded_instr & HIGH_BIT != 0 {
-        return Err(VirtualMachineError::InstructionNonZeroHighBit);
+    if (encoded_instr & HIGH_BITS) != 0 {
+        return Err(VirtualMachineError::InstructionNonZeroHighBits);
     }
 
     // Grab offsets and convert them from little endian format.
@@ -95,6 +95,8 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
         1 => Opcode::Call,
         2 => Opcode::Ret,
         4 => Opcode::AssertEq,
+        8 => Opcode::Blake2s,
+        16 => Opcode::Blake2sLastBlock,
         _ => return Err(VirtualMachineError::InvalidOpcode(opcode_num)),
     };
 
@@ -127,8 +129,8 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
     })
 }
 
-fn decode_offset(offset: u64) -> isize {
-    let vectorized_offset: [u8; 8] = offset.to_le_bytes();
+fn decode_offset(offset: u128) -> isize {
+    let vectorized_offset: [u8; 8] = (offset as u64).to_le_bytes();
     let offset_16b_encoded = u16::from_le_bytes([vectorized_offset[0], vectorized_offset[1]]);
     let complement_const = 0x8000u16;
     let (offset_16b, _) = offset_16b_encoded.overflowing_sub(complement_const);
@@ -147,10 +149,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn non_zero_high_bit() {
-        let error = decode_instruction(0x94A7800080008000);
+        let error = decode_instruction(0x214a7800080008000);
         assert_eq!(
             error.unwrap_err().to_string(),
-            "Instruction MSB should be 0",
+            "Instruction bits 65 to 127 should be 0",
         )
     }
 
@@ -200,10 +202,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_call_add_jmp_add_imm_fp_fp() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |    CALL|      ADD|     JUMP|      ADD|    IMM|     FP|     FP
-        //  0  0  0  1      0  1   0  0  1      0  1 0  0  1       1       1
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |          CALL|      ADD|     JUMP|      ADD|    IMM|     FP|     FP
+        //         0| 0  0  0  0  1      0  1   0  0  1      0  1 0  0  1       1       1
         //  0001 0100 1010 0111 = 0x14A7; offx = 0
         let inst = decode_instruction(0x14A7800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::FP);
@@ -219,10 +221,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_ret_add1_jmp_rel_mul_fp_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     RET|     ADD1| JUMP_REL|      MUL|     FP|     AP|     AP
-        //  0  0  1  0      1  0   0  1  0      1  0 0  1  0       0       0
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |           RET|     ADD1| JUMP_REL|      MUL|     FP|     AP|     AP
+        //         0  0  0  0  1  0      1  0   0  1  0      1  0 0  1  0       0       0
         //  0010 1001 0100 1000 = 0x2948; offx = 0
         let inst = decode_instruction(0x2948800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -238,10 +240,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add_jnz_mul_ap_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |ASSRT_EQ|      ADD|      JNZ|      MUL|     AP|     AP|     AP
-        //  0  1  0  0      1  0   1  0  0      1  0 1  0  0       0       0
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |      ASSRT_EQ|      ADD|      JNZ|      MUL|     AP|     AP|     AP
+        //         0  0  0  1  0  0      1  0   1  0  0      1  0 1  0  0       0       0
         //  0100 1010 0101 0000 = 0x4A50; offx = 0
         let inst = decode_instruction(0x4A50800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -257,10 +259,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add2_jnz_uncon_op0_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |ASSRT_EQ|     ADD2|      JNZ|UNCONSTRD|    OP0|     AP|     AP
-        //  0  1  0  0      0  0   1  0  0      0  0 0  0  0       0       0
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |      ASSRT_EQ|     ADD2|      JNZ|UNCONSTRD|    OP0|     AP|     AP
+        //         0  0  0  1  0  0      0  0   1  0  0      0  0 0  0  0       0       0
         //  0100 0010 0000 0000 = 0x4200; offx = 0
         let inst = decode_instruction(0x4200800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -276,10 +278,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_nop_regu_regu_op1_op0_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
-        //  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |           NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
+        //         0  0  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
         //  0000 0000 0000 0000 = 0x0000; offx = 0
         let inst = decode_instruction(0x0000800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -295,10 +297,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_offset_negative() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
-        //  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
+        //         0|        opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        // 31 ... 17|16 15 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //          |           NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
+        //         0  0  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
         //  0000 0000 0000 0000 = 0x0000; offx = 0
         let inst = decode_instruction(0x0000800180007FFF).unwrap();
         assert_eq!(inst.off0, -1);

--- a/vm/src/vm/errors/memory_errors.rs
+++ b/vm/src/vm/errors/memory_errors.rs
@@ -101,6 +101,8 @@ pub enum MemoryError {
     UnrelocatedMemory,
     #[error("Malformed public memory")]
     MalformedPublicMemory,
+    #[error("Expected u32 at address {0}")]
+    ExpectedU32(Box<Relocatable>),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -34,20 +34,20 @@ pub enum VirtualMachineError {
     MainScopeError(#[from] ExecScopeError),
     #[error(transparent)]
     Other(anyhow::Error),
-    #[error("Instruction MSB should be 0")]
-    InstructionNonZeroHighBit,
+    #[error("Instruction bits 65 to 127 should be 0")]
+    InstructionNonZeroHighBits,
     #[error("Instruction should be an int")]
     InvalidInstructionEncoding,
     #[error("Invalid op1_register value: {0}")]
-    InvalidOp1Reg(u64),
+    InvalidOp1Reg(u128),
     #[error("In immediate mode, off2 should be 1")]
     ImmShouldBe1,
     #[error("op0 must be known in double dereference")]
     UnknownOp0,
     #[error("Invalid ap_update value: {0}")]
-    InvalidApUpdate(u64),
+    InvalidApUpdate(u128),
     #[error("Invalid pc_update value: {0}")]
-    InvalidPcUpdate(u64),
+    InvalidPcUpdate(u128),
     #[error("Res.UNCONSTRAINED cannot be used with ApUpdate.ADD")]
     UnconstrainedResAdd,
     #[error("Res.UNCONSTRAINED cannot be used with PcUpdate.JUMP")]
@@ -73,9 +73,9 @@ pub enum VirtualMachineError {
     #[error("Couldn't get or load dst")]
     NoDst,
     #[error("Invalid res value: {0}")]
-    InvalidRes(u64),
+    InvalidRes(u128),
     #[error("Invalid opcode value: {0}")]
-    InvalidOpcode(u64),
+    InvalidOpcode(u128),
     #[error("This is not implemented")]
     NotImplemented,
     #[error("Inconsistent auto-deduction for {}, expected {}, got {:?}", (*.0).0, (*.0).1, (*.0).2)]
@@ -136,6 +136,8 @@ pub enum VirtualMachineError {
     RelocationNotFound(usize),
     #[error("{} batch size is not {}", (*.0).0, (*.0).1)]
     ModBuiltinBatchSize(Box<(BuiltinName, usize)>),
+    #[error("Blake2s opcode invalid operand: op{0} does not point to {1} u32 numbers.")]
+    Blake2sInvalidOperand(u8, u8),
 }
 
 #[cfg(test)]

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -4,21 +4,24 @@ use crate::types::builtin_name::BuiltinName;
 #[cfg(feature = "extensive_hints")]
 use crate::types::program::HintRange;
 use crate::{
-    hint_processor::hint_processor_definition::HintProcessor,
+    hint_processor::{
+        builtin_hint_processor::blake2s_hash::blake2s_compress,
+        hint_processor_definition::HintProcessor,
+    },
     types::{
         errors::math_errors::MathError,
         exec_scope::ExecutionScopes,
         instruction::{
             is_call_instruction, ApUpdate, FpUpdate, Instruction, Opcode, PcUpdate, Res,
         },
-        relocatable::{MaybeRelocatable, Relocatable},
+        relocatable::{MaybeRelocatable, MaybeRelocatable::RelocatableValue, Relocatable},
     },
     vm::{
         context::run_context::RunContext,
         decoding::decoder::decode_instruction,
         errors::{
             exec_scope_errors::ExecScopeError, memory_errors::MemoryError,
-            vm_errors::VirtualMachineError,
+            memory_errors::MemoryError::AddressNotRelocatable, vm_errors::VirtualMachineError,
         },
         runners::builtin_runner::{
             BuiltinRunner, OutputBuiltinRunner, RangeCheckBuiltinRunner, SignatureBuiltinRunner,
@@ -39,6 +42,7 @@ use super::runners::builtin_runner::{ModBuiltinRunner, RC_N_PARTS_STANDARD};
 use super::runners::cairo_pie::CairoPie;
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
+const BLAKE2S_INPUT_BLOCK_BYTES: u32 = 64;
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Operands {
@@ -404,7 +408,9 @@ impl VirtualMachine {
     fn run_instruction(&mut self, instruction: &Instruction) -> Result<(), VirtualMachineError> {
         let (operands, operands_addresses, deduced_operands) =
             self.compute_operands(instruction)?;
+
         self.insert_deduced_operands(deduced_operands, &operands, &operands_addresses)?;
+
         self.opcode_assertions(instruction, &operands)?;
 
         if let Some(ref mut trace) = &mut self.trace {
@@ -438,8 +444,79 @@ impl VirtualMachine {
             .memory
             .mark_as_accessed(operands_addresses.op1_addr);
 
+        if instruction.opcode == Opcode::Blake2s || instruction.opcode == Opcode::Blake2sLastBlock {
+            self.handle_blake2s_instruction(
+                &operands,
+                instruction.opcode == Opcode::Blake2sLastBlock,
+            )?;
+        }
+
         self.update_registers(instruction, operands)?;
         self.current_step += 1;
+
+        Ok(())
+    }
+
+    /// Executes a Blake2s or Blake2sLastBlock instruction.
+    /// Expects operands to be RelocatableValue and to point to segments of memory.
+    /// op0 is expected to point to a sequence of 9 u32 values (state and counter t0).
+    /// op1 is expected to point to a sequence of 16 u32 values (message).
+    /// dst is expected to point to a sequence of 9 cells, with the first 8 being each either
+    /// unitialised or containing the Blake2s compression output at that index and the 9th index
+    /// unitialised or containing the updated byte counter.
+    /// Deviation from the aforementioned expectations will result in an error.
+    /// The instruction will update the dst memory segment with the new state and counter.
+    /// Note: currently in Blake2sLastBlock it is assumed that [op1]!=0 and if 0<=j<=15 is the last
+    /// index for which [op1+j]!=0 then the final block of the message is only 4*(j+1) bytes long.
+    fn handle_blake2s_instruction(
+        &mut self,
+        operands: &Operands,
+        is_last_block: bool,
+    ) -> Result<(), VirtualMachineError> {
+        let dst: Relocatable = match operands.dst {
+            RelocatableValue(relocatable) => relocatable,
+            _ => return Err(VirtualMachineError::Memory(AddressNotRelocatable)),
+        };
+
+        let state_and_t0: [u32; 9] = (self.get_u32_range(&operands.op0, 9)?)
+            .try_into()
+            .map_err(|_| VirtualMachineError::Blake2sInvalidOperand(0, 9))?;
+        let message = (self.get_u32_range(&operands.op1, 16)?)
+            .try_into()
+            .map_err(|_| VirtualMachineError::Blake2sInvalidOperand(1, 16))?;
+
+        let mut new_state = vec![];
+        let next_t0 = state_and_t0[8] + BLAKE2S_INPUT_BLOCK_BYTES;
+
+        if !is_last_block {
+            new_state.extend(blake2s_compress(
+                state_and_t0[0..8].try_into().unwrap(),
+                &message,
+                next_t0,
+                0,
+                0,
+                0,
+            ));
+            new_state.push(next_t0);
+        } else {
+            // Assumption: the last block of the message has BLAKE2S_INPUT_BLOCK_BYTES bytes.
+            new_state.extend(blake2s_compress(
+                state_and_t0[0..8].try_into().unwrap(),
+                &message,
+                next_t0,
+                0,
+                0xffffffff,
+                0,
+            ));
+            //new_state.extend(blake2s_last_block_raw(&state_and_t0, &message, 64));
+            //blake2s_compress(&state, message, t0, 0, 0xffffffff, 0)
+        }
+
+        for (i, &val) in new_state.iter().enumerate() {
+            self.segments
+                .memory
+                .insert_as_accessed((dst + i)?, MaybeRelocatable::Int(Felt252::from(val)))?;
+        }
 
         Ok(())
     }
@@ -449,7 +526,7 @@ impl VirtualMachine {
             .segments
             .memory
             .get_integer(self.run_context.pc)?
-            .to_u64()
+            .to_u128()
             .ok_or(VirtualMachineError::InvalidInstructionEncoding)?;
         decode_instruction(instruction)
     }
@@ -924,6 +1001,33 @@ impl VirtualMachine {
         size: usize,
     ) -> Result<Vec<Cow<Felt252>>, MemoryError> {
         self.segments.memory.get_integer_range(addr, size)
+    }
+
+    /// Gets n u32 values from memory starting from addr (n being size),
+    /// Verifies that addr is &RelocatableValue and that the values are u32.
+    pub fn get_u32_range(
+        &self,
+        addr: &MaybeRelocatable,
+        size: usize,
+    ) -> Result<Vec<u32>, MemoryError> {
+        let addr_relocatable: Relocatable = match addr {
+            &RelocatableValue(relocatable) => relocatable,
+            _ => return Err(MemoryError::AddressNotRelocatable),
+        };
+        let res_cow = self.get_integer_range(addr_relocatable, size)?;
+        let mut res = vec![];
+        for (i, x) in res_cow.iter().enumerate() {
+            let le_digits = x.clone().into_owned().to_le_digits();
+            if le_digits[0] >= (1 << 32)
+                || le_digits[1] != 0
+                || le_digits[2] != 0
+                || le_digits[3] != 0
+            {
+                return Err(MemoryError::ExpectedU32(Box::new((addr_relocatable + i)?)));
+            }
+            res.push(le_digits[0] as u32);
+        }
+        Ok(res)
     }
 
     pub fn get_range_check_builtin(
@@ -4122,7 +4226,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_current_instruction_invalid_encoding() {
         let mut vm = vm!();
-        vm.segments = segments![((0, 0), ("112233445566778899", 16))];
+        vm.segments = segments![((0, 0), ("112233445566778899112233445566778899", 16))];
         assert_matches!(
             vm.decode_current_instruction(),
             Err(VirtualMachineError::InvalidInstructionEncoding)


### PR DESCRIPTION
# Blake2s opcode runner
## Description
Adding two opcodes for Blake2s: Blake2s and Blake2sLastBlock.
Both expect op0 to be a pointer to a sequence of 9 felts and and op1 to be a pointer to a sequence of 16 felts.
Said felts should represent u32 integers, i.e. have value of at most 2**32-1.
The first 8 felts of op0 represent a state and the 9th represents a counter.
The 16 felts of op1 represent a message.
The "output" consists of 9 felts representing u32 numbers. The first 8 are the output of the appropriate Blake2s compression (either of a final block or a non final block) and the 9th is the updated counter.
in both cases dst should be a pointer, it points to a sequence of 9 cells which each should either be uninitialised or already contain a value matching that of the output at the same index.
The opcode inserts the aforementioned output into the 9 cells [dst], [dst+1], ... [dst+8] (and yields an error if one of said cells already contains a value differing from the output).

Currently Blake2sLastBlock assumes that [op1]!=0 and if 0<=j<=15 is the last index for which [op1+j]!=0 then the final block of the message is only 4*(j+1) bytes long.
Currently Blake2s and Blake2sLastBlock have opcode_num 8 and 16 respectively, meaning encoded_instr is expanded to 128 bits with the 63 most significant bits expected to be 0 (otherwise yield an error).

The motivation is that it has been decided at Starkware that Blake2s is to be implemented at an opcode, thus it needs to be supported by the runner.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [x] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.