### PR TITLE
fix: bug in OS secp hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * refactor: Limit ret opcode decodeing to Cairo0's standards. [#1925](https://github.com/lambdaclass/cairo-vm/pull/1925)
 
+* fix: bug in OS secp hint [#1949](https://github.com/lambdaclass/cairo-vm/pull/1949)
+
 #### [2.0.0-rc4] - 2025-01-23
 
 * feat: implement `kzg` data availability hints [#1887](https://github.com/lambdaclass/cairo-vm/pull/1887)

--- a/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -699,8 +699,8 @@ from starkware.cairo.common.cairo_secp.secp_utils import pack
 from starkware.python.math_utils import ec_double_slope
 
 # Compute the slope.
-x = pack(ids.point.x, SECP256R1_P)
-y = pack(ids.point.y, SECP256R1_P)
+x = pack(ids.point.x, PRIME)
+y = pack(ids.point.y, PRIME)
 value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)"#;
 
 pub const EC_DOUBLE_SLOPE_EXTERNAL_CONSTS: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import pack


### PR DESCRIPTION
# Fix bug in OS SECP hint

## Should be `PRIME`

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

