### PR TITLE
feat: add support for alias identifiers destination in program serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: add support for alias identifiers destination in program serde [#2071](https://github.com/lambdaclass/cairo-vm/pull/2071)
+
 * dev: add Memory::get_maybe_relocatable  [#2039](https://github.com/lambdaclass/cairo-vm/pull/2039)
 
 * refactor: remove duplicated get_val function [#2065](https://github.com/lambdaclass/cairo-vm/pull/2065)

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -103,6 +103,8 @@ pub struct Identifier {
     pub members: Option<HashMap<String, Member>>,
     pub cairo_type: Option<String>,
     pub size: Option<usize>,
+    // In case of an alias - resolves to the original identifier
+    pub destination: Option<String>,
 }
 
 #[cfg_attr(feature = "test_utils", derive(Arbitrary))]
@@ -1014,6 +1016,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1028,6 +1031,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1040,6 +1044,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: Some(String::from("starkware.cairo.common.math.unsigned_div_rem")),
             },
         );
         identifiers.insert(
@@ -1054,6 +1059,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1066,6 +1072,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1078,6 +1085,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1090,6 +1098,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 

--- a/vm/src/serde/serialize_program.rs
+++ b/vm/src/serde/serialize_program.rs
@@ -128,6 +128,7 @@ pub(crate) struct IdentifierSerializer {
     pub members: Option<HashMap<String, Member>>,
     pub cairo_type: Option<String>,
     pub size: Option<usize>,
+    pub destination: Option<String>, // in case of alias
 }
 
 impl From<IdentifierSerializer> for Identifier {
@@ -140,6 +141,7 @@ impl From<IdentifierSerializer> for Identifier {
             members: identifier_serialer.members,
             cairo_type: identifier_serialer.cairo_type,
             size: identifier_serialer.size,
+            destination: identifier_serialer.destination,
         }
     }
 }
@@ -154,6 +156,7 @@ impl From<Identifier> for IdentifierSerializer {
             members: identifier_serialer.members,
             cairo_type: identifier_serialer.cairo_type,
             size: identifier_serialer.size,
+            destination: identifier_serialer.destination,
         }
     }
 }

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -721,6 +721,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -734,6 +735,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -776,6 +778,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -789,6 +792,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -939,6 +943,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -952,6 +957,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1066,6 +1072,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1079,6 +1086,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1132,6 +1140,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1145,6 +1154,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1193,6 +1203,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1205,6 +1216,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1217,6 +1229,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1229,6 +1242,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1241,6 +1255,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 
@@ -1297,6 +1312,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1309,6 +1325,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1321,6 +1338,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1333,6 +1351,7 @@ mod tests {
                 members: Some(HashMap::new()),
                 cairo_type: None,
                 size: Some(0),
+                destination: None,
             },
         );
         identifiers.insert(
@@ -1345,6 +1364,7 @@ mod tests {
                 members: None,
                 cairo_type: None,
                 size: None,
+                destination: None,
             },
         );
 

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -4597,6 +4597,7 @@ mod tests {
                     members: None,
                     cairo_type: None,
                     size: None,
+                    destination: None,
                 },
             )]
             .into_iter()
@@ -4626,6 +4627,7 @@ mod tests {
                         members: None,
                         cairo_type: None,
                         size: None,
+                        destination: None,
                     },
                 ),
                 (
@@ -4638,6 +4640,7 @@ mod tests {
                         members: None,
                         cairo_type: None,
                         size: None,
+                        destination: None,
                     },
                 ),
             ]
@@ -4668,6 +4671,7 @@ mod tests {
                     members: None,
                     cairo_type: None,
                     size: None,
+                    destination: None,
                 },
             )]
             .into_iter()


### PR DESCRIPTION
# Adds identifiers destination in program identifiers

Add alias identifiers' `destination` in the program model and serde.

## Description

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

