### PR TITLE
feat(breaking): add support for hint accessible scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat(BREAKING): add support for accessible scopes in hint processor [#2042](https://github.com/lambdaclass/cairo-vm/pull/2042)
+
 * dev: add Memory::get_maybe_relocatable  [#2039](https://github.com/lambdaclass/cairo-vm/pull/2039)
 
 * refactor: remove duplicated get_val function [#2065](https://github.com/lambdaclass/cairo-vm/pull/2065)

--- a/hint_accountant/src/main.rs
+++ b/hint_accountant/src/main.rs
@@ -51,12 +51,20 @@ fn run() {
     }
     let mut vm = VirtualMachine::new(false, false);
     let mut hint_executor = BuiltinHintProcessor::new_empty();
-    let (ap_tracking_data, reference_ids, references, mut exec_scopes, constants) = (
+    let (
+        ap_tracking_data,
+        reference_ids,
+        references,
+        mut exec_scopes,
+        constants,
+        accessible_scopes,
+    ) = (
         ApTracking::default(),
         HashMap::new(),
         Vec::new(),
         ExecutionScopes::new(),
         HashMap::new(),
+        Vec::new(),
     );
     let missing_hints: HashSet<_> = whitelists
         .into_iter()
@@ -64,7 +72,13 @@ fn run() {
         .map(|ahe| ahe.hint_lines.join("\n"))
         .filter(|h| {
             let hint_data = hint_executor
-                .compile_hint(h, &ap_tracking_data, &reference_ids, &references)
+                .compile_hint(
+                    h,
+                    &ap_tracking_data,
+                    &reference_ids,
+                    &references,
+                    &accessible_scopes,
+                )
                 .expect("this implementation is infallible");
             matches!(
                 hint_executor.execute_hint(&mut vm, &mut exec_scopes, &hint_data, &constants,),

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -132,6 +132,7 @@ pub struct HintProcessorData {
     pub code: String,
     pub ap_tracking: ApTracking,
     pub ids_data: HashMap<String, HintReference>,
+    pub accessible_scopes: Vec<String>,
 }
 
 impl HintProcessorData {
@@ -140,6 +141,7 @@ impl HintProcessorData {
             code,
             ap_tracking: ApTracking::default(),
             ids_data,
+            accessible_scopes: vec![],
         }
     }
 }

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -1263,6 +1263,8 @@ impl HintProcessorLogic for Cairo1HintProcessor {
         _reference_ids: &HashMap<String, usize>,
         //List of all references (key corresponds to element of the previous dictionary)
         _references: &[HintReference],
+        // List of accessible scopes in the hint
+        _accessible_scopes: &[String],
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         let data = hint_code.parse().ok().and_then(|x: usize| self.hints.get(&x).cloned())
         .ok_or_else(|| VirtualMachineError::CompileHintFail(

--- a/vm/src/hint_processor/hint_processor_definition.rs
+++ b/vm/src/hint_processor/hint_processor_definition.rs
@@ -43,7 +43,7 @@ pub trait HintProcessorLogic {
         reference_ids: &HashMap<String, usize>,
         //List of all references (key corresponds to element of the previous dictionary)
         references: &[HintReference],
-        // Lis of accessible scopes in the hint
+        // List of accessible scopes in the hint
         accessible_scopes: &[String],
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         Ok(any_box!(HintProcessorData {

--- a/vm/src/hint_processor/hint_processor_definition.rs
+++ b/vm/src/hint_processor/hint_processor_definition.rs
@@ -43,11 +43,14 @@ pub trait HintProcessorLogic {
         reference_ids: &HashMap<String, usize>,
         //List of all references (key corresponds to element of the previous dictionary)
         references: &[HintReference],
+        // Lis of accessible scopes in the hint
+        accessible_scopes: &[String],
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         Ok(any_box!(HintProcessorData {
             code: hint_code.to_string(),
             ap_tracking: ap_tracking_data.clone(),
             ids_data: get_ids_data(reference_ids, references)?,
+            accessible_scopes: accessible_scopes.to_vec(),
         }))
     }
 

--- a/vm/src/tests/run_deprecated_contract_class_simplified.rs
+++ b/vm/src/tests/run_deprecated_contract_class_simplified.rs
@@ -296,12 +296,17 @@ pub fn vm_load_program(
     let hint_ap_tracking_data = ApTracking::default();
     let reference_ids = HashMap::default();
     let references = vec![];
+    let accessible_scopes = vec![
+        String::from("__main__"),
+        String::from("__main__.get_number"),
+    ];
     // Compile the hint
     let compiled_hint = hint_processor.compile_hint(
         hint_code,
         &hint_ap_tracking_data,
         &reference_ids,
         &references,
+        &accessible_scopes,
     )?;
     // Create the hint extension
     // As the hint from the compiled constract has offset 0, the hint pc will be equal to the loaded contract's program base:

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -654,6 +654,7 @@ impl CairoRunner {
                         &hint.flow_tracking_data.ap_tracking,
                         &hint.flow_tracking_data.reference_ids,
                         references,
+                        &hint.accessible_scopes,
                     )
                     .map_err(|_| VirtualMachineError::CompileHintFail(hint.code.clone().into()))
             })


### PR DESCRIPTION
# Adds accessible scopes in hint and improves alias identifiers resolution

## Description

This PR enhances the Cairo VM by adding support for accessible scopes in hints.

**Key Changes:**
Accessible Scopes in Hints:
- Added accessible_scopes field to HintProcessorData and related structs.
- Updated compile_hint to accept accessible_scopes parameter across multiple files (e.g., hint_processor_definition.rs, cairo_1_hint_processor.rs).
- Initialized with default empty vector or specific scopes (e.g., __main__, __main__.get_number) where applicable.

**Impact:**
- Enables any implementer of execute_hint to only use the locally available constants, avoiding eventual conflicts of names

Also, related to https://github.com/lambdaclass/cairo-vm/issues/2041: this solves my problem as by making a `destination` field we can resolve the alias.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

