### PR TITLE
dev: make `VirtualMachine::get_traceback_entries` pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* dev: make `VirtualMachine::get_traceback_entries` pub
+
 * chore: Pin types-rs version to the one set in lockfile [#2140](https://github.com/lambdaclass/cairo-vm/pull/2140)
 
 * chore: Migrate from `pyenv` to `uv` [#1995](https://github.com/lambdaclass/cairo-vm/pull/1995)

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -821,9 +821,9 @@ impl VirtualMachine {
         Ok(())
     }
 
-    // Returns the values (fp, pc) corresponding to each call instruction in the traceback.
-    // Returns the most recent call last.
-    pub(crate) fn get_traceback_entries(&self) -> Vec<(Relocatable, Relocatable)> {
+    /// Returns the values (fp, pc) corresponding to each call instruction in the traceback.
+    /// Returns the most recent call last.
+    pub fn get_traceback_entries(&self) -> Vec<(Relocatable, Relocatable)> {
         let mut entries = Vec::<(Relocatable, Relocatable)>::new();
         let mut fp = Relocatable::from((1, self.run_context.fp));
         // Fetch the fp and pc traceback entries


### PR DESCRIPTION
# Make `VirtualMachine::get_traceback_entries` pub

## Description

Made `VirtualMachine::get_traceback_entries` so it can be used in `starknet-foundry` [backtrace feature](https://foundry-rs.github.io/starknet-foundry/snforge-advanced-features/debugging.html#backtrace)

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

