### PR TITLE
introduce opcode_extension to the structure of Instruction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: add the field `opcode_extension` to the structure of `Instruction` [#1933](https://github.com/lambdaclass/cairo-vm/pull/1933)
+
 * fix(BREAKING): Fix no trace padding flow in proof mode [#1909](https://github.com/lambdaclass/cairo-vm/pull/1909)
 
 * refactor: Limit ret opcode decodeing to Cairo0's standards. [#1925](https://github.com/lambdaclass/cairo-vm/pull/1925)

--- a/vm/src/types/instruction.rs
+++ b/vm/src/types/instruction.rs
@@ -27,6 +27,7 @@ pub struct Instruction {
     pub ap_update: ApUpdate,
     pub fp_update: FpUpdate,
     pub opcode: Opcode,
+    pub opcode_extension: OpcodeExtension,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -74,6 +75,11 @@ pub enum Opcode {
     AssertEq,
     Call,
     Ret,
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum OpcodeExtension {
+    Stone,
 }
 
 impl Instruction {

--- a/vm/src/vm/context/run_context.rs
+++ b/vm/src/vm/context/run_context.rs
@@ -106,7 +106,7 @@ mod tests {
     use super::*;
     use crate::relocatable;
     use crate::stdlib::string::ToString;
-    use crate::types::instruction::{ApUpdate, FpUpdate, Opcode, PcUpdate, Res};
+    use crate::types::instruction::{ApUpdate, FpUpdate, Opcode, OpcodeExtension, PcUpdate, Res};
     use crate::utils::test_utils::mayberelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::Felt252;
@@ -130,6 +130,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -158,6 +159,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -187,6 +189,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -215,6 +218,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -243,6 +247,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -271,6 +276,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -299,6 +305,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -327,6 +334,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -358,6 +366,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -388,6 +397,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {
@@ -420,6 +430,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let run_context = RunContext {

--- a/vm/src/vm/decoding/decoder.rs
+++ b/vm/src/vm/decoding/decoder.rs
@@ -1,16 +1,18 @@
 use crate::{
     types::instruction::{
-        ApUpdate, FpUpdate, Instruction, Op1Addr, Opcode, PcUpdate, Register, Res,
+        ApUpdate, FpUpdate, Instruction, Op1Addr, Opcode, OpcodeExtension, PcUpdate, Register, Res,
     },
     vm::errors::vm_errors::VirtualMachineError,
 };
 
-//  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-// 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+// opcode_extension|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+//           ... 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
 
 /// Decodes an instruction. The encoding is little endian, so flags go from bit 63 to 48.
+/// The bits 64 and beyond are reserved for the opcode extension.
+/// opcode_extension_num=0 means the instruction is a Stone instruction.
+/// opcode_extension_num>1 is for new Stwo opcodes.
 pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMachineError> {
-    const HIGH_BIT: u64 = 1u64 << 63;
     const DST_REG_MASK: u64 = 0x0001;
     const DST_REG_OFF: u64 = 0;
     const OP0_REG_MASK: u64 = 0x0002;
@@ -25,6 +27,7 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
     const AP_UPDATE_OFF: u64 = 10;
     const OPCODE_MASK: u64 = 0x7000;
     const OPCODE_OFF: u64 = 12;
+    const OPCODE_EXTENSION_OFF: u64 = 63;
 
     // Flags start on the 48th bit.
     const FLAGS_OFFSET: u64 = 48;
@@ -32,10 +35,6 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
     const OFF1_OFF: u64 = 16;
     const OFF2_OFF: u64 = 32;
     const OFFX_MASK: u64 = 0xFFFF;
-
-    if encoded_instr & HIGH_BIT != 0 {
-        return Err(VirtualMachineError::InstructionNonZeroHighBit);
-    }
 
     // Grab offsets and convert them from little endian format.
     let off0 = decode_offset(encoded_instr >> OFF0_OFF & OFFX_MASK);
@@ -52,6 +51,9 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
     let pc_update_num = (flags & PC_UPDATE_MASK) >> PC_UPDATE_OFF;
     let ap_update_num = (flags & AP_UPDATE_MASK) >> AP_UPDATE_OFF;
     let opcode_num = (flags & OPCODE_MASK) >> OPCODE_OFF;
+
+    // Grab opcode_extension
+    let opcode_extension_num = encoded_instr >> OPCODE_EXTENSION_OFF;
 
     // Match each flag to its corresponding enum value
     let dst_register = if dst_reg_num == 1 {
@@ -96,6 +98,15 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
         2 => Opcode::Ret,
         4 => Opcode::AssertEq,
         _ => return Err(VirtualMachineError::InvalidOpcode(opcode_num)),
+    };
+
+    let opcode_extension = match opcode_extension_num {
+        0 => OpcodeExtension::Stone,
+        _ => {
+            return Err(VirtualMachineError::InvalidOpcodeExtension(
+                opcode_extension_num,
+            ))
+        }
     };
 
     let ap_update = match (ap_update_num, opcode == Opcode::Call) {
@@ -145,6 +156,7 @@ pub fn decode_instruction(encoded_instr: u64) -> Result<Instruction, VirtualMach
         ap_update,
         fp_update,
         opcode,
+        opcode_extension,
     })
 }
 
@@ -164,16 +176,6 @@ mod decoder_test {
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
-
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn non_zero_high_bit() {
-        let error = decode_instruction(0x94A7800080008000);
-        assert_eq!(
-            error.unwrap_err().to_string(),
-            "Instruction MSB should be 0",
-        )
-    }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -221,10 +223,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_nop_add_jmp_add_imm_fp_fp() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |    NOp|      ADD|     JUMP|      ADD|    IMM|     FP|     FP
-        //  0  0  0  0      0  1   0  0  1      0  1 0  0  1       1       1
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      NOp|      ADD|     JUMP|      ADD|    IMM|     FP|     FP
+        //                0   0  0  0      0  1   0  0  1      0  1 0  0  1       1       1
         //  0000 0100 1010 0111 = 0x04A7; offx = 0
         let inst = decode_instruction(0x04A7800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::FP);
@@ -235,15 +237,16 @@ mod decoder_test {
         assert_matches!(inst.ap_update, ApUpdate::Add);
         assert_matches!(inst.opcode, Opcode::NOp);
         assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_nop_add1_jmp_rel_mul_fp_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     NOp|     ADD1| JUMP_REL|      MUL|     FP|     AP|     AP
-        //  0  0  0  0      1  0   0  1  0      1  0 0  1  0       0       0
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      NOp|     ADD1| JUMP_REL|      MUL|     FP|     AP|     AP
+        //                0   0  0  0      1  0   0  1  0      1  0 0  1  0       0       0
         //  0000 1001 0100 1000 = 0x0948; offx = 0
         let inst = decode_instruction(0x0948800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -254,15 +257,16 @@ mod decoder_test {
         assert_matches!(inst.ap_update, ApUpdate::Add1);
         assert_matches!(inst.opcode, Opcode::NOp);
         assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add_regular_mul_ap_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |ASSRT_EQ|      ADD|  REGULAR|      MUL|     AP|     AP|     AP
-        //  0  1  0  0      1  0   0  0  0      1  0 1  0  0       0       0
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone| ASSRT_EQ|      ADD|  REGULAR|      MUL|     AP|     AP|     AP
+        //                0   1  0  0      1  0   0  0  0      1  0 1  0  0       0       0
         //  0100 1000 0101 0000 = 0x4850; offx = 0
         let inst = decode_instruction(0x4850800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -273,15 +277,16 @@ mod decoder_test {
         assert_matches!(inst.ap_update, ApUpdate::Add1);
         assert_matches!(inst.opcode, Opcode::AssertEq);
         assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_assrt_add2_jnz_uncon_op0_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |ASSRT_EQ|     ADD2|      JNZ|UNCONSTRD|    OP0|     AP|     AP
-        //  0  1  0  0      0  0   1  0  0      0  0 0  0  0       0       0
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone| ASSRT_EQ|     ADD2|      JNZ|UNCONSTRD|    OP0|     AP|     AP
+        //                0   1  0  0      0  0   1  0  0      0  0 0  0  0       0       0
         //  0100 0010 0000 0000 = 0x4200; offx = 0
         let inst = decode_instruction(0x4200800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -292,15 +297,16 @@ mod decoder_test {
         assert_matches!(inst.ap_update, ApUpdate::Regular);
         assert_matches!(inst.opcode, Opcode::AssertEq);
         assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_flags_nop_regu_regu_op1_op0_ap_ap() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
-        //  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
+        //                0   0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
         //  0000 0000 0000 0000 = 0x0000; offx = 0
         let inst = decode_instruction(0x0000800080008000).unwrap();
         assert_matches!(inst.dst_register, Register::AP);
@@ -311,15 +317,16 @@ mod decoder_test {
         assert_matches!(inst.ap_update, ApUpdate::Regular);
         assert_matches!(inst.opcode, Opcode::NOp);
         assert_matches!(inst.fp_update, FpUpdate::Regular);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_offset_negative() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
-        //  0  0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      NOP|  REGULAR|  REGULAR|      OP1|    OP0|     AP|     AP
+        //                0   0  0  0      0  0   0  0  0      0  0 0  0  0       0       0
         //  0000 0000 0000 0000 = 0x0000; offx = 0
         let inst = decode_instruction(0x0000800180007FFF).unwrap();
         assert_eq!(inst.off0, -1);
@@ -330,10 +337,10 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_ret_cairo_standard() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     RET|  REGULAR|     JUMP|      Op1|     FP|     FP|     FP
-        //  0  0  1  0      0  0   0  0  1      0  0 0  1  0       1       1
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      RET|  REGULAR|     JUMP|      Op1|     FP|     FP|     FP
+        //                0   0  1  0      0  0   0  0  1      0  0 0  1  0       1       1
         //  0010 0000 1000 1011 = 0x208b; off0 = -2, off1 = -1
         let inst = decode_instruction(0x208b7fff7fff7ffe).unwrap();
         assert_matches!(inst.opcode, Opcode::Ret);
@@ -346,16 +353,17 @@ mod decoder_test {
         assert_matches!(inst.pc_update, PcUpdate::Jump);
         assert_matches!(inst.ap_update, ApUpdate::Regular);
         assert_matches!(inst.fp_update, FpUpdate::Dst);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_call_cairo_standard() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |    CALL|     Add2|  JumpRel|      Op1|     FP|     FP|     FP
-        //  0  0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
-        //  0001 0001 0000 0100 = 0x208b; off0 = 0, off1 = 1
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|     CALL|     Add2|  JumpRel|      Op1|    IMM|     FP|     FP
+        //                0   0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
+        //  0001 0001 0000 0100 = 0x1104; off0 = 0, off1 = 1
         let inst = decode_instruction(0x1104800180018000).unwrap();
         assert_matches!(inst.opcode, Opcode::Call);
         assert_matches!(inst.off0, 0);
@@ -367,15 +375,16 @@ mod decoder_test {
         assert_matches!(inst.pc_update, PcUpdate::JumpRel);
         assert_matches!(inst.ap_update, ApUpdate::Add2);
         assert_matches!(inst.fp_update, FpUpdate::APPlus2);
+        assert_matches!(inst.opcode_extension, OpcodeExtension::Stone);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_ret_opcode_error() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |     RET|  REGULAR|     JUMP|      Op1|     FP|     FP|     FP
-        //  0  0  1  0      0  0   0  0  1      0  0 0  1  0       1       1
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|      RET|  REGULAR|     JUMP|      Op1|     FP|     FP|     FP
+        //                0   0  1  0      0  0   0  0  1      0  0 0  1  0       1       1
         //  0010 0000 1000 1011 = 0x208b; off0 = -1, off1 = -1
         let error = decode_instruction(0x208b7fff7fff7fff);
         assert_matches!(error, Err(VirtualMachineError::InvalidOpcode(2)));
@@ -384,12 +393,24 @@ mod decoder_test {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn decode_call_opcode_error() {
-        //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
-        // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
-        //   |    CALL|     Add2|  JumpRel|      Op1|     FP|     FP|     FP
-        //  0  0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
-        //  0001 0001 0000 0100 = 0x208b; off0 = 1, off1 = 1
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //            Stone|     CALL|     Add2|  JumpRel|      Op1|     FP|     FP|     FP
+        //                0   0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
+        //  0001 0001 0000 0100 = 0x1104; off0 = 1, off1 = 1
         let error = decode_instruction(0x1104800180018001);
         assert_matches!(error, Err(VirtualMachineError::InvalidOpcode(1)));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn decode_invalid_opcode_extension_error() {
+        // opcode_extension|   opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
+        //           ... 15| 14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0
+        //              ???|     CALL|     Add2|  JumpRel|      Op1|    IMM|     FP|     FP
+        //                1   0  0  1      0  0   0  1  0      0  0 0  0  1       0       0
+        //  1001 0001 0000 0100 = 0x9104; off0 = 0, off1 = 1
+        let error = decode_instruction(0x9104800180018000);
+        assert_matches!(error, Err(VirtualMachineError::InvalidOpcodeExtension(1)));
     }
 }

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -34,8 +34,6 @@ pub enum VirtualMachineError {
     MainScopeError(#[from] ExecScopeError),
     #[error(transparent)]
     Other(anyhow::Error),
-    #[error("Instruction MSB should be 0")]
-    InstructionNonZeroHighBit,
     #[error("Instruction should be an int")]
     InvalidInstructionEncoding,
     #[error("Invalid op1_register value: {0}")]
@@ -76,6 +74,8 @@ pub enum VirtualMachineError {
     InvalidRes(u64),
     #[error("Invalid opcode value: {0}")]
     InvalidOpcode(u64),
+    #[error("Invalid opcode extension value: {0}")]
+    InvalidOpcodeExtension(u64),
     #[error("This is not implemented")]
     NotImplemented,
     #[error("Inconsistent auto-deduction for {}, expected {}, got {:?}", (*.0).0, (*.0).1, (*.0).2)]

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1268,6 +1268,7 @@ mod tests {
     use super::*;
     use crate::felt_hex;
     use crate::stdlib::collections::HashMap;
+    use crate::types::instruction::OpcodeExtension;
     use crate::types::layout_name::LayoutName;
     use crate::types::program::Program;
     use crate::{
@@ -1306,6 +1307,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1339,6 +1341,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Dst,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1372,6 +1375,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1405,6 +1409,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Dst,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1439,6 +1444,7 @@ mod tests {
             ap_update: ApUpdate::Add,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1475,6 +1481,7 @@ mod tests {
             ap_update: ApUpdate::Add,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1510,6 +1517,7 @@ mod tests {
             ap_update: ApUpdate::Add1,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1546,6 +1554,7 @@ mod tests {
             ap_update: ApUpdate::Add2,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1582,6 +1591,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1618,6 +1628,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1651,6 +1662,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1684,6 +1696,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1717,6 +1730,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1752,6 +1766,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1786,6 +1801,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1818,6 +1834,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1849,6 +1866,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1882,6 +1900,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1915,6 +1934,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -1953,6 +1973,7 @@ mod tests {
             ap_update: ApUpdate::Add2,
             fp_update: FpUpdate::Dst,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -2003,6 +2024,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::Call,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2031,6 +2053,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2063,6 +2086,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2090,6 +2114,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2122,6 +2147,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2151,6 +2177,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2180,6 +2207,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::Ret,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2210,6 +2238,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::Call,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2237,6 +2266,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2268,6 +2298,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2294,6 +2325,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2325,6 +2357,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2354,6 +2387,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2382,6 +2416,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2412,6 +2447,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2441,6 +2477,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2470,6 +2507,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2499,6 +2537,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2526,6 +2565,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2553,6 +2593,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2579,6 +2620,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2601,6 +2643,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::Call,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2626,6 +2669,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::Ret,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let vm = vm!();
@@ -2648,6 +2692,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let mut vm = vm!();
@@ -2708,6 +2753,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
         let mut vm = vm!();
         //Create program and execution segments
@@ -2767,6 +2813,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let mut vm = vm!();
@@ -2822,6 +2869,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let mut vm = vm!();
@@ -2847,6 +2895,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -2877,6 +2926,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -2911,6 +2961,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -2943,6 +2994,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::Call,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -2976,6 +3028,7 @@ mod tests {
             ap_update: ApUpdate::Regular,
             fp_update: FpUpdate::APPlus2,
             opcode: Opcode::Call,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let operands = Operands {
@@ -3343,6 +3396,7 @@ mod tests {
             ap_update: ApUpdate::Add1,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
         let mut builtin = HashBuiltinRunner::new(Some(8), true);
         builtin.base = 3;
@@ -3431,6 +3485,7 @@ mod tests {
             ap_update: ApUpdate::Add1,
             fp_update: FpUpdate::Regular,
             opcode: Opcode::AssertEq,
+            opcode_extension: OpcodeExtension::Stone,
         };
 
         let mut builtin = BitwiseBuiltinRunner::new(Some(256), true);


### PR DESCRIPTION
# Introduce opcode_extension to the structure of Instruction

## Description
In preparation for adding new opcodes to Stwo, we introduce another field named opcode_extension to the structure Instruction.
That field is an enum that in the future will denote which of the new opcodes is being used in the instruction.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/1933)
<!-- Reviewable:end -->
