### PR TITLE
[2.x.y] Pin types-rs version to the one set in lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* chore: Pin types-rs version to the one set in lockfile [#2140](https://github.com/lambdaclass/cairo-vm/pull/2140)
+
 #### [2.2.0] - 2025-05-28
 
 * chore: update Rust required version to 1.87.0  [#2103](https://github.com/lambdaclass/cairo-vm/pull/2103)

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -59,7 +59,7 @@ keccak = { workspace = true }
 hashbrown = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-starknet-types-core = { version = "0.1.2", default-features = false, features = ["serde", "curve", "num-traits", "hash"] }
+starknet-types-core = { version = "=0.1.7", default-features = false, features = ["serde", "curve", "num-traits", "hash"] }
 rust_decimal = { version = "1.35.0", default-features = false }
 
 # only for std


### PR DESCRIPTION
Besides pointing to `2.x.y` instead of `main`, the main difference with #2140 is that this PR pin types-rs 0.1.7 instead of 0.1.8 to match the corresponding lockfile.