### PR TITLE
CI: run main workflows also on starkware-development branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: benchmark
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
 
 permissions:
   # deployments permission to deploy GitHub pages website

--- a/.github/workflows/cairo_1_programs.yml
+++ b/.github/workflows/cairo_1_programs.yml
@@ -2,7 +2,7 @@ name: Cairo 1 programs execution
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -2,7 +2,7 @@ name: Update missing hints tracking issue
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/hyper_threading_benchmarks.yml
+++ b/.github/workflows/hyper_threading_benchmarks.yml
@@ -8,8 +8,7 @@ permissions:
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main, starkware-development ]
 
 jobs:
   benchmark:

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -2,7 +2,7 @@ name: iai Benchmark
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
 
 jobs:
   cache-iai-results:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: QA
 on:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -3,7 +3,7 @@ name: Test dependencies and cairo-vm install
 on:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [ main, starkware-development ]
   pull_request:
     branches: [ '**' ]
 


### PR DESCRIPTION
# CI: run main workflows also on starkware-development branch

Updates the CI workflows so that `main` workflows are also executed on the `starkware-development` branch.

Note: The `hyper_threading_benchmark` workflow will be compared against `main`, and not against `starkware-development`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

