### PR TITLE
fix: Add boundary tests for SecpSplitOutOfRange in secp_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Optimize bigint3_split function with early overflow check [#2062](https://github.com/lambdaclass/cairo-vm/pull/2062)
+
 * refactor: remove duplicated get_val function [#2065](https://github.com/lambdaclass/cairo-vm/pull/2065)
 
 * fix: Always use a normal segment in first SegmentArena segment [#1845](https://github.com/lambdaclass/cairo-vm/pull/1845)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Upcoming Changes
 
+
 * feat: add support for alias identifiers destination in program serde [#2071](https://github.com/lambdaclass/cairo-vm/pull/2071)
 
 * feat(BREAKING): add support for accessible scopes in hint processor [#2042](https://github.com/lambdaclass/cairo-vm/pull/2042)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* fix: Optimize bigint3_split function with early overflow check [#2062](https://github.com/lambdaclass/cairo-vm/pull/2062)
+* test: Enhanced tests for bigint3_split function to validate boundary conditions [#2062](https://github.com/lambdaclass/cairo-vm/pull/2062)
 
 * feat: add support for alias identifiers destination in program serde [#2071](https://github.com/lambdaclass/cairo-vm/pull/2071)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 #### Upcoming Changes
 
-* test: Enhanced tests for bigint3_split function to validate boundary conditions [#2062](https://github.com/lambdaclass/cairo-vm/pull/2062)
-
 * feat: add support for alias identifiers destination in program serde [#2071](https://github.com/lambdaclass/cairo-vm/pull/2071)
 
 * feat(BREAKING): add support for accessible scopes in hint processor [#2042](https://github.com/lambdaclass/cairo-vm/pull/2042)

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -79,11 +79,6 @@ d0 + BASE * d1 + BASE**2 * d2,
 where BASE = 2**86.
 */
 pub fn bigint3_split(integer: &num_bigint::BigUint) -> Result<[num_bigint::BigUint; 3], HintError> {
-    let max_allowed = &*BASE * &*BASE * &*BASE - BigUint::from(1u32);
-    if integer > &max_allowed {
-        return Err(HintError::SecpSplitOutOfRange(Box::new(integer.clone())));
-    }
-
     let mut canonical_repr: [num_bigint::BigUint; 3] = Default::default();
     let mut num = integer.clone();
     for item in &mut canonical_repr {

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -126,11 +126,11 @@ mod tests {
                 .to_biguint()
                 .expect("Couldn't convert to BigUint"),
         );
-        
+
         let max_value = &*BASE * &*BASE * &*BASE - BigUint::from(1u32);
         let over_max_value = &*BASE * &*BASE * &*BASE;
         let way_over_max_value = &*BASE * &*BASE * &*BASE * &*BASE;
-        
+
         let array_max = bigint3_split(&max_value);
         let array_over_max = bigint3_split(&over_max_value);
         let array_way_over_max = bigint3_split(&way_over_max_value);
@@ -163,21 +163,21 @@ mod tests {
                     .expect("Couldn't convert to BigUint")
             ]
         );
-        
+
         assert_matches!(
             array_max,
             Ok(x) if x == [
                 BASE_MINUS_ONE.clone(),
-                BASE_MINUS_ONE.clone(), 
+                BASE_MINUS_ONE.clone(),
                 BASE_MINUS_ONE.clone()
             ]
         );
-        
+
         assert_matches!(
             array_over_max,
             Err(HintError::SecpSplitOutOfRange(bx)) if *bx == over_max_value
         );
-        
+
         assert_matches!(
             array_way_over_max,
             Err(HintError::SecpSplitOutOfRange(bx)) if *bx == way_over_max_value

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -121,14 +121,13 @@ mod tests {
                 .to_biguint()
                 .expect("Couldn't convert to BigUint"),
         );
-        //TODO, Check SecpSplitutOfRange limit
-        let array_4 = bigint3_split(
-            &bigint_str!(
-                "773712524553362671811952647737125245533626718119526477371252455336267181195264"
-            )
-            .to_biguint()
-            .expect("Couldn't convert to BigUint"),
-        );
+        //Check SecpSplitOutOfRange exact limit
+        // BASE**3 = 2**258 would be the exact upper bound where bigint3_split should fail
+        let max_value = &*BASE * &*BASE * &*BASE - BigUint::from(1u32);
+        let over_max_value = &*BASE * &*BASE * &*BASE;
+        
+        let array_max = bigint3_split(&max_value);
+        let array_over_max = bigint3_split(&over_max_value);
 
         assert_matches!(
             array_1,
@@ -158,14 +157,21 @@ mod tests {
                     .expect("Couldn't convert to BigUint")
             ]
         );
+        
+        // Verify max value at the boundary works
         assert_matches!(
-            array_4,
-            Err(HintError::SecpSplitOutOfRange(bx)) if *bx == bigint_str!(
-                    "773712524553362671811952647737125245533626718119526477371252455336267181195264"
-                )
-                    .to_biguint()
-                    .expect("Couldn't convert to BigUint")
-
+            array_max,
+            Ok(x) if x == [
+                BASE_MINUS_ONE.clone(),
+                BASE_MINUS_ONE.clone(), 
+                BASE_MINUS_ONE.clone()
+            ]
+        );
+        
+        // Verify one above max value fails with SecpSplitOutOfRange
+        assert_matches!(
+            array_over_max,
+            Err(HintError::SecpSplitOutOfRange(bx)) if *bx == over_max_value
         );
     }
 }


### PR DESCRIPTION


## Description

Implemented the TODO in secp_utils.rs by adding proper boundary tests for the 
bigint3_split function. Tests now verify that values up to BASE³-1 work correctly,
while BASE³ and above properly trigger SecpSplitOutOfRange errors. This provides 
complete test coverage for the function's range validation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

