### PR TITLE
Bump cairo-lang to 0.13.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -634,6 +634,37 @@ jobs:
         key: codecov-cache-test-no_std-mod_builtin-${{ github.sha }}
         fail-on-cache-miss: true
 
+    - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 1)
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test#1-cairo-0-secp-hints.info
+        key: codecov-cache-test#1-cairo-0-secp-hints-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 2)
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test#2-cairo-0-secp-hints.info
+        key: codecov-cache-test#2-cairo-0-secp-hints-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 3)
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test#3-cairo-0-secp-hints.info
+        key: codecov-cache-test#3-cairo-0-secp-hints-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 4)
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test#4-cairo-0-secp-hints.info
+        key: codecov-cache-test#4-cairo-0-secp-hints-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Fetch results for tests without stdlib (w/cairo-0-secp-hints)
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-no_std-cairo-0-secp-hints.info
+        key: codecov-cache-test-no_std-cairo-0-secp-hints-${{ github.sha }}
+        fail-on-cache-miss: true
+
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Upcoming Changes
 
+* chore: bump pip `cairo-lang` 0.13.5 [#1959](https://github.com/lambdaclass/cairo-vm/pull/1959)
 
 * feat: add support for alias identifiers destination in program serde [#2071](https://github.com/lambdaclass/cairo-vm/pull/2071)
 

--- a/cairo_programs/cairo-0-secp-hints-feature/negative_points.cairo
+++ b/cairo_programs/cairo-0-secp-hints-feature/negative_points.cairo
@@ -1,0 +1,56 @@
+%builtins range_check
+
+from starkware.cairo.common.secp256r1.ec import (
+    EcPoint,
+)
+from starkware.cairo.common.secp256r1.bigint import nondet_bigint3
+from starkware.cairo.common.cairo_secp.bigint3 import BigInt3
+
+func main{range_check_ptr: felt}() {
+    let point = EcPoint(
+        BigInt3(1, 2, 3),
+        BigInt3(-1, -2, -3),
+    );
+
+    let slope = compute_doubling_slope_prime(point);
+    assert slope = BigInt3(
+        15487438216801236710343013, 27596288489803578791625491, 8178446608657045587339469
+    );
+
+    let slope = compute_doubling_slope_secp256r1(point);
+    assert slope = BigInt3(
+        56511396263956479754791421, 38561311687768998103117219, 2015104701319196654781984
+    );
+
+    return ();
+}
+
+func compute_doubling_slope_prime{range_check_ptr}(point: EcPoint) -> BigInt3 {
+    %{
+        from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA, SECP256R1_P
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import ec_double_slope
+
+        # Compute the slope.
+        x = pack(ids.point.x, PRIME)
+        y = pack(ids.point.y, PRIME)
+        value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)
+    %}
+    let (slope: BigInt3) = nondet_bigint3();
+    return slope;
+}
+
+func compute_doubling_slope_secp256r1{range_check_ptr}(point: EcPoint) -> BigInt3 {
+    %{
+        from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA, SECP256R1_P
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        from starkware.python.math_utils import ec_double_slope
+
+        # Compute the slope.
+        x = pack(ids.point.x, SECP256R1_P)
+        y = pack(ids.point.y, SECP256R1_P)
+        value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)
+    %}
+    let (slope: BigInt3) = nondet_bigint3();
+    return slope;
+}

--- a/cairo_programs/cairo-0-secp-hints-feature/negative_points.cairo
+++ b/cairo_programs/cairo-0-secp-hints-feature/negative_points.cairo
@@ -34,6 +34,18 @@ func main{range_check_ptr: felt}() {
         56004882917990234964232380, 17943756516348761157632108, 3811440313376405071875160
     );
 
+    let slope = BigInt3(-1,-2,-3);
+    let x = ec_double_x_prime(point, slope);
+    assert x = BigInt3(
+        648518346341351470, 77370588372549613637288996, 18662792551970020321619971
+    );
+
+    let slope = BigInt3(-1,-2,-3);
+    let x = ec_double_x_secp256r1(point, slope);
+    assert x = BigInt3(
+        21299552074028835321108137, 50187220174510023990904347, 2291813387120727975022296
+    );
+
     return ();
 }
 
@@ -121,4 +133,35 @@ func try_get_point_from_x_secp256r1{range_check_ptr}(x: BigInt3, v: felt) -> Big
     %}
     let (y: BigInt3) = nondet_bigint3();
     return y;
+}
+
+
+func ec_double_x_prime{range_check_ptr}(point: EcPoint, slope: BigInt3) -> BigInt3 {
+    %{
+        from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+
+        slope = pack(ids.slope, PRIME)
+        x = pack(ids.point.x, PRIME)
+        y = pack(ids.point.y, PRIME)
+
+        value = new_x = (pow(slope, 2, SECP256R1_P) - 2 * x) % SECP256R1_P
+    %}
+    let (new_x: BigInt3) = nondet_bigint3();
+    return new_x;
+}
+
+func ec_double_x_secp256r1{range_check_ptr}(point: EcPoint, slope: BigInt3) -> BigInt3 {
+    %{
+        from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+
+        slope = pack(ids.slope, SECP256R1_P)
+        x = pack(ids.point.x, SECP256R1_P)
+        y = pack(ids.point.y, SECP256R1_P)
+
+        value = new_x = (pow(slope, 2, SECP256R1_P) - 2 * x) % SECP256R1_P
+    %}
+    let (new_x: BigInt3) = nondet_bigint3();
+    return new_x;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ bitarray==2.7.3
 fastecdsa==2.3.2
 sympy==1.11.1
 typeguard==2.13.3
-cairo-lang==0.13.3
+cairo-lang==0.13.5

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -117,7 +117,7 @@ use crate::{
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
 #[cfg(feature = "cairo-0-secp-hints")]
-use {super::secp::cairo0_hints, starknet_types_core::felt::CAIRO_PRIME_BIGINT};
+use {super::secp::cairo0_hints, crate::utils::CAIRO_PRIME};
 
 #[cfg(feature = "test_utils")]
 use crate::hint_processor::builtin_hint_processor::print::{print_array, print_dict, print_felt};
@@ -909,7 +909,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
-                &SECP256R1_P,
+                SECP256R1_P.magnitude(),
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::SECP_DOUBLE_ASSIGN_NEW_X_V2 => cairo0_hints::secp_double_assign_new_x(
@@ -918,7 +918,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
-                &CAIRO_PRIME_BIGINT,
+                &CAIRO_PRIME,
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::FAST_SECP_ADD_ASSIGN_NEW_Y => cairo0_hints::fast_secp_add_assign_new_y(
@@ -968,7 +968,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
-                &SECP256R1_P,
+                SECP256R1_P.magnitude(),
             ),
 
             #[cfg(feature = "cairo-0-secp-hints")]
@@ -978,7 +978,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
-                &CAIRO_PRIME_BIGINT,
+                &CAIRO_PRIME,
             ),
 
             #[cfg(feature = "cairo-0-secp-hints")]

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -1,3 +1,4 @@
+use super::blake2s_utils::example_blake2s_compress;
 use super::{
     blake2s_utils::finalize_blake2s_v3,
     ec_recover::{
@@ -22,9 +23,11 @@ use super::{
         pack::*,
     },
 };
-#[cfg(feature = "test_utils")]
-use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 use crate::Felt252;
+use crate::{
+    hint_processor::builtin_hint_processor::secp::secp_utils::{SECP256R1_ALPHA, SECP256R1_P},
+    utils::CAIRO_PRIME,
+};
 use crate::{
     hint_processor::{
         builtin_hint_processor::secp::ec_utils::{
@@ -116,16 +119,14 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
+
 #[cfg(feature = "cairo-0-secp-hints")]
-use {super::secp::cairo0_hints, crate::utils::CAIRO_PRIME};
-
+use crate::hint_processor::builtin_hint_processor::secp::cairo0_hints;
 #[cfg(feature = "test_utils")]
-use crate::hint_processor::builtin_hint_processor::print::{print_array, print_dict, print_felt};
-use crate::hint_processor::builtin_hint_processor::secp::secp_utils::{
-    SECP256R1_ALPHA, SECP256R1_P,
+use crate::hint_processor::builtin_hint_processor::{
+    print::{print_array, print_dict, print_felt},
+    skip_next_instruction::skip_next_instruction,
 };
-
-use super::blake2s_utils::example_blake2s_compress;
 
 pub struct HintProcessorData {
     pub code: String,
@@ -518,6 +519,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "point",
+                &CAIRO_PRIME,
                 &SECP_P,
                 &ALPHA,
             ),
@@ -527,6 +529,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "point",
+                &CAIRO_PRIME,
                 &SECP_P_V2,
                 &ALPHA_V2,
             ),
@@ -536,6 +539,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "pt",
+                &CAIRO_PRIME,
                 &SECP_P,
                 &ALPHA,
             ),
@@ -545,6 +549,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "point",
+                SECP256R1_P.magnitude(),
                 &SECP256R1_P,
                 &SECP256R1_ALPHA,
             ),
@@ -554,6 +559,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "point",
+                &CAIRO_PRIME,
                 &SECP256R1_P,
                 &SECP256R1_ALPHA,
             ),

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -549,6 +549,15 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &SECP256R1_P,
                 &SECP256R1_ALPHA,
             ),
+            hint_code::EC_DOUBLE_SLOPE_V5 => compute_doubling_slope(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                "point",
+                &SECP256R1_P,
+                &SECP256R1_ALPHA,
+            ),
             hint_code::EC_DOUBLE_SLOPE_EXTERNAL_CONSTS => compute_doubling_slope_external_consts(
                 vm,
                 exec_scopes,
@@ -903,6 +912,14 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 constants,
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
+            cairo0_hints::SECP_DOUBLE_ASSIGN_NEW_X_V2 => cairo0_hints::secp_double_assign_new_x(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::FAST_SECP_ADD_ASSIGN_NEW_Y => cairo0_hints::fast_secp_add_assign_new_y(
                 vm,
                 exec_scopes,
@@ -945,6 +962,15 @@ impl HintProcessorLogic for BuiltinHintProcessor {
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::SECP_R1_GET_POINT_FROM_X => cairo0_hints::r1_get_point_from_x(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+
+            #[cfg(feature = "cairo-0-secp-hints")]
+            cairo0_hints::SECP_R1_GET_POINT_FROM_X_V2 => cairo0_hints::r1_get_point_from_x(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "cairo-0-secp-hints")]
-use super::secp::cairo0_hints;
 use super::{
     blake2s_utils::finalize_blake2s_v3,
     ec_recover::{
@@ -24,6 +22,8 @@ use super::{
         pack::*,
     },
 };
+#[cfg(feature = "test_utils")]
+use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 use crate::Felt252;
 use crate::{
     hint_processor::{
@@ -116,9 +116,8 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-
-#[cfg(feature = "test_utils")]
-use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
+#[cfg(feature = "cairo-0-secp-hints")]
+use {super::secp::cairo0_hints, starknet_types_core::felt::CAIRO_PRIME_BIGINT};
 
 #[cfg(feature = "test_utils")]
 use crate::hint_processor::builtin_hint_processor::print::{print_array, print_dict, print_felt};
@@ -910,6 +909,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
+                &SECP256R1_P,
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::SECP_DOUBLE_ASSIGN_NEW_X_V2 => cairo0_hints::secp_double_assign_new_x(
@@ -918,6 +918,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
+                &CAIRO_PRIME_BIGINT,
             ),
             #[cfg(feature = "cairo-0-secp-hints")]
             cairo0_hints::FAST_SECP_ADD_ASSIGN_NEW_Y => cairo0_hints::fast_secp_add_assign_new_y(
@@ -967,6 +968,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
+                &SECP256R1_P,
             ),
 
             #[cfg(feature = "cairo-0-secp-hints")]
@@ -976,6 +978,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
+                &CAIRO_PRIME_BIGINT,
             ),
 
             #[cfg(feature = "cairo-0-secp-hints")]

--- a/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -609,6 +609,14 @@ from starkware.python.math_utils import ec_double_slope
 x = pack(ids.point.x, SECP256R1_P)
 y = pack(ids.point.y, SECP256R1_P)
 value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)"#}),
+(EC_DOUBLE_SLOPE_V5, indoc! {r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA, SECP256R1_P
+from starkware.cairo.common.cairo_secp.secp_utils import pack
+from starkware.python.math_utils import ec_double_slope
+
+# Compute the slope.
+x = pack(ids.point.x, PRIME)
+y = pack(ids.point.y, PRIME)
+value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)"#}),
 (EC_DOUBLE_SLOPE_EXTERNAL_CONSTS, indoc! {r#"from starkware.cairo.common.cairo_secp.secp_utils import pack
 from starkware.python.math_utils import ec_double_slope
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -95,6 +95,18 @@ impl<const NUM_LIMBS: usize> BigIntN<'_, NUM_LIMBS> {
             .sum()
     }
 
+    #[cfg(feature = "cairo-0-secp-hints")]
+    pub(crate) fn pack86_for_prime(self, prime: &BigUint) -> BigInt {
+        self.limbs
+            .into_iter()
+            .take(3)
+            .enumerate()
+            .map(|(idx, value)| {
+                crate::math_utils::signed_felt_for_prime(*value, prime).shl(idx * 86)
+            })
+            .sum()
+    }
+
     pub(crate) fn split(num: &BigUint) -> Self {
         let limbs = split(num, 128);
         Self::from_values(limbs)

--- a/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -95,7 +95,6 @@ impl<const NUM_LIMBS: usize> BigIntN<'_, NUM_LIMBS> {
             .sum()
     }
 
-    #[cfg(feature = "cairo-0-secp-hints")]
     pub(crate) fn pack86_for_prime(self, prime: &BigUint) -> BigInt {
         self.limbs
             .into_iter()

--- a/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
@@ -23,6 +23,7 @@ use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::One;
 use num_traits::Zero;
+use starknet_types_core::felt::CAIRO_PRIME_BIGINT;
 
 use super::bigint_utils::{BigInt3, Uint384};
 use super::ec_utils::EcPoint;
@@ -234,9 +235,12 @@ pub fn r1_get_point_from_x(
     //     if (y & 1) != request.y_parity:
     //         y = (-y) % prime
 
-    let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?
-        .pack86()
-        .mod_floor(&pack_prime);
+    let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?;
+    let x = if pack_prime.eq(&CAIRO_PRIME_BIGINT) {
+        x.pack86()
+    } else {
+        x.pack86().mod_floor(pack_prime)
+    };
 
     let y_square_int = y_squared_from_x(&x, &SECP256R1_ALPHA, &SECP256R1_B, &SECP256R1_P);
     exec_scopes.insert_value::<BigInt>("y_square_int", y_square_int.clone());
@@ -293,9 +297,23 @@ pub fn secp_double_assign_new_x(
     //ids.point
     let point = EcPoint::from_var_name("point", vm, ids_data, ap_tracking)?;
 
-    let slope = slope.pack86().mod_floor(pack_prime);
-    let x = point.x.pack86().mod_floor(pack_prime);
-    let y = point.y.pack86().mod_floor(pack_prime);
+    let slope = if pack_prime.eq(&CAIRO_PRIME_BIGINT) {
+        slope.pack86()
+    } else {
+        slope.pack86().mod_floor(pack_prime)
+    };
+
+    let x = if pack_prime.eq(&CAIRO_PRIME_BIGINT) {
+        point.x.pack86()
+    } else {
+        point.x.pack86().mod_floor(pack_prime)
+    };
+
+    let y = if pack_prime.eq(&CAIRO_PRIME_BIGINT) {
+        point.y.pack86()
+    } else {
+        point.y.pack86().mod_floor(pack_prime)
+    };
 
     let value =
         (slope.modpow(&(2usize.into()), &SECP256R1_P) - (&x << 1u32)).mod_floor(&SECP256R1_P);

--- a/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
@@ -72,6 +72,27 @@ if ids.v % 2 == y % 2:
     value = y
 else:
     value = (-y) % SECP256R1.prime"#}),
+(SECP_R1_GET_POINT_FROM_X_V2, indoc! {r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
+from starkware.python.math_utils import y_squared_from_x
+
+y_square_int = y_squared_from_x(
+    x=pack(ids.x, PRIME),
+    alpha=SECP256R1.alpha,
+    beta=SECP256R1.beta,
+    field_prime=SECP256R1.prime,
+)
+
+# Note that (y_square_int ** ((SECP256R1.prime + 1) / 4)) ** 2 =
+#   = y_square_int ** ((SECP256R1.prime + 1) / 2) =
+#   = y_square_int ** ((SECP256R1.prime - 1) / 2 + 1) =
+#   = y_square_int * y_square_int ** ((SECP256R1.prime - 1) / 2) = y_square_int * {+/-}1.
+y = pow(y_square_int, (SECP256R1.prime + 1) // 4, SECP256R1.prime)
+
+# We need to decide whether to take y or prime - y.
+if ids.v % 2 == y % 2:
+    value = y
+else:
+    value = (-y) % SECP256R1.prime"#}),
 (IS_ON_CURVE_2, indoc! {r#"ids.is_on_curve = (y * y) % SECP256R1.prime == y_square_int"#}),
 (SECP_DOUBLE_ASSIGN_NEW_X, indoc! {r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
 from starkware.cairo.common.cairo_secp.secp_utils import pack
@@ -79,6 +100,14 @@ from starkware.cairo.common.cairo_secp.secp_utils import pack
 slope = pack(ids.slope, SECP256R1_P)
 x = pack(ids.point.x, SECP256R1_P)
 y = pack(ids.point.y, SECP256R1_P)
+
+value = new_x = (pow(slope, 2, SECP256R1_P) - 2 * x) % SECP256R1_P"#}),
+(SECP_DOUBLE_ASSIGN_NEW_X_V2, indoc! {r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+from starkware.cairo.common.cairo_secp.secp_utils import pack
+
+slope = pack(ids.slope, PRIME)
+x = pack(ids.point.x, PRIME)
+y = pack(ids.point.y, PRIME)
 
 value = new_x = (pow(slope, 2, SECP256R1_P) - 2 * x) % SECP256R1_P"#}),
 (GENERATE_NIBBLES, indoc! {r#"num = (ids.scalar.high << 128) + ids.scalar.low

--- a/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
@@ -201,6 +201,7 @@ pub fn r1_get_point_from_x(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
+    pack_prime: &BigInt,
 ) -> Result<(), HintError> {
     exec_scopes.insert_value::<BigInt>("SECP256R1_P", SECP256R1_P.clone());
 
@@ -235,7 +236,7 @@ pub fn r1_get_point_from_x(
 
     let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?
         .pack86()
-        .mod_floor(&SECP256R1_P);
+        .mod_floor(&pack_prime);
 
     let y_square_int = y_squared_from_x(&x, &SECP256R1_ALPHA, &SECP256R1_B, &SECP256R1_P);
     exec_scopes.insert_value::<BigInt>("y_square_int", y_square_int.clone());
@@ -284,6 +285,7 @@ pub fn secp_double_assign_new_x(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
+    pack_prime: &BigInt,
 ) -> Result<(), HintError> {
     exec_scopes.insert_value::<BigInt>("SECP256R1_P", SECP256R1_P.clone());
     //ids.slope
@@ -291,9 +293,9 @@ pub fn secp_double_assign_new_x(
     //ids.point
     let point = EcPoint::from_var_name("point", vm, ids_data, ap_tracking)?;
 
-    let slope = slope.pack86().mod_floor(&SECP256R1_P);
-    let x = point.x.pack86().mod_floor(&SECP256R1_P);
-    let y = point.y.pack86().mod_floor(&SECP256R1_P);
+    let slope = slope.pack86().mod_floor(pack_prime);
+    let x = point.x.pack86().mod_floor(pack_prime);
+    let y = point.y.pack86().mod_floor(pack_prime);
 
     let value =
         (slope.modpow(&(2usize.into()), &SECP256R1_P) - (&x << 1u32)).mod_floor(&SECP256R1_P);
@@ -560,6 +562,7 @@ mod tests {
             &ids_data,
             &ap_tracking,
             &constants,
+            &SECP256R1_P,
         )
         .expect("calculate_value() failed");
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -125,6 +125,7 @@ pub fn compute_doubling_slope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     point_alias: &str,
+    pack_prime: &BigUint,
     secp_p: &BigInt,
     alpha: &BigInt,
 ) -> Result<(), HintError> {
@@ -132,7 +133,14 @@ pub fn compute_doubling_slope(
     //ids.point
     let point = EcPoint::from_var_name(point_alias, vm, ids_data, ap_tracking)?;
 
-    let value = ec_double_slope(&(point.x.pack86(), point.y.pack86()), alpha, secp_p)?;
+    let value = ec_double_slope(
+        &(
+            point.x.pack86_for_prime(pack_prime),
+            point.y.pack86_for_prime(pack_prime),
+        ),
+        alpha,
+        secp_p,
+    )?;
     exec_scopes.insert_value("value", value.clone());
     exec_scopes.insert_value("slope", value);
     Ok(())

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -119,6 +119,7 @@ Implements hint:
     value = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)
 %}
 */
+#[allow(clippy::too_many_arguments)]
 pub fn compute_doubling_slope(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -70,6 +70,16 @@ pub fn signed_felt(felt: Felt252) -> BigInt {
     }
 }
 
+pub fn signed_felt_for_prime(value: Felt252, prime: &BigUint) -> BigInt {
+    let value = value.to_biguint();
+    let half_prime = prime / 2u32;
+    if value > half_prime {
+        BigInt::from_biguint(num_bigint::Sign::Minus, prime - &value)
+    } else {
+        BigInt::from_biguint(num_bigint::Sign::Plus, value)
+    }
+}
+
 /// QM31 utility function, used specifically for Stwo.
 /// QM31 operations are to be relocated into https://github.com/lambdaclass/lambdaworks.
 /// Reads four u64 coordinates from a single Felt252.

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -1346,6 +1346,15 @@ fn cairo_run_secp_cairo0_ec_mul_by_uint256() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(feature = "cairo-0-secp-hints")]
+fn cairo_run_secp_cairo0_negative_points() {
+    let program_data =
+        include_bytes!("../../../cairo_programs/cairo-0-secp-hints-feature/negative_points.json");
+    run_program_simple(program_data.as_slice());
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg(feature = "cairo-0-data-availability-hints")]
 fn cairo_run_data_availability_reduced_mul() {
     let program_data =


### PR DESCRIPTION
Bump cairo-lang to 0.13.5

Updates the hint definitions to match the updated versions. The only difference is that the hints now use `PRIME` instead of `SECP256R1_P` when packing.

I also modified the implementation to work for both `PRIME` and `SECP256R1_P`. Do do this, I created a new math utility: `pack86_for_prime`. It works just like `pack86`, but it receives the prime to use, rather than asume that we always use the Cairo prime.

Added tests for negative points, for all updated hints.

## Hint Differences

SECP_R1_GET_POINT_FROM_X:
```
<     x=pack(ids.x, SECP256R1.prime),
>     x=pack(ids.x, PRIME),
```

SECP_DOUBLE_ASSIGN_NEW_X
```
< slope = pack(ids.slope, SECP256R1_P)
< x = pack(ids.point.x, SECP256R1_P)
< y = pack(ids.point.y, SECP256R1_P)
---
> slope = pack(ids.slope, PRIME)
> x = pack(ids.point.x, PRIME)
> y = pack(ids.point.y, PRIME)
```

EC_DOUBLE_SLOPE
```
< x = pack(ids.point.x, SECP256R1_P)
< y = pack(ids.point.y, SECP256R1_P)
---
> x = pack(ids.point.x, PRIME)
> y = pack(ids.point.y, PRIME)
```
