### PR TITLE
Improve memory_segments coverage

### DIFF
--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -622,6 +622,22 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn write_arg_invalid_type() {
+        let data = vec!["Invalid Type 1", "Invalid Type 2"];
+        let ptr = Relocatable::from((1, 0));
+        let mut segments = MemorySegmentManager::new();
+        for _ in 0..2 {
+            segments.add();
+        }
+
+        let exec = segments.write_arg(ptr, &data);
+
+        assert_eq!(exec, Err(MemoryError::WriteArg));
+        assert!(segments.memory.data[1].is_empty())
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn segment_default() {
         let segment_mng_new = MemorySegmentManager::new();
         let segment_mng_def: MemorySegmentManager = Default::default();
@@ -877,11 +893,11 @@ mod tests {
         );
     }
 
-    /// Test that the call to .gen_arg() with a Vec<Relocatable> writes its
-    /// contents into a new segment and returns a pointer to it.
+    /// Test that the call to .gen_arg() with a Vec<MaybeRelocatable::Relocatable>
+    /// writes its contents into a new segment and returns a pointer to it.
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn gen_arg_vec_relocatable() {
+    fn gen_arg_vec_mayberelocatables() {
         let mut memory_segment_manager = MemorySegmentManager::new();
 
         assert_matches!(
@@ -891,6 +907,26 @@ mod tests {
                     MaybeRelocatable::from((0, 1)),
                     MaybeRelocatable::from((0, 2)),
                     MaybeRelocatable::from((0, 3)),
+                ],
+            ),
+            Ok(x) if x == mayberelocatable!(0, 0)
+        );
+    }
+
+    /// Test that call to .gen_arg() with a Vec<Relocatable> writes its
+    /// contentsinto a new segment and returns a pointer to it.
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn gen_arg_vec_relocatables() {
+        let mut memory_segment_manager = MemorySegmentManager::new();
+
+        assert_matches!(
+            memory_segment_manager.gen_arg(
+                &vec![
+                    Relocatable::from((0, 0)),
+                    Relocatable::from((0, 1)),
+                    Relocatable::from((0, 2)),
+                    Relocatable::from((0, 3)),
                 ],
             ),
             Ok(x) if x == mayberelocatable!(0, 0)


### PR DESCRIPTION
# Improve memory_segments coverage

## Description

Aims to omprove the test coverage on memory_segments. It ads the following tests:
- Test for calling .write_arg() with an invalid type.
- Test for calling .gen_arg() with a vector of Relocatables.
- Test for calling .is_valid_memory_value() with a felt.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

