### PR TITLE
Fix_compilation_of_stwo_exclusive_programs_in_makefile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,6 @@ jobs:
           cairo_bench_programs,
           cairo_proof_programs,
           cairo_test_programs,
-          cairo_stwo_exclusive_programs,
           cairo_1_test_contracts,
           cairo_2_test_contracts,
         ]
@@ -496,8 +495,8 @@ jobs:
         - program-target: cairo_stwo_exclusive_programs
           programs-dir: cairo_programs/stwo_exclusive_programs
           extra-args: '--cairo_pie_output {program}.rs.pie.zip'
-        - program-target: cairo_programs/stwo_exclusive_programs
-          programs-dir: cairo_stwo_exclusive_programs
+        - program-target: cairo_stwo_exclusive_programs_proof_mode
+          programs-dir: cairo_programs/stwo_exclusive_programs
           extra-args: '--proof_mode --air_public_input {program}.rs.air_public_input --air_private_input {program}.rs.air_private_input '
     name: Compute memory and execution traces with cairo-vm
     needs: [ build-programs, build-release ]

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ MOD_BUILTIN_TEST_PROOF_DIR=cairo_programs/mod_builtin_feature/proof
 MOD_BUILTIN_TEST_PROOF_FILES:=$(wildcard $(MOD_BUILTIN_TEST_PROOF_DIR)/*.cairo)
 COMPILED_MOD_BUILTIN_PROOF_TESTS:=$(patsubst $(MOD_BUILTIN_TEST_PROOF_DIR)/%.cairo, $(MOD_BUILTIN_TEST_PROOF_DIR)/%.json, $(MOD_BUILTIN_TEST_PROOF_FILES))
 
+STWO_EXCLUSIVE_DIR=cairo_programs/stwo_exclusive_programs
+STWO_EXCLUSIVE_FILES:=$(wildcard $(STWO_EXCLUSIVE_DIR)/*.cairo)
+COMPILED_STWO_EXCLUSIVE_TESTS:=$(patsubst $(STWO_EXCLUSIVE_DIR)/%.cairo, $(STWO_EXCLUSIVE_DIR)/%.json, $(STWO_EXCLUSIVE_FILES))
+
 $(TEST_PROOF_DIR)/%.json: $(TEST_PROOF_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_PROOF_DIR):$(PROOF_BENCH_DIR)" $< --output $@ --proof_mode
 
@@ -68,6 +72,9 @@ $(PROOF_BENCH_DIR)/%.json: $(PROOF_BENCH_DIR)/%.cairo
 $(MOD_BUILTIN_TEST_PROOF_DIR)/%.json: $(MOD_BUILTIN_TEST_PROOF_DIR)/%.cairo
 	cairo-compile --cairo_path="$(MOD_BUILTIN_TEST_PROOF_DIR):$(MOD_BUILTIN_TEST_PROOF_DIR)" $< --output $@ --proof_mode
 
+$(STWO_EXCLUSIVE_DIR)/%.json: $(STWO_EXCLUSIVE_DIR)/%.cairo
+	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@ --proof_mode
+
 # ======================
 # Run without proof mode
 # ======================
@@ -81,10 +88,6 @@ CAIRO_PIE:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.pie.zip, $(COMPILED_TEST
 CAIRO_RS_MEM:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.memory, $(COMPILED_TESTS))
 CAIRO_RS_TRACE:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.trace, $(COMPILED_TESTS))
 CAIRO_RS_PIE:=$(patsubst $(TEST_DIR)/%.json, $(TEST_DIR)/%.rs.pie.zip, $(COMPILED_TESTS))
-
-STWO_EXCLUSIVE_DIR=cairo_programs/stwo_exclusive_programs
-STWO_EXCLUSIVE_FILES:=$(wildcard $(STWO_EXCLUSIVE_DIR)/*.cairo)
-COMPILED_STWO_EXCLUSIVE_TESTS:=$(patsubst $(STWO_EXCLUSIVE_DIR)/%.cairo, $(STWO_EXCLUSIVE_DIR)/%.json, $(STWO_EXCLUSIVE_FILES))
 
 BENCH_DIR=cairo_programs/benchmarks
 BENCH_FILES:=$(wildcard $(BENCH_DIR)/*.cairo)
@@ -252,8 +255,7 @@ check:
 	cargo check
 
 cairo_test_programs: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS) $(COMPILED_PRINT_TESTS) $(COMPILED_MOD_BUILTIN_TESTS) $(COMPILED_SECP_CAIRO0_HINTS) $(COMPILED_KZG_DA_CAIRO0_HINTS)
-cairo_proof_programs: $(COMPILED_PROOF_TESTS) $(COMPILED_MOD_BUILTIN_PROOF_TESTS)
-cairo_stwo_exclusive_programs: $(COMPILED_STWO_EXCLUSIVE_TESTS)
+cairo_proof_programs: $(COMPILED_PROOF_TESTS) $(COMPILED_MOD_BUILTIN_PROOF_TESTS) $(COMPILED_STWO_EXCLUSIVE_TESTS)
 cairo_bench_programs: $(COMPILED_BENCHES)
 cairo_1_test_contracts: $(CAIRO_1_COMPILED_CASM_CONTRACTS)
 cairo_2_test_contracts: $(CAIRO_2_COMPILED_CASM_CONTRACTS)
@@ -357,6 +359,7 @@ clean:
 	rm -f $(TEST_DIR)/*.pie
 	rm -f $(BENCH_DIR)/*.json
 	rm -f $(BAD_TEST_DIR)/*.json
+	rm -f $(STWO_EXCLUSIVE_DIR)/*.json
 	rm -f $(SECP_CAIRO0_HINTS_DIR)/*.json
 	rm -f $(KZG_DA_CAIRO0_HINTS_DIR)/*.json
 	rm -f $(PRINT_TEST_DIR)/*.json

--- a/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
+++ b/cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.cairo
@@ -9,10 +9,13 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 const COUNTER = 64;
 const U32_MASK = 0xffffffff;
 
-// Tests the Blake2s and Blake2sLastBlock opcode runners using a preexisting implementation within the repo as reference.
+// Tests the Blake2s and Blake2sLastBlock opcode runners using a preexisting implementation within
+// the repo as reference.
 // The initial state, a random message of 64 bytes and a counter are used as input.
-// Both the opcode and the reference implementation are run on the same inputs and then their outputs are compared.
-// Before comparing the outputs, it is verified that the opcode runner has written the output to the correct location.
+// Both the opcode and the reference implementation are run on the same inputs and then their
+// outputs are compared.
+// Before comparing the outputs, it is verified that the opcode runner has written the output to the
+// correct location.
 func main{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     run_blake_test(is_last_block=FALSE);
     run_blake_test(is_last_block=TRUE);

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -578,6 +578,14 @@ fn blake2s_opcode_test() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn blake2s_opcode_proof_mode_test() {
+    let program_data =
+        include_bytes!("../../../cairo_programs/stwo_exclusive_programs/blake2s_opcode_test.json");
+    run_program(program_data.as_slice(), true, None, None, None);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn relocate_segments() {
     let program_data = include_bytes!("../../../cairo_programs/relocate_segments.json");
     run_program_simple(program_data.as_slice());


### PR DESCRIPTION
# TITLE
Fix Compilation of Stwo Exclusive Programs in Makefile

## Description
Ensures programs in stwo_exclusive_programs dir are compiled by 'make test`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

