### PR TITLE
Make MemorySegmentManager's memory field private

### DIFF
--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -1,6 +1,7 @@
 use crate::stdlib::collections::HashSet;
 use core::cmp::max;
 use core::fmt;
+use std::borrow::Cow;
 
 use crate::vm::runners::cairo_pie::CairoPieMemory;
 use crate::Felt252;
@@ -327,6 +328,16 @@ impl MemorySegmentManager {
             self.memory.insert((*si as isize, *so).into(), val)?;
         }
         Ok(())
+    }
+
+    pub fn get_integer(&self, key: Relocatable) -> Result<Felt252, MemoryError> {
+        self.memory.get_integer(key).map(Cow::into_owned)
+    }
+    pub fn get_relocatable(&self, key: Relocatable) -> Result<Relocatable, MemoryError> {
+        self.memory.get_relocatable(key)
+    }
+    pub fn get_maybe_relocatable(&self, key: Relocatable) -> Result<MaybeRelocatable, MemoryError> {
+        self.memory.get_maybe_relocatable(key)
     }
 }
 

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -23,7 +23,7 @@ use super::memory::MemoryCell;
 pub struct MemorySegmentManager {
     pub segment_sizes: HashMap<usize, usize>,
     pub segment_used_sizes: Option<Vec<usize>>,
-    pub memory: Memory,
+    pub(crate) memory: Memory,
     // A map from segment index to a list of pairs (offset, page_id) that constitute the
     // public memory. Note that the offset is absolute (not based on the page_id).
     pub public_memory_offsets: HashMap<usize, Vec<(usize, usize)>>,


### PR DESCRIPTION
# Make MemorySegmentManager's memory field private

To allow the user to keep accessing the memory, we provide some public getters.

Closes #2158
