### PR TITLE
Stav/remove test compare to python vm

### DIFF
--- a/vm/src/tests/compare_factorial_outputs_all_layouts.sh
+++ b/vm/src/tests/compare_factorial_outputs_all_layouts.sh
@@ -21,15 +21,6 @@ for layout in "plain" "small" "dex" "recursive" "starknet" "starknet_with_keccak
     else
         passed_tests=$((passed_tests + 1))
     fi
-    # Compare memory
-    echo "Running memory comparison for layout $layout"
-    if ! ./vm/src/tests/memory_comparator.py factorial_rs.memory factorial_py.memory; then
-        echo "Memory differs for layout $layout"
-        exit_code=1
-        failed_tests=$((failed_tests + 1))
-    else
-        passed_tests=$((passed_tests + 1))
-    fi
     # Compare air public input
     echo "Running air public input  comparison for layout $layout"
     if ! ./vm/src/tests/air_public_input_comparator.py factorial_rs.air_public_input factorial_py.air_public_input; then

--- a/vm/src/tests/compare_outputs_dynamic_layouts.sh
+++ b/vm/src/tests/compare_outputs_dynamic_layouts.sh
@@ -207,15 +207,6 @@ for case in "${CASES[@]}"; do
         passed_tests=$((passed_tests + 1))
     fi
 
-    # Compare memory
-    echo "Running memory comparison for case: $case"
-    if ! ./vm/src/tests/memory_comparator.py program_rs.memory program_py.memory; then
-        echo "Memory differs for case: $case"
-        exit_code=1
-        failed_tests=$((failed_tests + 1))
-    else
-        passed_tests=$((passed_tests + 1))
-    fi
 
     # Compare air public input
     echo "Running air public input  comparison for case: $case"

--- a/vm/src/tests/compare_vm_state.sh
+++ b/vm/src/tests/compare_vm_state.sh
@@ -65,7 +65,7 @@ for file in $(ls $tests_path | grep .cairo$ | sed -E 's/\.cairo$//'); do
         fi
     fi
 
-    if $memory; then
+    if $memory && -z $proof_tests_path;  then
         if ! ./memory_comparator.py $path_file.memory $path_file.rs.memory; then
             echo "Memory differs for $file"
             exit_code=1

--- a/vm/src/tests/memory_comparator.py
+++ b/vm/src/tests/memory_comparator.py
@@ -13,28 +13,27 @@ def compare_memory_file_contents(cairo_raw_mem, cairo_rs_raw_mem):
     cairo_mem = read_memory_file_contents(cairo_raw_mem)
     cairo_rs_mem = read_memory_file_contents(cairo_rs_raw_mem)
 
-    # TODO(Stav): Uncomment the following lines when moving the logic for filling builtin segment holes into `get_prover_input_info`.
-    # assert len(cairo_mem) == len(cairo_rs_mem), f'len(cairo_mem)={len(cairo_mem)} len(cairo_mem)={len(cairo_rs_mem)}'
-    # if cairo_mem != cairo_rs_mem:
-    #     print(f'Mismatch between cairo_lang and cairo-vm')
-    #     print('keys in cairo_lang but not cairo-vm:')
-    #     for k in cairo_mem:
-    #         if k in cairo_rs_mem:
-    #             continue
-    #     print(f'{k}:{cairo_mem[k]}')
-    #     print('keys in cairo-vm but not cairo_lang:')
-    #     for k in cairo_rs_mem:
-    #         if k in cairo_mem:
-    #             continue
-    #         print(f'{k}:{cairo_rs_mem[k]}')
-    #     print('mismatched values (cairo_lang <-> cairo-vm)):')
-    #     for k in cairo_rs_mem:
-    #         if k not in cairo_mem:
-    #             continue
-    #         if cairo_rs_mem[k] == cairo_mem[k]:
-    #             continue
-    #         print(f'{k}:({cairo_mem[k]} <-> {cairo_rs_mem[k]})')
-    #     exit(1)
+    assert len(cairo_mem) == len(cairo_rs_mem), f'len(cairo_mem)={len(cairo_mem)} len(cairo_mem)={len(cairo_rs_mem)}'
+    if cairo_mem != cairo_rs_mem:
+        print(f'Mismatch between cairo_lang and cairo-vm')
+        print('keys in cairo_lang but not cairo-vm:')
+        for k in cairo_mem:
+            if k in cairo_rs_mem:
+                continue
+        print(f'{k}:{cairo_mem[k]}')
+        print('keys in cairo-vm but not cairo_lang:')
+        for k in cairo_rs_mem:
+            if k in cairo_mem:
+                continue
+            print(f'{k}:{cairo_rs_mem[k]}')
+        print('mismatched values (cairo_lang <-> cairo-vm)):')
+        for k in cairo_rs_mem:
+            if k not in cairo_mem:
+                continue
+            if cairo_rs_mem[k] == cairo_mem[k]:
+                continue
+            print(f'{k}:({cairo_mem[k]} <-> {cairo_rs_mem[k]})')
+        exit(1)
 
 def read_memory_file_contents(raw_mem_content) -> {}:
         mem = {}

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -5682,7 +5682,7 @@ mod tests {
         assert!(cairo_runner.vm.segments.memory.data[9][4].is_none());
 
         assert_matches!(
-            cairo_runner.end_run(false, false, &mut hint_processor),
+            cairo_runner.end_run(false, false, &mut hint_processor, true),
             Ok(())
         );
 


### PR DESCRIPTION
Initially, we planned to fill holes only in the memory used for prover_input_info, but we realized it would be better for Stone to receive a memory file without holes as well —since this they are already computed by the VM.
Therefore, we no longer intend to compare the memory against the Python VM’s memory, as they will not be identical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2086)
<!-- Reviewable:end -->
