### PR TITLE
stavbe: change AirPrivateInputSerializable fields to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 * fix: Check overflow in cairo pie address calculation [#1945](https://github.com/lambdaclass/cairo-vm/pull/1945)
 
+* chore: Expose 'trace_path' and 'memory_path' fields in `AirPrivateInputSerializable` as public for external access [#1900] (https://github.com/lambdaclass/cairo-vm/pull/1900)
+
 #### [2.0.0-rc5] - 2025-02-24
 
 * fix: Fix Cairo Pie limiting the number of segments to 2^16 [#1960](https://github.com/lambdaclass/cairo-vm/pull/1960)

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -12,8 +12,8 @@ use crate::Felt252;
 // Serializable format, matches the file output of the python implementation
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AirPrivateInputSerializable {
-    trace_path: String,
-    memory_path: String,
+    pub trace_path: String,
+    pub memory_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pedersen: Option<Vec<PrivateInput>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

