### PR TITLE
dev: make Memory::get `pub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* dev: add Memory::get_maybe_relocatable  [#2039](https://github.com/lambdaclass/cairo-vm/pull/2039)
+
 * refactor: remove duplicated get_val function [#2065](https://github.com/lambdaclass/cairo-vm/pull/2065)
 
 * fix: Always use a normal segment in first SegmentArena segment [#1845](https://github.com/lambdaclass/cairo-vm/pull/1845)

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -1209,6 +1209,29 @@ mod memory_tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn get_maybe_relocatable_valid_relocatable() {
+        let memory = memory![((0, 0), (1, 0))];
+        assert_eq!(
+            memory
+                .get_maybe_relocatable(Relocatable::from((0, 0)))
+                .unwrap(),
+            Relocatable::from((1, 0)).into()
+        );
+    }
+
+    #[test]
+    fn get_maybe_relocatable_valid_integer() {
+        let memory = memory![((0, 0), 10)];
+        assert_eq!(
+            memory
+                .get_maybe_relocatable(Relocatable::from((0, 0)))
+                .unwrap(),
+            10.into()
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn default_memory() {
         let mem: Memory = Default::default();
         assert_eq!(mem.data.len(), 0);

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -238,7 +238,7 @@ impl Memory {
     }
 
     /// Retrieve a value from memory (either normal or temporary) and apply relocation rules
-    pub(crate) fn get<'a, 'b: 'a, K: 'a>(&'b self, key: &'a K) -> Option<Cow<'b, MaybeRelocatable>>
+    pub fn get<'a, 'b: 'a, K: 'a>(&'b self, key: &'a K) -> Option<Cow<'b, MaybeRelocatable>>
     where
         Relocatable: TryFrom<&'a K>,
     {

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -455,6 +455,7 @@ impl Memory {
             .get(&key)
             .ok_or_else(|| MemoryError::UnknownMemoryCell(Box::new(key)))?
         {
+            // Note: the `Borrowed` variant will never occur.
             Cow::Borrowed(maybe_rel) => Ok(maybe_rel.clone()),
             Cow::Owned(maybe_rel) => Ok(maybe_rel),
         }


### PR DESCRIPTION
# Make Memory::get `pub`

## Description

`get` becomes public, as now that `memory` itself is public, I want to be able to call `get` and get a MaybeRelocatable, without going through `get_integer` or `get_relocatable`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

