### PR TITLE
Prepare for release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+#### [2.3.1] - 2025-07-29
+
 * chore: Pin types-rs version to 0.1.8 [#2146](https://github.com/lambdaclass/cairo-vm/pull/2146)
 
 #### [2.3.0] - 2025-07-28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-tracer"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "axum",
  "cairo-vm",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "cairo1-run"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -1645,7 +1645,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cairo-vm",
  "serde",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_threading"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cairo-vm",
  "rayon",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-demo"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cairo-vm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["ensure-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo-vm/"
@@ -24,8 +24,8 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
-cairo-vm = { path = "./vm", version = "2.3.0", default-features = false }
-cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.3.0", default-features = false }
+cairo-vm = { path = "./vm", version = "2.3.1", default-features = false }
+cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.3.1", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
     "serde",


### PR DESCRIPTION
New release 2.3.1 will include:

- chore: Pin types-rs version to 0.1.8 [#2146](https://github.com/lambdaclass/cairo-vm/pull/2146)