### PR TITLE
Fix docu indentation

### DIFF
--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -33,9 +33,10 @@ pub struct ValidationRule(
 /// - BIT62: ACCESS flag, 1 when the cell has been accessed in a way observable to Cairo.
 /// - BIT61: RELOCATABLE flag, 1 when the contained value is a `Relocatable`, 0 when it is a
 ///   `Felt252`.
-///   `Felt252` values are stored in big-endian order to keep the flag bits free.
-///   `Relocatable` values are stored as native endian, with the 3rd word storing the segment index
-///   and the 4th word storing the offset.
+///
+/// `Felt252` values are stored in big-endian order to keep the flag bits free.
+/// `Relocatable` values are stored as native endian, with the 3rd word storing the segment index
+/// and the 4th word storing the offset.
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Debug)]
 #[repr(align(32))]
 pub(crate) struct MemoryCell([u64; 4]);
@@ -520,8 +521,9 @@ impl Memory {
     /// - `lhs` exists in memory but `rhs` doesn't -> (Ordering::Greater, 0)
     /// - `rhs` exists in memory but `lhs` doesn't -> (Ordering::Less, 0)
     /// - None of `lhs` or `rhs` exist in memory -> (Ordering::Equal, 0)
-    ///   Everything else behaves much like `memcmp` in C.
-    ///   This is meant as an optimization for hints to avoid allocations.
+    ///
+    /// Everything else behaves much like `memcmp` in C.
+    /// This is meant as an optimization for hints to avoid allocations.
     pub(crate) fn memcmp(
         &self,
         lhs: Relocatable,


### PR DESCRIPTION
# Fix documentation indentation

## Description

Fix wrong indentation on documentation

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

