### PR TITLE
[DNM] docs: add --run_from_cairo_pie documentation for Cairo 0 and Cairo 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,29 @@ The cairo-vm-cli supports the following optional arguments:
 
 - `--allow_missing_builtins`: Disables the check that all builtins used by the program need to be included in the selected layout. Enabled by default when in proof_mode.
 
-- `run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled json file. The name of the file will be the first argument received by the CLI (as if it were to run a normal compiled program). Can only be used if proof_mode is not enabled.
+- `--run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled json file. The name of the file will be the first argument received by the CLI (as if it were to run a normal compiled program). Can only be used if proof_mode is not enabled.
+
+  **Using Cairo PIE files in Cairo 0:**
+  ```bash
+  # First, compile a Cairo 0 program and run it to generate a Cairo PIE file
+  cairo-compile cairo_programs/fibonacci.cairo --output cairo_programs/fibonacci_compiled.json
+  target/release/cairo-vm-cli cairo_programs/fibonacci_compiled.json --layout all_cairo --cairo_pie_output fibonacci.pie
+  
+  # Then, run the program from the Cairo PIE file
+  target/release/cairo-vm-cli fibonacci.pie --run_from_cairo_pie --layout all_cairo --print_output
+  ```
+
+  **Using Cairo PIE files in Cairo 1:**
+  ```bash
+  # First, run a Cairo 1 program and generate a Cairo PIE file
+  cd cairo1-run
+  cargo run ../cairo_programs/cairo-1-programs/fibonacci.cairo --layout all_cairo --cairo_pie_output fibonacci.pie
+  
+  # Then, run the program from the Cairo PIE file
+  cargo run fibonacci.pie --run_from_cairo_pie --layout all_cairo
+  ```
+
+  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
 
 - `cairo_layout_params_file`: Only used with dynamic layout. Receives the name of a json file with the dynamic layout parameters.
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ The cairo-vm-cli supports the following optional arguments:
 
   ```bash
   # First, compile a Cairo 0 program and run it to generate a Cairo PIE file
-  cairo-compile cairo_programs/fibonacci.cairo --output cairo_programs/fibonacci_compiled.json
-  target/release/cairo-vm-cli cairo_programs/fibonacci_compiled.json --layout all_cairo --cairo_pie_output fibonacci.pie
+  cairo-compile cairo_programs/print.cairo --output cairo_programs/print_compiled.json
+  target/release/cairo-vm-cli cairo_programs/print_compiled.json --layout all_cairo --cairo_pie_output print.pie
   
   # Then, run the program from the Cairo PIE file
-  target/release/cairo-vm-cli fibonacci.pie --run_from_cairo_pie --layout all_cairo --print_output
+  target/release/cairo-vm-cli print.pie --run_from_cairo_pie --layout all_cairo --print_output
   ```
 
   Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The cairo-vm-cli supports the following optional arguments:
 
 - `--run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled json file. The name of the file will be the first argument received by the CLI (as if it were to run a normal compiled program). Can only be used if proof_mode is not enabled.
 
-  **Using Cairo PIE files in Cairo 0:**
+  **Using Cairo PIE files:**
   ```bash
   # First, compile a Cairo 0 program and run it to generate a Cairo PIE file
   cairo-compile cairo_programs/fibonacci.cairo --output cairo_programs/fibonacci_compiled.json
@@ -192,17 +192,7 @@ The cairo-vm-cli supports the following optional arguments:
   target/release/cairo-vm-cli fibonacci.pie --run_from_cairo_pie --layout all_cairo --print_output
   ```
 
-  **Using Cairo PIE files in Cairo 1:**
-  ```bash
-  # First, run a Cairo 1 program and generate a Cairo PIE file
-  cd cairo1-run
-  cargo run ../cairo_programs/cairo-1-programs/fibonacci.cairo --layout all_cairo --cairo_pie_output fibonacci.pie
-  
-  # Then, run the program from the Cairo PIE file
-  cargo run fibonacci.pie --run_from_cairo_pie --layout all_cairo
-  ```
-
-  Note: When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
+  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
 
 - `cairo_layout_params_file`: Only used with dynamic layout. Receives the name of a json file with the dynamic layout parameters.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ The cairo-vm-cli supports the following optional arguments:
 
 - `--run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled json file. The name of the file will be the first argument received by the CLI (as if it were to run a normal compiled program). Can only be used if proof_mode is not enabled.
 
-  **Using Cairo PIE files:**
   ```bash
   # First, compile a Cairo 0 program and run it to generate a Cairo PIE file
   cairo-compile cairo_programs/fibonacci.cairo --output cairo_programs/fibonacci_compiled.json

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The cairo-vm-cli supports the following optional arguments:
   target/release/cairo-vm-cli print.pie --run_from_cairo_pie --layout all_cairo --print_output
   ```
 
-  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
+  Note: When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
 
 - `cairo_layout_params_file`: Only used with dynamic layout. Receives the name of a json file with the dynamic layout parameters.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The cairo-vm-cli supports the following optional arguments:
   cargo run fibonacci.pie --run_from_cairo_pie --layout all_cairo
   ```
 
-  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
+  Note: When using the `--run_from_cairo_pie` flag, the layout specified must be the same as the one used to create the PIE file, otherwise you may encounter compatibility issues.
 
 - `cairo_layout_params_file`: Only used with dynamic layout. Receives the name of a json file with the dynamic layout parameters.
 

--- a/cairo1-run/README.md
+++ b/cairo1-run/README.md
@@ -69,6 +69,19 @@ The cairo1-run cli supports the following optional arguments:
 
 * `--cairo_pie_output <CAIRO_PIE_OUTPUT>`: Receives the name of a file and outputs the Cairo PIE into it. Can only be used if proof_mode, is not enabled.
 
+* `--run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled Cairo 1 program or Sierra file. The name of the file will be the first argument received by the CLI. Can only be used if proof_mode is not enabled.
+
+  Example:
+  ```bash
+  # First, run a Cairo 1 program and generate a Cairo PIE file
+  cargo run ../cairo_programs/cairo-1-programs/fibonacci.cairo --layout all_cairo --cairo_pie_output fibonacci.pie
+  
+  # Then, run the program from the Cairo PIE file
+  cargo run fibonacci.pie --run_from_cairo_pie --layout all_cairo
+  ```
+
+  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, make sure to specify the same layout that was used to create the PIE file.
+
 * `--append_return_values`: Adds extra instructions to the program in order to append the return and input values to the output builtin's segment. This is the default behaviour for proof_mode. Only allows `Array<felt252>` as return and input value.
 
 ## Running circuits

--- a/cairo1-run/README.md
+++ b/cairo1-run/README.md
@@ -69,19 +69,6 @@ The cairo1-run cli supports the following optional arguments:
 
 * `--cairo_pie_output <CAIRO_PIE_OUTPUT>`: Receives the name of a file and outputs the Cairo PIE into it. Can only be used if proof_mode, is not enabled.
 
-* `--run_from_cairo_pie`: Runs a Cairo PIE instead of a compiled Cairo 1 program or Sierra file. The name of the file will be the first argument received by the CLI. Can only be used if proof_mode is not enabled.
-
-  Example:
-  ```bash
-  # First, run a Cairo 1 program and generate a Cairo PIE file
-  cargo run ../cairo_programs/cairo-1-programs/fibonacci.cairo --layout all_cairo --cairo_pie_output fibonacci.pie
-  
-  # Then, run the program from the Cairo PIE file
-  cargo run fibonacci.pie --run_from_cairo_pie --layout all_cairo
-  ```
-
-  Note: Cairo PIE files cannot be run in proof_mode. When using the `--run_from_cairo_pie` flag, make sure to specify the same layout that was used to create the PIE file.
-
 * `--append_return_values`: Adds extra instructions to the program in order to append the return and input values to the output builtin's segment. This is the default behaviour for proof_mode. Only allows `Array<felt252>` as return and input value.
 
 ## Running circuits


### PR DESCRIPTION
Clone of #2077 to run jobs that fail because of contributions being external.