### PR TITLE
implement Blake2s opcode in runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: implement `Blake2s` opcode in VM [#1927](https://github.com/lambdaclass/cairo-vm/pull/1927)
+
 * feat: remove `NonZeroReservedBits` from `VirtualMachineError` [#1948](https://github.com/lambdaclass/cairo-vm/pull/1948)
 
 * feat: set `encoded_instruction` to be u128 for opcode_extensions to come [#1940](https://github.com/lambdaclass/cairo-vm/pull/1940)

--- a/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
+++ b/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
@@ -1,0 +1,163 @@
+%builtins range_check bitwise
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_blake2s.blake2s import STATE_SIZE_FELTS, INPUT_BLOCK_FELTS, _get_sigma
+from starkware.cairo.common.cairo_blake2s.packed_blake2s import N_PACKED_INSTANCES, blake2s_compress
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+const COUNTER = 64;
+const U32_MASK = 0xffffffff;
+
+// Tests the Blake2s opcode runner using a preexisting implementation within the repo as reference.
+// The initial state, a random message of 64 bytes and counter are used as input.
+// Both the opcode and the reference implementation are run on the same inputs and then their outputs are compared.
+// Before comparing the outputs, it is verified that the opcode runner has written the output to the correct location.
+func main{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    alloc_locals;
+
+    let (local random_message) = alloc();
+    assert random_message[0] = 930933030;
+    assert random_message[1] = 1766240503;
+    assert random_message[2] = 3660871006;
+    assert random_message[3] = 388409270;
+    assert random_message[4] = 1948594622;
+    assert random_message[5] = 3119396969;
+    assert random_message[6] = 3924579183;
+    assert random_message[7] = 2089920034;
+    assert random_message[8] = 3857888532;
+    assert random_message[9] = 929304360;
+    assert random_message[10] = 1810891574;
+    assert random_message[11] = 860971754;
+    assert random_message[12] = 1822893775;
+    assert random_message[13] = 2008495810;
+    assert random_message[14] = 2958962335;
+    assert random_message[15] = 2340515744;
+
+    let (local input_state) = alloc();
+    // Set the initial state to IV (IV[0] is modified).
+    assert input_state[0] = 0x6B08E647;  // IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+    assert input_state[1] = 0xBB67AE85;
+    assert input_state[2] = 0x3C6EF372;
+    assert input_state[3] = 0xA54FF53A;
+    assert input_state[4] = 0x510E527F;
+    assert input_state[5] = 0x9B05688C;
+    assert input_state[6] = 0x1F83D9AB;
+    assert input_state[7] = 0x5BE0CD19;
+    static_assert STATE_SIZE_FELTS == 8;
+
+    // Use the packed blake2s_compress to compute the output of the first instance.
+    let (sigma) = _get_sigma();
+    let (local cairo_output) = alloc();
+    blake2s_compress(
+        h=input_state,
+        message=random_message,
+        t0=COUNTER,
+        f0=0,
+        sigma=sigma,
+        output=cairo_output,
+    );
+
+    // Unpack the first instance of the blake2s_compress output (extract the first 32 bits).
+    assert bitwise_ptr[0].x = cairo_output[0];
+    assert bitwise_ptr[0].y = U32_MASK;
+    assert bitwise_ptr[1].x = cairo_output[1];
+    assert bitwise_ptr[1].y = U32_MASK;
+    assert bitwise_ptr[2].x = cairo_output[2];
+    assert bitwise_ptr[2].y = U32_MASK;
+    assert bitwise_ptr[3].x = cairo_output[3];
+    assert bitwise_ptr[3].y = U32_MASK;
+    assert bitwise_ptr[4].x = cairo_output[4];
+    assert bitwise_ptr[4].y = U32_MASK;
+    assert bitwise_ptr[5].x = cairo_output[5];
+    assert bitwise_ptr[5].y = U32_MASK;
+    assert bitwise_ptr[6].x = cairo_output[6];
+    assert bitwise_ptr[6].y = U32_MASK;
+    assert bitwise_ptr[7].x = cairo_output[7];
+    assert bitwise_ptr[7].y = U32_MASK;
+
+    // Run the blake2s opcode runner on the same inputs and store its output.
+    let vm_output = run_blake2s(
+        dst=COUNTER,
+        op0=input_state,
+        op1=random_message,
+    );
+
+    // Verify that the opcode runner has written the 8 felts to the correct location.
+    tempvar check_nonempty = vm_output[0];
+    tempvar check_nonempty = vm_output[1];
+    tempvar check_nonempty = vm_output[2];
+    tempvar check_nonempty = vm_output[3];
+    tempvar check_nonempty = vm_output[4];
+    tempvar check_nonempty = vm_output[5];
+    tempvar check_nonempty = vm_output[6];
+    tempvar check_nonempty = vm_output[7];
+
+    // Compare the vm_output to the blake2s_compress first instance output.
+    assert vm_output[0] = bitwise_ptr[0].x_and_y;
+    assert vm_output[1] = bitwise_ptr[1].x_and_y;
+    assert vm_output[2] = bitwise_ptr[2].x_and_y;
+    assert vm_output[3] = bitwise_ptr[3].x_and_y;
+    assert vm_output[4] = bitwise_ptr[4].x_and_y;
+    assert vm_output[5] = bitwise_ptr[5].x_and_y;
+    assert vm_output[6] = bitwise_ptr[6].x_and_y;
+    assert vm_output[7] = bitwise_ptr[7].x_and_y;
+
+    let bitwise_ptr = bitwise_ptr + BitwiseBuiltin.SIZE * STATE_SIZE_FELTS;
+
+    return ();
+}
+
+// Forces the runner to execute the Blake2s with the given operands.
+// op0 is a pointer to an array of 8 felts as u32 integers of the state.
+// op1 is a pointer to an array of 16 felts as u32 integers of the messsage.
+// dst is a felt representing a u32 of the counter.
+// ap contains a pointer to an array of 8 felts as u32 integers of the output state.
+// Those values are stored within addresses fp-5, fp-4 and fp-3 respectively.
+// An instruction encoding is built from offsets -5, -4, -3 and flags which are all 0 except for
+// those denoting uses of fp as the base for operand addresses and flag_opcode_blake (16th flag).
+// The instruction is then written to [pc] and the runner is forced to execute Blake2s.
+func run_blake2s(
+    dst: felt,
+    op0: felt*,
+    op1: felt*,
+) -> felt* {
+    alloc_locals;
+
+    // Set the offsets for the operands.
+    let offset0 = (2**15)-5;
+    let offset1 = (2**15)-4;
+    let offset2 = (2**15)-3;
+    static_assert dst == [fp -5];
+    static_assert op0 == [fp -4];
+    static_assert op1 == [fp -3];
+
+    // Set the flags for the instruction.
+    let flag_dst_base_fp = 1;
+    let flag_op0_base_fp = 1;
+    let flag_op1_imm = 0;
+    let flag_op1_base_fp = 1;
+    let flag_op1_base_ap = 0;
+    let flag_res_add = 0;
+    let flag_res_mul = 0;
+    let flag_PC_update_jump = 0;
+    let flag_PC_update_jump_rel = 0;
+    let flag_PC_update_jnz = 0;
+    let flag_ap_update_add = 0;
+    let flag_ap_update_add_1 = 0;
+    let flag_opcode_call = 0;
+    let flag_opcode_ret = 0;
+    let flag_opcode_assert_eq = 0;
+    let flag_opcode_blake2s = 1;
+
+    // Build the instruction encoding.
+    let flag_num = flag_dst_base_fp+flag_op0_base_fp*(2**1)+flag_op1_imm*(2**2)+flag_op1_base_fp*(2**3)+flag_opcode_blake2s*(2**15);
+    let instruction_num = offset0 + offset1*(2**16) + offset2*(2**32) + flag_num*(2**48);
+    static_assert instruction_num==9226608988349300731;
+
+    // Write the instruction to [pc] and point [ap] to the designated output.
+    let (local vm_output) = alloc();
+    assert [ap] = cast(vm_output, felt);
+    dw 9226608988349300731;
+
+    return cast([ap], felt*);
+}

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -570,6 +570,14 @@ fn blake2s_integration_tests() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn blake2s_opcode_test() {
+    let program_data =
+        include_bytes!("../../../cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.json");
+    run_program_simple(program_data.as_slice());
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments.json");
     run_program_simple(program_data.as_slice());

--- a/vm/src/types/instruction.rs
+++ b/vm/src/types/instruction.rs
@@ -80,6 +80,7 @@ pub enum Opcode {
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum OpcodeExtension {
     Stone,
+    Blake,
 }
 
 impl Instruction {

--- a/vm/src/vm/decoding/decoder.rs
+++ b/vm/src/vm/decoding/decoder.rs
@@ -102,6 +102,17 @@ pub fn decode_instruction(encoded_instr: u128) -> Result<Instruction, VirtualMac
 
     let opcode_extension = match opcode_extension_num {
         0 => OpcodeExtension::Stone,
+        1 => {
+            if opcode != Opcode::NOp
+                || (op1_addr != Op1Addr::FP && op1_addr != Op1Addr::AP)
+                || res != Res::Op1
+                || pc_update != PcUpdate::Regular
+                || (ap_update_num != 0 && ap_update_num != 2)
+            {
+                return Err(VirtualMachineError::InvalidBlake2sFlags(flags & 0x7FFF));
+            };
+            OpcodeExtension::Blake
+        }
         _ => {
             return Err(VirtualMachineError::InvalidOpcodeExtension(
                 opcode_extension_num,
@@ -414,13 +425,59 @@ mod decoder_test {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn decode_opcode_extension_clash() {
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //  79 ... 17 16 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Blake|     CALL|  REGULAR|  REGULAR|      Op1|     FP|     AP|     AP
+        //                1   0  0  1      0  0   0  0  0      0  0 0  1  0       0       0
+        //  1001 0000 0000 1000 = 0x9008; off0 = 1, off1 = 1
+        let error = decode_instruction(0x9008800180018001);
+        assert_matches!(error, Err(VirtualMachineError::InvalidBlake2sFlags(4104)));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn decode_blake_imm() {
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //  79 ... 17 16 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Blake|      NOP|  REGULAR|  REGULAR|      Op1|    IMM|     AP|     AP
+        //                1   0  0  0      0  0   0  0  0      0  0 0  0  1       0       0
+        //  1000 0000 0000 0100 = 0x8004; off0 = 1, off1 = 1
+        let error = decode_instruction(0x8004800180018001);
+        assert_matches!(error, Err(VirtualMachineError::InvalidBlake2sFlags(4)));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn decode_blake() {
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //  79 ... 17 16 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Blake|      NOP|     ADD1|  REGULAR|      Op1|     AP|     FP|     FP
+        //                1   0  0  0      1  0   0  0  0      0  0 1  0  0       1       1
+        //  1000 1000 0001 0011 = 0x8813; off0 = 1, off1 = 1
+        let inst = decode_instruction(0x8813800180018001).unwrap();
+        assert_matches!(inst.opcode, Opcode::NOp);
+        assert_matches!(inst.off0, 1);
+        assert_matches!(inst.off1, 1);
+        assert_matches!(inst.dst_register, Register::FP);
+        assert_matches!(inst.op0_register, Register::FP);
+        assert_matches!(inst.op1_addr, Op1Addr::AP);
+        assert_matches!(inst.res, Res::Op1);
+        assert_matches!(inst.pc_update, PcUpdate::Regular);
+        assert_matches!(inst.ap_update, ApUpdate::Add1);
+        assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Blake);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_invalid_opcode_extension_error() {
         // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         //  79 ... 17 16 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
         //              ???|     CALL|     Add2|  JumpRel|      Op1|    IMM|     FP|     FP
-        //                1   0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
-        //  1001 0001 0000 0100 = 0x9104; off0 = 0, off1 = 1
-        let error = decode_instruction(0x9104800180018000);
-        assert_matches!(error, Err(VirtualMachineError::InvalidOpcodeExtension(1)));
+        //          0  1  1   0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
+        //  0001 1001 0001 0000 0100 = 0x39104; off0 = 0, off1 = 1
+        let error = decode_instruction(0x19104800180018000);
+        assert_matches!(error, Err(VirtualMachineError::InvalidOpcodeExtension(3)));
     }
 }

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -136,6 +136,10 @@ pub enum VirtualMachineError {
     RelocationNotFound(usize),
     #[error("{} batch size is not {}", (*.0).0, (*.0).1)]
     ModBuiltinBatchSize(Box<(BuiltinName, usize)>),
+    #[error("Blake2s opcode invalid operand: op{0} does not point to {1} u32 numbers.")]
+    Blake2sInvalidOperand(u8, u8),
+    #[error("Blake2s opcode invalid flags {0}")]
+    InvalidBlake2sFlags(u128),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Blake2s opcode runner
## Description
Adding the opcode Blake2s to the VM.
Expects op0 to be a pointer to a sequence of 8 felts and and op1 to be a pointer to a sequence of 16 felts.
Said felts should represent u32 integers, i.e. have value of at most 2**32-1.
The 8 felts of op0 represent a state and the 16 felts of op1 represent a message.
dst should hold the value of the counter.
The "output" consists of 8 felts representing u32 numbers of the output of the (non last block) Blake2s compression.
ap should store a pointer, it points to a sequence of 8 cells which each should either be uninitialised or already contain a value matching that of the output at the same index.
The opcode inserts the aforementioned output into the 8 cells [[ap]], [[ap]+1], ... [[ap]+7] (and yields an error if one of said cells already contains a value differing from the output).

Currently Blake2s has opcode_num 8, meaning encoded_instr can use all 64 bits and InstructionNonZeroHighBits is no longer needed as an error.

The motivation is that it has been decided at Starkware that Blake2s is to be implemented at an opcode, thus it needs to be supported by the runner.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [x] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/1927)
<!-- Reviewable:end -->
