### PR TITLE
feat: implement VirtualMachine::is_accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+
+* feat: implement VirtualMachine::is_accessed [#2033](https://github.com/lambdaclass/cairo-vm/pull/2033)
+
 * Refactor: Replaced HashMap with BTreeMap to guarantee deterministic ordering of the data [#2023] (https://github.com/lambdaclass/cairo-vm/pull/2023)
 
 * fix: Updated the logic for collecting builtin segment data for prover input info, removing dependency on the existence of stop pointers. [#2022](https://github.com/lambdaclass/cairo-vm/pull/2022)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -971,6 +971,10 @@ impl VirtualMachine {
         self.segments.memory.mem_eq(lhs, rhs, len)
     }
 
+    pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {
+        self.segments.is_accessed(addr)
+    }
+
     ///Gets `n_ret` return values from memory
     pub fn get_return_values(&self, n_ret: usize) -> Result<Vec<MaybeRelocatable>, MemoryError> {
         let addr = (self.run_context.get_ap() - n_ret)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -4733,12 +4733,18 @@ mod tests {
             ((0, 1), 0),
             ((0, 2), 1),
             ((0, 10), 10),
-            ((1, 1), 1)
+            ((1, 1), 1),
+            ((1, 2), 0),
+            ((2, 0), 0),
+            ((-1, 0), 0),
+            ((-1, 1), 0)
         ];
         vm.mark_address_range_as_accessed((0, 0).into(), 3).unwrap();
         vm.mark_address_range_as_accessed((0, 10).into(), 2)
             .unwrap();
         vm.mark_address_range_as_accessed((1, 1).into(), 1).unwrap();
+        vm.mark_address_range_as_accessed((-1, 0).into(), 1)
+            .unwrap();
         //Check that the following addresses have been accessed:
         // Addresses have been copied from python execution:
         let mem = &vm.segments.memory.data;
@@ -4759,6 +4765,14 @@ mod tests {
                 .get_amount_of_accessed_addresses_for_segment(1),
             Some(1)
         );
+        assert!(vm.is_accessed(&Relocatable::from((0, 0))).unwrap());
+        assert!(vm.is_accessed(&Relocatable::from((0, 2))).unwrap());
+        assert!(vm.is_accessed(&Relocatable::from((0, 10))).unwrap());
+        assert!(vm.is_accessed(&Relocatable::from((1, 1))).unwrap());
+        assert!(!vm.is_accessed(&Relocatable::from((1, 2))).unwrap());
+        assert!(!vm.is_accessed(&Relocatable::from((2, 0))).unwrap());
+        assert!(vm.is_accessed(&Relocatable::from((-1, 0))).unwrap());
+        assert!(!vm.is_accessed(&Relocatable::from((-1, 1))).unwrap());
     }
 
     #[test]

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -648,6 +648,21 @@ impl Memory {
         Ok(values)
     }
 
+    pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {
+        let (i, j) = from_relocatable_to_indexes(*addr);
+        let data = if addr.segment_index < 0 {
+            &self.temp_data
+        } else {
+            &self.data
+        };
+        Ok(data
+            .get(i)
+            .ok_or(MemoryError::UnknownMemoryCell(Box::new(*addr)))?
+            .get(j)
+            .ok_or(MemoryError::UnknownMemoryCell(Box::new(*addr)))?
+            .is_accessed())
+    }
+
     pub fn mark_as_accessed(&mut self, addr: Relocatable) {
         let (i, j) = from_relocatable_to_indexes(addr);
         let data = if addr.segment_index < 0 {

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -648,17 +648,19 @@ impl Memory {
         Ok(values)
     }
 
-    pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {
-        let (i, j) = from_relocatable_to_indexes(*addr);
+    fn get_cell(&self, addr: Relocatable) -> Option<&MemoryCell> {
+        let (i, j) = from_relocatable_to_indexes(addr);
         let data = if addr.segment_index < 0 {
             &self.temp_data
         } else {
             &self.data
         };
-        Ok(data
-            .get(i)
-            .ok_or(MemoryError::UnknownMemoryCell(Box::new(*addr)))?
-            .get(j)
+        data.get(i)?.get(j)
+    }
+
+    pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {
+        Ok(self
+            .get_cell(*addr)
             .ok_or(MemoryError::UnknownMemoryCell(Box::new(*addr)))?
             .is_accessed())
     }

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -200,6 +200,10 @@ impl MemorySegmentManager {
         }
     }
 
+    pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {
+        self.memory.is_accessed(addr)
+    }
+
     /// Counts the memory holes (aka unaccessed memory cells) in memory
     /// # Parameters
     /// - `builtin_segment_indexes`: Set representing the segments indexes of the builtins initialized in the VM, except for the output builtin.


### PR DESCRIPTION
# Implement public API for `is_accessed` from `Relocatable`.

## Description

When using the VM to run the Starknet OS, we require a public API to check if a cell is accessed (for segmented contract loading).

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

