### PR TITLE
feat: implement SharedProgramData::get_main()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: implement SharedProgramData::get_main() [#2101](https://github.com/lambdaclass/cairo-vm/pull/2101)
+
 #### [2.1.0] - 2025-05-21
 
 * chore: bump pip `cairo-lang` 0.13.5 [#1959](https://github.com/lambdaclass/cairo-vm/pull/1959)

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -73,6 +73,12 @@ pub struct SharedProgramData {
     pub reference_manager: Vec<HintReference>,
 }
 
+impl SharedProgramData {
+    pub fn get_main(&self) -> Option<usize> {
+        self.main
+    }
+}
+
 #[cfg(feature = "test_utils")]
 impl<'a> Arbitrary<'a> for SharedProgramData {
     /// Create an arbitary [`SharedProgramData`] using `HintsCollection::new` to generate `hints` and
@@ -810,6 +816,27 @@ mod tests {
     fn get_prime() {
         let program = Program::default();
         assert_eq!(PRIME_STR, program.prime());
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn get_main() {
+        let program = Program::default();
+        assert_eq!(None, program.shared_program_data.get_main());
+        let program = Program::new(
+            Vec::new(),
+            Vec::new(),
+            Some(7),
+            HashMap::new(),
+            ReferenceManager {
+                references: Vec::new(),
+            },
+            HashMap::new(),
+            Vec::new(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(Some(7), program.shared_program_data.get_main());
     }
 
     #[test]


### PR DESCRIPTION
# Implement SharedProgramData::get_main()

## Description

Add a getter for the main entry point of a program.
Required to compute the OS program hash from an instance of a `Program` (the main entry point is part of the preimage).

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

