### PR TITLE
stav: extract information for the prover from the runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * feat: replace `thiserror-no-std` with `thiserror 2` [#1919](https://github.com/lambdaclass/cairo-vm/pull/1919)
 
+* feat: Add `ProverInfo` and extract the relevant information for it from the runner [#2001](https://github.com/lambdaclass/cairo-vm/pull/2001)
+
 #### [2.0.1] - 2025-03-17
 
 * feat: Limited padding of builtin segments to >=16 [#1981](https://github.com/lambdaclass/cairo-vm/pull/1981)


### PR DESCRIPTION
# Add ProverInfo struct and create it from the runner

# In contrast to how we did it before, we want to use the data while it's still relocatable and perform the relocation in the adapter. For this, we need the memory, trace, built-in segment information, and public memory addresses before they are relocated. 
I accidentally closed the original PR and was unable to reopen the branch https://reviewable.io/reviews/lambdaclass/cairo-vm/1982. Sorry about that. 

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2001)
<!-- Reviewable:end -->
