### PR TITLE
Prepare for release 2.1.0

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
           components: rustfmt, clippy
     - uses: actions/checkout@v4

--- a/.github/workflows/cairo_1_programs.yml
+++ b/.github/workflows/cairo_1_programs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
       - name: Set up Cargo cache
         uses: Swatinem/rust-cache@v2
       - name: Checkout

--- a/.github/workflows/fresh_run.yml
+++ b/.github/workflows/fresh_run.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
 
     - name: Install Pyenv
       uses: "gabrielfalcao/pyenv-action@v13"

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Set up Cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout

--- a/.github/workflows/hyper_threading_benchmarks.yml
+++ b/.github/workflows/hyper_threading_benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install -y hyperfine
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
         components: rustfmt, clippy
 

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install Rust
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
 
       - name: Checkout
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Python3 Build

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install Rust
       if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Set up cargo cache
       if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
       uses: Swatinem/rust-cache@v2
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Python3 Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Publish crate cairo-vm
       env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
           components: rustfmt, clippy
     - name: Set up cargo cache
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
         targets: wasm32-unknown-unknown
 
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
         targets: wasm32-unknown-unknown
 
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
         targets: wasm32-unknown-unknown
 
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
           components: llvm-tools-preview
     - name: Set up cargo cache
@@ -393,7 +393,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.85.0
+      uses: dtolnay/rust-toolchain@1.86.0
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+#### [2.1.0] - 2025-05-21
+
 * chore: bump pip `cairo-lang` 0.13.5 [#1959](https://github.com/lambdaclass/cairo-vm/pull/1959)
 
 * fix: Use Cairo prime instead of SECP_P in WRITE_DIVMOD_SEGMENT hint [#2078](https://github.com/lambdaclass/cairo-vm/pull/2078)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "bincode 2.0.0-rc.3",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-tracer"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "axum",
  "cairo-vm",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "cairo1-run"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "bincode 2.0.0-rc.3",
@@ -1644,7 +1644,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "cairo-vm",
  "serde",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_threading"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "cairo-vm",
  "rayon",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-demo"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "cairo-vm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["ensure-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo-vm/"
@@ -24,8 +24,8 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
-cairo-vm = { path = "./vm", version = "2.0.1", default-features = false }
-cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.0.1", default-features = false }
+cairo-vm = { path = "./vm", version = "2.1.0", default-features = false }
+cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.1.0", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
     "serde",

--- a/cairo-vm-tracer/src/tracer.rs
+++ b/cairo-vm-tracer/src/tracer.rs
@@ -71,7 +71,7 @@ async fn get_data(tracer_data: State<TracerData>) -> Json<DataReponse> {
             .map(|x| {
                 field_element_repr(
                     &x.to_bigint(),
-                    &BigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap(),
+                    &BigInt::parse_bytes(&PRIME_STR.as_bytes()[2..], 16).unwrap(),
                 )
             })
             .enumerate()

--- a/cairo-vm-tracer/src/tracer_data.rs
+++ b/cairo-vm-tracer/src/tracer_data.rs
@@ -211,7 +211,7 @@ pub fn get_instruction_encoding(
         return Err(TraceDataError::InstructionIsNone(pc.to_string()));
     }
     let instruction_encoding = memory[pc].unwrap();
-    let prime = BigUint::parse_bytes(prime[2..].as_bytes(), 16).unwrap();
+    let prime = BigUint::parse_bytes(&prime.as_bytes()[2..], 16).unwrap();
 
     let imm_addr = BigUint::from(pc + 1) % prime;
     let imm_addr = usize::try_from(imm_addr.clone())

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Includes the same changes from [3.0.0-rc.1](https://github.com/lambdaclass/cairo-vm/releases/tag/v3.0.0-rc.1) but it excludes #2042 because it is a breaking change