### PR TITLE
chore(ci): bump actions/cache to v4

### DIFF
--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Cache Inputs
       id: cache-inputs
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
       # Path where the inputs for the fuzzer are stored
         path: fuzzer/hfuzz_workspace/fuzz_json/input

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.base.sha }}
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-iai-results
       with:
         path: |


### PR DESCRIPTION
Updated actions/cache from v3 → v4 

[GitHub Actions v4 release](https://github.com/actions/cache/releases/tag/v4) 
