### PR TITLE
fix: also mark PC as accessed in run_instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+*  fix: also mark PC as accessed in run_instruction [#2106](https://github.com/lambdaclass/cairo-vm/pull/2106)
+
 #### [2.1.0] - 2025-05-21
 
 * chore: bump pip `cairo-lang` 0.13.5 [#1959](https://github.com/lambdaclass/cairo-vm/pull/1959)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -440,6 +440,7 @@ impl VirtualMachine {
         self.segments
             .memory
             .mark_as_accessed(operands_addresses.op1_addr);
+        self.segments.memory.mark_as_accessed(self.run_context.pc);
 
         if instruction.opcode_extension == OpcodeExtension::Blake
             || instruction.opcode_extension == OpcodeExtension::BlakeFinalize
@@ -3606,11 +3607,16 @@ mod tests {
             ],
         );
         //Check that the following addresses have been accessed:
-        // Addresses have been copied from python execution:
+        // Addresses have been copied from python execution + addresses of accessed code:
         let mem = &vm.segments.memory.data;
+        assert!(mem[0][0].is_accessed());
         assert!(mem[0][1].is_accessed());
+        assert!(mem[0][2].is_accessed());
+        assert!(mem[0][3].is_accessed());
         assert!(mem[0][4].is_accessed());
+        assert!(mem[0][5].is_accessed());
         assert!(mem[0][6].is_accessed());
+        assert!(mem[0][7].is_accessed());
         assert!(mem[1][0].is_accessed());
         assert!(mem[1][1].is_accessed());
         assert!(mem[1][2].is_accessed());
@@ -3621,7 +3627,7 @@ mod tests {
             vm.segments
                 .memory
                 .get_amount_of_accessed_addresses_for_segment(0),
-            Some(3)
+            Some(8)
         );
         assert_eq!(
             vm.segments
@@ -5366,11 +5372,16 @@ mod tests {
             ],
         );
         //Check that the following addresses have been accessed:
-        // Addresses have been copied from python execution:
+        // Addresses have been copied from python execution + addresses of accessed code:
         let mem = &vm.segments.memory.data;
+        assert!(mem[4][0].is_accessed());
         assert!(mem[4][1].is_accessed());
+        assert!(mem[4][2].is_accessed());
+        assert!(mem[4][3].is_accessed());
         assert!(mem[4][4].is_accessed());
+        assert!(mem[4][5].is_accessed());
         assert!(mem[4][6].is_accessed());
+        assert!(mem[4][7].is_accessed());
         assert!(mem[1][0].is_accessed());
         assert!(mem[1][1].is_accessed());
         assert!(mem[1][2].is_accessed());
@@ -5381,7 +5392,7 @@ mod tests {
             vm.segments
                 .memory
                 .get_amount_of_accessed_addresses_for_segment(4),
-            Some(3)
+            Some(8)
         );
         assert_eq!(
             vm.segments


### PR DESCRIPTION
# Also mark PC as accessed in run_instruction

## Description

Fix an inconsistency between the VM and the python VM: in `run_instruction`, in addition to marking the operands as accessed, the PC must also be marked as such (see [here](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/lang/vm/vm_core.py#L458-L459)).

This issue came up in contract segment verification phase of the OS run with the rust VM.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

