### PR TITLE
Fix another issue with external contributors in ci

### DIFF
--- a/.github/workflows/hyper_threading_benchmarks.yml
+++ b/.github/workflows/hyper_threading_benchmarks.yml
@@ -1,5 +1,11 @@
 name: Benchmark Hyper Threading
 
+permissions:
+  # permission to write a bench comment
+  issues: write
+  # permission to write a bench comment
+  pull-requests: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
I think the job needs issue and pr write permissions according to the action docs

see https://github.com/lambdaclass/cairo-vm/actions/runs/13790413720/job/38568884831?pr=1988

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

