### PR TITLE
Update fastecdsa python package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * chore: update Rust required version to 1.85.0 [#1990](https://github.com/lambdaclass/cairo-vm/pull/1990)
 
+* chore: Update fastecdsa python package [#1993](https://github.com/lambdaclass/cairo-vm/pull/1993)
+
 #### [2.0.0] - 2025-02-26
 
 * fix: Check overflow in cairo pie address calculation [#1945](https://github.com/lambdaclass/cairo-vm/pull/1945)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ecdsa==0.18.0
 bitarray==2.7.3
-fastecdsa==2.3.0
+fastecdsa==2.3.2
 sympy==1.11.1
 typeguard==2.13.3
 cairo-lang==0.13.3


### PR DESCRIPTION
fastecdsa 2.3.2 has security fixes https://github.com/advisories/GHSA-ph86-g9r3-5qw4

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

