### PR TITLE
feat: implemented delete_unaccessed function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Upcoming Changes
 
-*  fix: also mark PC as accessed in run_instruction [#2106](https://github.com/lambdaclass/cairo-vm/pull/2106)
+* feat: implemented delete_unaccessed function [#2099](https://github.com/lambdaclass/cairo-vm/pull/2099)
+
+* fix: also mark PC as accessed in run_instruction [#2106](https://github.com/lambdaclass/cairo-vm/pull/2106)
 
 #### [2.1.0] - 2025-05-21
 

--- a/vm/src/vm/errors/memory_errors.rs
+++ b/vm/src/vm/errors/memory_errors.rs
@@ -15,6 +15,10 @@ use crate::types::{
 
 #[derive(Debug, PartialEq, Error)]
 pub enum MemoryError {
+    #[error("Cell {0} has already been accessed; it cannot be removed.")]
+    UnsetAccessedCell(Relocatable),
+    #[error("Cell {0} is not allocated; it cannot be removed.")]
+    UnsetUnallocatedCell(Relocatable),
     #[error(transparent)]
     Math(#[from] MathError),
     #[error(transparent)]

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -185,6 +185,18 @@ impl Memory {
         }
     }
 
+    fn get_segment(&mut self, key: Relocatable) -> Result<&mut Vec<MemoryCell>, MemoryError> {
+        let (value_index, _) = from_relocatable_to_indexes(key);
+        let data = if key.segment_index.is_negative() {
+            &mut self.temp_data
+        } else {
+            &mut self.data
+        };
+        let data_len = data.len();
+        data.get_mut(value_index)
+            .ok_or_else(|| MemoryError::UnallocatedSegment(Box::new((value_index, data_len))))
+    }
+
     /// Inserts a value into a memory address
     /// Will return an Error if the segment index given by the address corresponds to a non-allocated segment,
     /// or if the inserted value is inconsistent with the current value at the memory cell
@@ -194,18 +206,8 @@ impl Memory {
         MaybeRelocatable: From<V>,
     {
         let val = MaybeRelocatable::from(val);
-        let (value_index, value_offset) = from_relocatable_to_indexes(key);
-
-        let data = if key.segment_index.is_negative() {
-            &mut self.temp_data
-        } else {
-            &mut self.data
-        };
-
-        let data_len = data.len();
-        let segment = data
-            .get_mut(value_index)
-            .ok_or_else(|| MemoryError::UnallocatedSegment(Box::new((value_index, data_len))))?;
+        let segment = self.get_segment(key)?;
+        let (_, value_offset) = from_relocatable_to_indexes(key);
 
         //Check if the element is inserted next to the last one on the segment
         //Forgoing this check would allow data to be inserted in a different index
@@ -235,6 +237,25 @@ impl Memory {
             }
         };
         self.validate_memory_cell(key)
+    }
+
+    pub(crate) fn delete_unaccessed(&mut self, addr: Relocatable) -> Result<(), MemoryError> {
+        let (_, offset) = from_relocatable_to_indexes(addr);
+        let segment = self.get_segment(addr)?;
+
+        // Make sure the offset exists.
+        if offset >= segment.len() {
+            return Err(MemoryError::UnsetUnallocatedCell(addr));
+        }
+
+        // Ensure the cell has not been accessed.
+        if segment[offset].is_accessed() {
+            return Err(MemoryError::UnsetAccessedCell(addr));
+        }
+
+        // Unset the cell.
+        segment[offset] = MemoryCell::NONE;
+        Ok(())
     }
 
     /// Retrieve a value from memory (either normal or temporary) and apply relocation rules
@@ -669,6 +690,11 @@ impl Memory {
             &self.data
         };
         data.get(i)?.get(j)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_cell_for_testing(&self, addr: Relocatable) -> Option<&MemoryCell> {
+        self.get_cell(addr)
     }
 
     pub fn is_accessed(&self, addr: &Relocatable) -> Result<bool, MemoryError> {


### PR DESCRIPTION
# Implemented prevent_segment_execution function

## Description:

In the Starknet OS's `bytecode_hash_internal_node` implementation, we have [this snippet](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/core/os/contract_class/compiled_class.cairo#L244-L253):
```
            // Set the first felt of the bytecode to -1 to make sure that the execution cannot jump
            // to this segment (-1 is an invalid opcode).
            // The hash in this case is guessed and the actual bytecode is unconstrained (except for
            // the first felt).
            %{
                # Sanity check.
                assert not is_accessed(ids.data_ptr), "The segment is skipped but was accessed."
                del memory.data[ids.data_ptr]
            %}
            assert data_ptr[0] = -1;
```
This PR is to support the above logic: marking a segment as non-executable, and complying with the `assert data_ptr[0] = -1` after the hint.

## Checklist
- [x] Linked to Github Issue
- [v] Unit tests added
- [x] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
  - [v] CHANGELOG has been updated.

