### PR TITLE
Stav/use btmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+* Refactor: Replaced HashMap with BTreeMap to guarantee deterministic ordering of the data [#2023] (https://github.com/lambdaclass/cairo-vm/pull/2023)
+
 * fix: Updated the logic for collecting builtin segment data for prover input info, removing dependency on the existence of stop pointers. [#2022](https://github.com/lambdaclass/cairo-vm/pull/2022)
 
 * fix: Keep None values in memory segments for the prover input info [#2021](https://github.com/lambdaclass/cairo-vm/pull/2021)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -4,7 +4,7 @@ use crate::{
     math_utils::safe_div_usize,
     stdlib::{
         any::Any,
-        collections::{HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
         prelude::*,
     },
@@ -1516,7 +1516,7 @@ impl CairoRunner {
             })
             .collect();
 
-        let builtins_segments: HashMap<usize, BuiltinName> = self
+        let builtins_segments: BTreeMap<usize, BuiltinName> = self
             .vm
             .builtin_runners
             .iter()
@@ -1554,9 +1554,9 @@ pub struct ProverInputInfo {
     /// A vector of segments, where each segment is a vector of maybe relocatable values or holes (`None`).
     pub relocatable_memory: Vec<Vec<Option<MaybeRelocatable>>>,
     /// A map from segment index to a vector of offsets within the segment, representing the public memory addresses.
-    pub public_memory_offsets: HashMap<usize, Vec<usize>>,
+    pub public_memory_offsets: BTreeMap<usize, Vec<usize>>,
     /// A map from the builtin segment index into its name.
-    pub builtins_segments: HashMap<usize, BuiltinName>,
+    pub builtins_segments: BTreeMap<usize, BuiltinName>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -5603,7 +5603,7 @@ mod tests {
         assert!(prover_info.public_memory_offsets.is_empty());
         assert_eq!(
             prover_info.builtins_segments,
-            HashMap::from([(2, BuiltinName::ecdsa)])
+            BTreeMap::from([(2, BuiltinName::ecdsa)])
         );
     }
 


### PR DESCRIPTION
# Use Btreemap instead of hashmap

## Description

 For deterministic iteration order in the adapter side.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2023)
<!-- Reviewable:end -->
