### PR TITLE
Try to fix benchmark hyper threading ci for external contributors

### DIFF
--- a/.github/workflows/hyper_threading_benchmarks.yml
+++ b/.github/workflows/hyper_threading_benchmarks.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - name: Checkout PR
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Setup Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
I think specifying the ref as head_ref tried to checkout the head using lambda repo instead of the author fork.

See https://github.com/lambdaclass/cairo-vm/actions/runs/13784962437/job/38554300107?pr=1988


