### PR TITLE
remove NonZeroReservedBits from VirtualMachineError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: remove `NonZeroReservedBits` from `VirtualMachineError` [#1948](https://github.com/lambdaclass/cairo-vm/pull/1948)
+
 * feat: set `encoded_instruction` to be u128 for opcode_extensions to come [#1940](https://github.com/lambdaclass/cairo-vm/pull/1940)
 
 * feat: add `get_u32_range` to `impl VirtualMachine` add `get_u32` and `get_u32_range` to `impl Memory` [#1936](https://github.com/lambdaclass/cairo-vm/pull/1936)

--- a/vm/src/vm/decoding/decoder.rs
+++ b/vm/src/vm/decoding/decoder.rs
@@ -13,8 +13,6 @@ use crate::{
 /// opcode_extension_num=0 means the instruction is a Stone instruction.
 /// opcode_extension_num>0 is for new Stwo opcodes.
 pub fn decode_instruction(encoded_instr: u128) -> Result<Instruction, VirtualMachineError> {
-    // HIGH_BITS_MASK is a mask to extract the high bits that are yet to be used in any opcode extension.
-    const HIGH_BITS_MASK: u128 = ((1 << 127) - (1 << 64)) << 1;
     const DST_REG_MASK: u128 = 0x0001;
     const DST_REG_OFF: u128 = 0;
     const OP0_REG_MASK: u128 = 0x0002;
@@ -37,10 +35,6 @@ pub fn decode_instruction(encoded_instr: u128) -> Result<Instruction, VirtualMac
     const OFF1_OFF: u128 = 16;
     const OFF2_OFF: u128 = 32;
     const OFFX_MASK: u128 = 0xFFFF;
-
-    if (encoded_instr & HIGH_BITS_MASK) != 0 {
-        return Err(VirtualMachineError::NonZeroReservedBits);
-    }
 
     // Grab offsets and convert them from little endian format.
     let off0 = decode_offset(encoded_instr >> OFF0_OFF & OFFX_MASK);
@@ -189,7 +183,7 @@ mod decoder_test {
         let error = decode_instruction(0x214a7800080008000);
         assert_eq!(
             error.unwrap_err().to_string(),
-            "Reserved instruction bits must be 0",
+            "Invalid opcode extension value: 4",
         )
     }
 

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -34,8 +34,6 @@ pub enum VirtualMachineError {
     MainScopeError(#[from] ExecScopeError),
     #[error(transparent)]
     Other(anyhow::Error),
-    #[error("Reserved instruction bits must be 0")]
-    NonZeroReservedBits,
     #[error("Instruction should be an int")]
     InvalidInstructionEncoding,
     #[error("Invalid op1_register value: {0}")]


### PR DESCRIPTION
# Remove NonZeroReservedBits from VirtualMachineError

## Description
Remove NonZeroReservedBits from VirtualMachineError because the cases it catches would be caught by InvalidOpcodeExtension anyways and it doesn't really add info to the error.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

