### PR TITLE
Update actions/cache to its recommended version

### DIFF
--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Cache Inputs
       id: cache-inputs
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       with:
       # Path where the inputs for the fuzzer are stored
         path: fuzzer/hfuzz_workspace/fuzz_json/input

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Cache Inputs
       id: cache-inputs
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v3.4.0
       with:
       # Path where the inputs for the fuzzer are stored
         path: fuzzer/hfuzz_workspace/fuzz_json/input

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
 
       - name: Fetch from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: ${{ matrix.branch }}_programs/*.json
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Populate cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: bin/cairo-vm-cli-${{ matrix.branch }}
@@ -108,25 +108,25 @@ jobs:
         tool: hyperfine@1.16
 
     - name: Fetch base binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: bin/cairo-vm-cli-base
         key: binary-${{ github.event.pull_request.base.sha }}
 
     - name: Fetch HEAD binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: bin/cairo-vm-cli-head
         key: binary-${{ github.event.pull_request.head.sha }}
 
     - name: Fetch base programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: base_programs/*.json
         key: benchmarks-base-${{ needs.build-programs.outputs.benchmark-hashes-base }}
 
     - name: Fetch head programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: head_programs/*.json
         key: benchmarks-head-${{ needs.build-programs.outputs.benchmark-hashes-head }}

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
 
       - name: Fetch from cache
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v3.4.0
         id: cache
         with:
           path: ${{ matrix.branch }}_programs/*.json
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Populate cache
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v3.4.0
         id: cache
         with:
           path: bin/cairo-vm-cli-${{ matrix.branch }}
@@ -108,25 +108,25 @@ jobs:
         tool: hyperfine@1.16
 
     - name: Fetch base binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: bin/cairo-vm-cli-base
         key: binary-${{ github.event.pull_request.base.sha }}
 
     - name: Fetch HEAD binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: bin/cairo-vm-cli-head
         key: binary-${{ github.event.pull_request.head.sha }}
 
     - name: Fetch base programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: base_programs/*.json
         key: benchmarks-base-${{ needs.build-programs.outputs.benchmark-hashes-base }}
 
     - name: Fetch head programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: head_programs/*.json
         key: benchmarks-head-${{ needs.build-programs.outputs.benchmark-hashes-head }}

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -29,7 +29,7 @@ jobs:
       run: make iai-benchmark-action
 
     - name: Save cache for ${{ github.sha }}
-      uses: actions/cache/save@v4.2.0
+      uses: actions/cache/save@v3.4.0
       with:
         path: |
           */target/iai/iai_benchmark/

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -29,7 +29,7 @@ jobs:
       run: make iai-benchmark-action
 
     - name: Save cache for ${{ github.sha }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4.2.0
       with:
         path: |
           */target/iai/iai_benchmark/

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.base.sha }}
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v3.4.0
       id: cache-iai-results
       with:
         path: |
@@ -66,7 +66,7 @@ jobs:
         cargo install --version 0.3.1 iai-callgrind-runner
 
     - name: Restore cache for ${{ github.event.pull_request.base.sha }}
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: |
           */target/iai/iai_benchmark/

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.base.sha }}
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       id: cache-iai-results
       with:
         path: |
@@ -66,7 +66,7 @@ jobs:
         cargo install --version 0.3.1 iai-callgrind-runner
 
     - name: Restore cache for ${{ github.event.pull_request.base.sha }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           */target/iai/iai_benchmark/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch from cache
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v3.4.0
       id: cache-programs
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
@@ -119,38 +119,38 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch test programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch proof programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch bench programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_bench_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 1)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_1_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 2)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_2_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
 
     - name: Merge caches
-      uses: actions/cache/save@v4.2.0
+      uses: actions/cache/save@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -179,7 +179,7 @@ jobs:
 
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -224,7 +224,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -271,7 +271,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -306,7 +306,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -343,7 +343,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -385,7 +385,7 @@ jobs:
 
     - name: Save coverage
       if: matrix.target != 'test-wasm'
-      uses: actions/cache/save@v4.2.0
+      uses: actions/cache/save@v3.4.0
       with:
         path: lcov-${{ matrix.target }}-${{ matrix.special_features }}.info
         key: codecov-cache-${{ matrix.target }}-${{ matrix.special_features }}-${{ github.sha }}
@@ -404,7 +404,7 @@ jobs:
       run: cargo b --release -p cairo-vm-cli
     # We don't read from cache because it should always miss
     - name: Store in cache
-      uses: actions/cache/save@v4.2.0
+      uses: actions/cache/save@v3.4.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -434,7 +434,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Check cache
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v3.4.0
       id: trace-cache
       with:
         path: |
@@ -459,7 +459,7 @@ jobs:
 
     - name: Fetch programs
       if: steps.trace-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -494,7 +494,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Fetch release binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -506,7 +506,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -520,7 +520,7 @@ jobs:
         --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace \
         ${{ matrix.extra-args }}
     - name: Update cache
-      uses: actions/cache/save@v4.2.0
+      uses: actions/cache/save@v3.4.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -540,92 +540,92 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Fetch results for tests with stdlib (part. 1)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#1-.info
         key: codecov-cache-test#1--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 2)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#2-.info
         key: codecov-cache-test#2--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 3)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#3-.info
         key: codecov-cache-test#3--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 4)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#4-.info
         key: codecov-cache-test#4--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test-no_std-.info
         key: codecov-cache-test-no_std--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 1)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#1-extensive_hints.info
         key: codecov-cache-test#1-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 2)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#2-extensive_hints.info
         key: codecov-cache-test#2-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 3)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#3-extensive_hints.info
         key: codecov-cache-test#3-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 4)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#4-extensive_hints.info
         key: codecov-cache-test#4-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib (w/extensive_hints)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-no_std-extensive_hints.info
         key: codecov-cache-test-no_std-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
 
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 1)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#1-mod_builtin.info
         key: codecov-cache-test#1-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 2)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#2-mod_builtin.info
         key: codecov-cache-test#2-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 3)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#3-mod_builtin.info
         key: codecov-cache-test#3-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 4)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-test#4-mod_builtin.info
         key: codecov-cache-test#4-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib (w/mod_builtin)
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: lcov-no_std-mod_builtin.info
         key: codecov-cache-test-no_std-mod_builtin-${{ github.sha }}
@@ -656,7 +656,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch traces for cairo-lang
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -668,7 +668,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -734,7 +734,7 @@ jobs:
       run: pip install -r requirements.txt
       
     - name: Fetch release binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -746,7 +746,7 @@ jobs:
         path: cairo_programs/proof_programs/
     
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -773,7 +773,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Fetch release binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -785,14 +785,14 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
 
     - name: Fetch pie
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -824,14 +824,14 @@ jobs:
       run: pip install -r requirements.txt
       
     - name: Fetch release binary
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
         fail-on-cache-miss: true
     
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@v4.2.0
+      uses: actions/cache/restore@v3.4.0
       with:
         path: |
           cairo_programs/**/*.memory

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -632,7 +632,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: '*.info'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -632,7 +632,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v4.2.0
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: '*.info'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       id: cache-programs
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
@@ -119,38 +119,38 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch test programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch proof programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch bench programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_bench_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 1)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_1_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 2)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_2_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
 
     - name: Merge caches
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -179,7 +179,7 @@ jobs:
 
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -224,7 +224,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -271,7 +271,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -306,7 +306,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -343,7 +343,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -385,7 +385,7 @@ jobs:
 
     - name: Save coverage
       if: matrix.target != 'test-wasm'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4.2.0
       with:
         path: lcov-${{ matrix.target }}-${{ matrix.special_features }}.info
         key: codecov-cache-${{ matrix.target }}-${{ matrix.special_features }}-${{ github.sha }}
@@ -404,7 +404,7 @@ jobs:
       run: cargo b --release -p cairo-vm-cli
     # We don't read from cache because it should always miss
     - name: Store in cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4.2.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -434,7 +434,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Check cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       id: trace-cache
       with:
         path: |
@@ -459,7 +459,7 @@ jobs:
 
     - name: Fetch programs
       if: steps.trace-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -494,7 +494,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Fetch release binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -506,7 +506,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -520,7 +520,7 @@ jobs:
         --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace \
         ${{ matrix.extra-args }}
     - name: Update cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4.2.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -540,99 +540,99 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Fetch results for tests with stdlib (part. 1)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#1-.info
         key: codecov-cache-test#1--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 2)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#2-.info
         key: codecov-cache-test#2--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 3)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#3-.info
         key: codecov-cache-test#3--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 4)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#4-.info
         key: codecov-cache-test#4--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test-no_std-.info
         key: codecov-cache-test-no_std--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 1)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#1-extensive_hints.info
         key: codecov-cache-test#1-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 2)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#2-extensive_hints.info
         key: codecov-cache-test#2-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 3)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#3-extensive_hints.info
         key: codecov-cache-test#3-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 4)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#4-extensive_hints.info
         key: codecov-cache-test#4-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib (w/extensive_hints)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-no_std-extensive_hints.info
         key: codecov-cache-test-no_std-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
 
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 1)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#1-mod_builtin.info
         key: codecov-cache-test#1-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 2)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#2-mod_builtin.info
         key: codecov-cache-test#2-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 3)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#3-mod_builtin.info
         key: codecov-cache-test#3-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/mod_builtin; part. 4)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-test#4-mod_builtin.info
         key: codecov-cache-test#4-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests without stdlib (w/mod_builtin)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: lcov-no_std-mod_builtin.info
         key: codecov-cache-test-no_std-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4.2.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: '*.info'
@@ -656,7 +656,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch traces for cairo-lang
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -668,7 +668,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -734,7 +734,7 @@ jobs:
       run: pip install -r requirements.txt
       
     - name: Fetch release binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -746,7 +746,7 @@ jobs:
         path: cairo_programs/proof_programs/
     
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
@@ -773,7 +773,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Fetch release binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -785,14 +785,14 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
         fail-on-cache-miss: true
 
     - name: Fetch pie
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           cairo_programs/**/*.memory
@@ -824,14 +824,14 @@ jobs:
       run: pip install -r requirements.txt
       
     - name: Fetch release binary
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
         fail-on-cache-miss: true
     
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           cairo_programs/**/*.memory

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -51,7 +51,7 @@ jobs:
 
       # we don't use swatinem because rustc isn't installed yet
       - name: Cache Rust dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v3.4.0
         with:
           path: |
             ~/.cargo/
@@ -70,7 +70,7 @@ jobs:
 
       # NOTE: we don't use install-python because lsb_release isn't installed
       - name: Cache Python dependencies
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v3.4.0
         with:
           path: |
             ~/.cache/pip/wheels

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -51,7 +51,7 @@ jobs:
 
       # we don't use swatinem because rustc isn't installed yet
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.0
         with:
           path: |
             ~/.cargo/
@@ -70,7 +70,7 @@ jobs:
 
       # NOTE: we don't use install-python because lsb_release isn't installed
       - name: Cache Python dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.2.0
         with:
           path: |
             ~/.cache/pip/wheels


### PR DESCRIPTION
# TITLE

## Description
There are some versions which will be deprecated (making the ci to fail) soon. This version I've updated to is one of the recommended ones.
See: https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

