### PR TITLE
Stav/add to cairo1 config stwo optimizations

### DIFF
--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -172,10 +172,12 @@ fn run(args: impl Iterator<Item = String>) -> Result<Option<String>, Error> {
         relocate_mem: args.memory_file.is_some() || args.air_public_input.is_some(),
         layout: args.layout,
         trace_enabled: args.trace_file.is_some() || args.air_public_input.is_some(),
+        relocate_trace: args.trace_file.is_some() || args.air_public_input.is_some(),
         args: &args.args.0,
         finalize_builtins: args.air_public_input.is_some() || args.cairo_pie_output.is_some(),
         append_return_values: args.append_return_values,
         dynamic_layout_params: cairo_layout_params,
+        disable_trace_padding: false,
     };
 
     // Try to parse the file as a sierra program


### PR DESCRIPTION
Due to the client-side proving usecase, I’d like to add the same optimization we introduced for the Cairo 0 runner to the Cairo 1 runner as well (dissable trace padding + not trace allocation). 
Note that this optimization won’t be exposed through the CLI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lambdaclass/cairo-vm/2134)
<!-- Reviewable:end -->
