### PR TITLE
CI: Fix cache not found error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,13 +42,12 @@ jobs:
     strategy:
       matrix:
         # NOTE: we build cairo_bench_programs so clippy can check the benchmarks too
-        program-target: [
-          cairo_bench_programs,
-          cairo_proof_programs,
-          cairo_test_programs,
-          cairo_1_test_contracts,
-          cairo_2_test_contracts,
-        ]
+        program-target:
+        - cairo_bench_programs
+        - cairo_proof_programs
+        - cairo_test_programs
+        - cairo_1_test_contracts
+        - cairo_2_test_contracts
     name: Build Cairo programs
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,7 +161,7 @@ jobs:
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'examples/wasm-demo/src/array_sum.cairo') }}
 
   lint:
-    needs: build-programs
+    needs: merge-caches
     name: Run Lints
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
# CI: Fix cache not found error

This PR fixes two errors:
- The `Run lints` job depended on `merge-caches`, but this dependency was not explicit, causing the job to fail sometimes.
- The syntax for a flow style sequence was invalid, and not all parsers worked correctly. The Github parser does parse it correctly, but its not standard.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

