### PR TITLE
Keep None memory cells for the prover input info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Keep None values in memory segments for the prover input info [#2021](https://github.com/lambdaclass/cairo-vm/pull/2021)
+
 * refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x [#2003] (https://github.com/lambdaclass/cairo-vm/pull/2003)
 
 * fix: Fix `WriteReturnFp` error due to a bad loading of initial gas [#2015](https://github.com/lambdaclass/cairo-vm/pull/2015)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1502,7 +1502,7 @@ impl CairoRunner {
             .memory
             .data
             .iter()
-            .map(|segment| segment.iter().filter_map(|cell| cell.get_value()).collect())
+            .map(|segment| segment.iter().map(|cell| cell.get_value()).collect())
             .collect();
 
         let public_memory_offsets = self
@@ -1540,8 +1540,8 @@ impl CairoRunner {
 pub struct ProverInputInfo {
     /// A vector of trace entries, i.e. pc, ap, fp, where pc is relocatable.
     pub relocatable_trace: Vec<TraceEntry>,
-    /// A vector of segments, where each segment is a vector of maybe relocatable values.
-    pub relocatable_memory: Vec<Vec<MaybeRelocatable>>,
+    /// A vector of segments, where each segment is a vector of maybe relocatable values or holes (`None`).
+    pub relocatable_memory: Vec<Vec<Option<MaybeRelocatable>>>,
     /// A map from segment index to a vector of offsets within the segment, representing the public memory addresses.
     pub public_memory_offsets: HashMap<usize, Vec<usize>>,
     /// A map from the builtin segment index into its name.
@@ -5581,8 +5581,14 @@ mod tests {
             offset: 0,
         });
         assert_eq!(prover_info.relocatable_trace, expected_trace);
-        assert_eq!(prover_info.relocatable_memory[0][3], expected_in_memory_0_3);
-        assert_eq!(prover_info.relocatable_memory[1][0], expected_in_memory_1_0);
+        assert_eq!(
+            prover_info.relocatable_memory[0][3],
+            Some(expected_in_memory_0_3)
+        );
+        assert_eq!(
+            prover_info.relocatable_memory[1][0],
+            Some(expected_in_memory_1_0)
+        );
         assert!(prover_info.public_memory_offsets.is_empty());
         assert_eq!(
             prover_info.builtins_segments,


### PR DESCRIPTION
# Keep None memory cells for the prover input info.

## 

Found a bug using the current version.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2021)
<!-- Reviewable:end -->
