### PR TITLE
Check overflow in cairo pie address calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Check overflow in cairo pie address calculation [#1945](https://github.com/lambdaclass/cairo-vm/pull/1945)
+
 * fix(BREAKING): Fix no trace padding flow in proof mode [#1909](https://github.com/lambdaclass/cairo-vm/pull/1909)
 
 * refactor: Limit ret opcode decodeing to Cairo0's standards. [#1925](https://github.com/lambdaclass/cairo-vm/pull/1925)

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -528,7 +528,9 @@ pub(super) mod serde_impl {
                 .and_then(|n| n.checked_add(ADDR_BASE))
                 .and_then(|n| n.checked_add(*offset as u64))
                 .ok_or_else(|| {
-                    serde::ser::Error::custom("final memory address calculation overflowed")
+                    serde::ser::Error::custom(format!(
+                        "failed to serialize address: {segment}:{offset}"
+                    ))
                 })?;
 
             res.extend_from_slice(mem_addr.to_le_bytes().as_ref());

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -858,6 +858,17 @@ mod test {
         );
     }
 
+    #[test]
+    fn serialize_cairo_pie_memory_with_overflow() {
+        let memory = CairoPieMemory(vec![
+            ((0, 0), MaybeRelocatable::Int(0.into())),
+            ((0, 1), MaybeRelocatable::Int(1.into())),
+            ((usize::MAX, 0), MaybeRelocatable::Int(2.into())),
+        ]);
+
+        serde_json::to_value(memory).unwrap_err();
+    }
+
     #[rstest]
     #[cfg(feature = "std")]
     #[case(include_bytes!("../../../../cairo_programs/fibonacci.json"), "fibonacci")]


### PR DESCRIPTION
# Check overflow in cairo pie address calculation

## Description

Uses `checked_add` and `checked_mul` to return explicit errors rather than silently failing in case of an overflow.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

