### PR TITLE
collecting pa also when proof_mode=false

### DIFF
--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -106,8 +106,8 @@ pub fn cairo_run_program_with_initial_scope(
     )?;
 
     cairo_runner.vm.verify_auto_deductions()?;
-    cairo_runner.read_return_values(allow_missing_builtins)?;
-    if cairo_run_config.proof_mode {
+    cairo_runner.read_return_values(allow_missing_builtins, cairo_run_config.trace_enabled)?;
+    if cairo_run_config.proof_mode || cairo_run_config.trace_enabled {
         cairo_runner.finalize_segments()?;
     }
     if secure_run {
@@ -211,7 +211,7 @@ pub fn cairo_run_pie(
     )?;
 
     cairo_runner.vm.verify_auto_deductions()?;
-    cairo_runner.read_return_values(allow_missing_builtins)?;
+    cairo_runner.read_return_values(allow_missing_builtins, cairo_run_config.trace_enabled)?;
 
     if secure_run {
         verify_secure_runner(&cairo_runner, true, None)?;
@@ -261,7 +261,7 @@ pub fn cairo_run_fuzzed_program(
     cairo_runner.end_run(false, false, hint_processor)?;
 
     cairo_runner.vm.verify_auto_deductions()?;
-    cairo_runner.read_return_values(allow_missing_builtins)?;
+    cairo_runner.read_return_values(allow_missing_builtins, cairo_run_config.trace_enabled)?;
     if cairo_run_config.proof_mode {
         cairo_runner.finalize_segments()?;
     }

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -1245,7 +1245,7 @@ fn run_program_with_custom_mod_builtin_params(
         .unwrap();
 
     cairo_runner.vm.verify_auto_deductions().unwrap();
-    cairo_runner.read_return_values(false).unwrap();
+    cairo_runner.read_return_values(false, false).unwrap();
     if cairo_run_config.proof_mode {
         cairo_runner.finalize_segments().unwrap();
     }

--- a/vm/src/vm/runners/builtin_runner/modulo.rs
+++ b/vm/src/vm/runners/builtin_runner/modulo.rs
@@ -830,7 +830,7 @@ mod tests {
         runner.run_until_pc(end, &mut hint_processor).unwrap();
         runner.run_for_steps(1, &mut hint_processor).unwrap();
         runner.end_run(false, false, &mut hint_processor).unwrap();
-        runner.read_return_values(false).unwrap();
+        runner.read_return_values(false, false).unwrap();
         runner.finalize_segments().unwrap();
 
         // We compare against the execution of python cairo-run with the same layout


### PR DESCRIPTION
Public memory offsets are written to each segment when calling finalize().
This currently happens only in proof mode.
We changed the call to finalize to be called when trace is enabled (which is set when the flag prover input info is some).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2055)
<!-- Reviewable:end -->
