### PR TITLE
Refactor QM31 test

### DIFF
--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -621,7 +621,7 @@ mod tests {
     use num_prime::RandPrime;
 
     #[cfg(feature = "std")]
-    use proptest::prelude::*;
+    use proptest::{array::uniform4, prelude::*};
 
     // Only used in proptest for now
     #[cfg(feature = "std")]
@@ -1307,7 +1307,7 @@ mod tests {
 
     /// Used for the QM31 tests
     #[cfg(feature = "std")]
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum Configuration {
         Zero,
         One,
@@ -1332,9 +1332,12 @@ mod tests {
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-        fn qm31_packed_reduced_inv_extensive(a in configuration_strat(), b in configuration_strat(), c in configuration_strat(), d in configuration_strat()) {
+        fn qm31_packed_reduced_inv_extensive(configs in uniform4(configuration_strat())
+                                                            .prop_filter("All configs cant be Zero variant",
+                                                            |arr| arr.iter().all(|x| *x == Configuration::Zero))
+        ) {
             let mut rng = SmallRng::seed_from_u64(11480028852697973135);
-            let x_coordinates: [u64; 4] = [a,b,c,d].map(|x| match x {
+            let x_coordinates: [u64; 4] = configs.map(|x| match x {
                     Configuration::Zero => 0,
                     Configuration::One => 1,
                     Configuration::MinusOne => STWO_PRIME - 1,

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -1307,7 +1307,6 @@ mod tests {
 
     /// Used for the QM31 tests
     #[cfg(feature = "std")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[derive(Clone, Copy, Debug)]
     enum Configuration {
         Zero,
@@ -1318,7 +1317,6 @@ mod tests {
 
     /// Necessary strat to use proptest on the QM31 test
     #[cfg(feature = "std")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn configuration_strat() -> BoxedStrategy<Configuration> {
         prop_oneof![
             Just(Configuration::Zero),

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -1332,6 +1332,17 @@ mod tests {
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn qm31_packed_reduced_inv_random(x_coordinates in uniform4(0u64..STWO_PRIME)
+                                                            .prop_filter("All configs cant be Zero variant",
+                                                            |arr| !arr.iter().all(|x| *x == 0))
+        ) {
+            let x = qm31_coordinates_to_packed_reduced(x_coordinates);
+            let res = qm31_packed_reduced_inv(x).unwrap();
+            assert_eq!(qm31_packed_reduced_mul(x, res), Ok(Felt252::from(1)));
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn qm31_packed_reduced_inv_extensive(configs in uniform4(configuration_strat())
                                                             .prop_filter("All configs cant be Zero variant",
                                                             |arr| !arr.iter().all(|x| *x == Configuration::Zero))

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -1334,7 +1334,8 @@ mod tests {
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn qm31_packed_reduced_inv_extensive(configs in uniform4(configuration_strat())
                                                             .prop_filter("All configs cant be Zero variant",
-                                                            |arr| arr.iter().all(|x| *x == Configuration::Zero))
+                                                            |arr| !arr.iter().all(|x| *x == Configuration::Zero))
+                                                            .no_shrink()
         ) {
             let mut rng = SmallRng::seed_from_u64(11480028852697973135);
             let x_coordinates: [u64; 4] = configs.map(|x| match x {

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -1304,6 +1304,7 @@ mod tests {
     }
 
     /// Used for the QM31 tests
+    #[cfg(feature = "std")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[derive(Clone, Copy, Debug)]
     enum Configuration {
@@ -1314,6 +1315,7 @@ mod tests {
     }
 
     /// Necessary strat to use proptest on the QM31 test
+    #[cfg(feature = "std")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn configuration_strat() -> BoxedStrategy<Configuration> {
         prop_oneof![

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -1286,56 +1286,6 @@ mod tests {
         assert_eq!(qm31_packed_reduced_mul(x, res), Ok(Felt252::from(1)));
     }
 
-    // TODO: Refactor using proptest and separating particular cases
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn test_qm31_packed_reduced_inv_extensive() {
-        let mut rng = SmallRng::seed_from_u64(11480028852697973135);
-        #[derive(Clone, Copy)]
-        enum Configuration {
-            Zero,
-            One,
-            MinusOne,
-            Random,
-        }
-        let configurations = [
-            Configuration::Zero,
-            Configuration::One,
-            Configuration::MinusOne,
-            Configuration::Random,
-        ];
-        let mut cartesian_product = vec![];
-        for &a in &configurations {
-            for &b in &configurations {
-                for &c in &configurations {
-                    for &d in &configurations {
-                        cartesian_product.push([a, b, c, d]);
-                    }
-                }
-            }
-        }
-
-        for test_case in cartesian_product {
-            let x_coordinates: [u64; 4] = test_case
-                .iter()
-                .map(|&x| match x {
-                    Configuration::Zero => 0,
-                    Configuration::One => 1,
-                    Configuration::MinusOne => STWO_PRIME - 1,
-                    Configuration::Random => rng.gen_range(0..STWO_PRIME),
-                })
-                .collect::<Vec<u64>>()
-                .try_into()
-                .unwrap();
-            if x_coordinates == [0, 0, 0, 0] {
-                continue;
-            }
-            let x = qm31_coordinates_to_packed_reduced(x_coordinates);
-            let res = qm31_packed_reduced_inv(x).unwrap();
-            assert_eq!(qm31_packed_reduced_mul(x, res), Ok(Felt252::from(1)));
-        }
-    }
-
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_qm31_packed_reduced_div() {
@@ -1354,6 +1304,7 @@ mod tests {
     }
 
     /// Used for the QM31 tests
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[derive(Clone, Copy, Debug)]
     enum Configuration {
         Zero,
@@ -1363,6 +1314,7 @@ mod tests {
     }
 
     /// Necessary strat to use proptest on the QM31 test
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn configuration_strat() -> BoxedStrategy<Configuration> {
         prop_oneof![
             Just(Configuration::Zero),
@@ -1377,6 +1329,7 @@ mod tests {
     proptest! {
 
         #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn qm31_packed_reduced_inv_extensive(a in configuration_strat(), b in configuration_strat(), c in configuration_strat(), d in configuration_strat()) {
             let mut rng = SmallRng::seed_from_u64(11480028852697973135);
             let x_coordinates: [u64; 4] = [a,b,c,d].map(|x| match x {

--- a/vm/src/math_utils/mod.rs
+++ b/vm/src/math_utils/mod.rs
@@ -613,6 +613,8 @@ mod tests {
     use assert_matches::assert_matches;
 
     use num_traits::Num;
+
+    #[cfg(feature = "std")]
     use rand::Rng;
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
# Refactor QM31 test

## Description

The test `test_qm31_packed_reduced_inv_extensive` is now made with `proptest`

Fixes #1969 

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

