### PR TITLE
fix: add VM Execution State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: add ExecutionState structure and get_execution_state method [#2043](https://github.com/lambdaclass/cairo-vm/pull/2043)
+
 * feat: add get_current_step getter [#2034](https://github.com/lambdaclass/cairo-vm/pull/2034)
 
 * feat: implement VirtualMachine::is_accessed [#2033](https://github.com/lambdaclass/cairo-vm/pull/2033)

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -327,3 +327,30 @@ fn get_casm_contract_builtins(
         .map(|s| BuiltinName::from_str(s).expect("Invalid builtin name"))
         .collect()
 }
+
+#[cfg(test)]
+mod execution_state_tests {
+    use crate::vm::vm_core::VirtualMachine;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_get_execution_state_integration() {
+        // Create a virtual machine directly for testing
+        let mut vm = VirtualMachine::new(true, false);
+        
+        // Set some values for testing
+        vm.run_context.ap = 123;
+        vm.run_context.fp = 456;
+        vm.current_step = 10;
+        
+        // Get the execution state
+        let execution_state = vm.get_execution_state();
+        
+        // Check the main state attributes
+        assert_eq!(execution_state.ap, 123);
+        assert_eq!(execution_state.fp, 456);
+        assert_eq!(execution_state.current_step, 10);
+        assert_eq!(execution_state.run_finished, false); // Expect false as we didn't set it
+        assert!(execution_state.memory_segments_count > 0);
+    }
+}

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -5434,6 +5434,7 @@ mod tests {
         );
     }
 
+    #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_state_test() {
         let mut vm = vm!();

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -5434,16 +5434,6 @@ mod tests {
         );
     }
 
-    /// Returns the current execution state of the virtual machine
-    /// 
-    /// This function gathers all essential components of the VM state, including  
-    /// the current registers (pc, ap, fp), execution step information, and
-    /// active built-in functions.
-    /// 
-    /// # Return Value
-    /// 
-    /// `ExecutionState` is a structure containing the current state of the VM
-    #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn get_execution_state_test() {
         let mut vm = vm!();

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -1269,15 +1269,15 @@ impl VirtualMachine {
         }
     }
 
-    /// Возвращает текущее состояние выполнения виртуальной машины
+    /// Returns the current execution state of the virtual machine
     /// 
-    /// Эта функция собирает все важные компоненты состояния VM, включая
-    /// текущие регистры (pc, ap, fp), информацию о шаге выполнения и 
-    /// активных builtin функциях.
+    /// This function gathers all important components of the VM state, including
+    /// the current registers (pc, ap, fp), execution step information, and 
+    /// active built-in functions.
     /// 
-    /// # Возвращаемое значение
+    /// # Return value
     /// 
-    /// `ExecutionState` структура с текущим состоянием VM
+    /// `ExecutionState` structure containing the current VM state
     pub fn get_execution_state(&self) -> ExecutionState {
         ExecutionState {
             pc: self.run_context.pc,

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -103,22 +103,22 @@ pub struct VirtualMachine {
     pub(crate) relocation_table: Option<Vec<usize>>,
 }
 
-/// Структура для хранения состояния выполнения виртуальной машины
+/// Structure for storing the execution state of a virtual machine
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionState {
-    /// Текущий счетчик программы (Program Counter)
+    /// Current program counter (Program Counter)
     pub pc: Relocatable,
-    /// Текущий указатель распределения (Allocation Pointer)
+    /// Current allocation pointer (Allocation Pointer)
     pub ap: usize,
-    /// Текущий указатель кадра (Frame Pointer)
+    /// Current frame pointer (Frame Pointer)
     pub fp: usize,
-    /// Текущий шаг выполнения
+    /// Current execution step
     pub current_step: usize,
-    /// Завершено ли выполнение
+    /// Whether execution is finished
     pub run_finished: bool,
-    /// Количество сегментов памяти
+    /// Number of memory segments
     pub memory_segments_count: usize,
-    /// Информация о работающих builtins
+    /// Information about active built-ins
     pub active_builtins: Vec<String>,
 }
 


### PR DESCRIPTION
# Add VM Execution State

## Description

Added ExecutionState structure and get_execution_state() method to capture current VM state. Helps with debugging and simplifies integration with external tools.
What's included:
- Structure with key VM parameters (pc, ap, fp, current_step, etc.)
- Tests to verify functionality
- Documentation

## Checklist
-  [x] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added
- [ ] This change requires new documentation.
- [x] Documentation updated
- [ ] CHANGELOG has been updated.


