### PR TITLE
Enable memory comparisons again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -521,7 +521,7 @@ jobs:
         ls ${{ matrix.programs-dir }}/*.json | cut -f1 -d'.' | \
         xargs -P 2 -I '{program}' \
         ./target/release/cairo-vm-cli '{program}'.json --layout starknet_with_keccak \
-        --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace \
+        --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace --fill-holes false \
         ${{ matrix.extra-args }}
     - name: Update cache
       uses: actions/cache/save@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+
+* feat: Add `--fill-holes` CLI flag instead of relying on `--proof-mode` [#2165](https://github.com/lambdaclass/cairo-vm/pull/2165)
+
 * feat: Remove prover input info struct and add getters instead [#2149](https://github.com/lambdaclass/cairo-vm/pull/2149)
 
 * feat: Added support for large files in PIE [#2136](https://github.com/lambdaclass/cairo-vm/pull/2136)
@@ -26,8 +29,6 @@
 * feat: Added hints felt unpacking for blake [#2032](https://github.com/lambdaclass/cairo-vm/pull/2032)
 
 * dev: make `VirtualMachine::get_traceback_entries` pub
-
-* feat: Add `--fill-holes` CLI flag instead of relying on `--proof-mode` [#2165](https://github.com/lambdaclass/cairo-vm/pull/2165)
 
 * chore: Pin types-rs version to the one set in lockfile [#2140](https://github.com/lambdaclass/cairo-vm/pull/2140)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 * dev: make `VirtualMachine::get_traceback_entries` pub
 
+* feat: Add `--fill-holes` CLI flag instead of relying on `--proof-mode` [#2165](https://github.com/lambdaclass/cairo-vm/pull/2165)
+
 * chore: Pin types-rs version to the one set in lockfile [#2140](https://github.com/lambdaclass/cairo-vm/pull/2140)
 
 * chore: Migrate from `pyenv` to `uv` [#1995](https://github.com/lambdaclass/cairo-vm/pull/1995)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(TEST_PROOF_DIR)/%.json: $(TEST_PROOF_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_PROOF_DIR):$(PROOF_BENCH_DIR)" $< --output $@ --proof_mode
 
 $(TEST_PROOF_DIR)/%.rs.trace $(TEST_PROOF_DIR)/%.rs.memory $(TEST_PROOF_DIR)/%.rs.air_public_input $(TEST_PROOF_DIR)/%.rs.air_private_input: $(TEST_PROOF_DIR)/%.json $(RELBIN)
-	cargo llvm-cov run -p cairo-vm-cli --release --no-report -- --layout starknet_with_keccak --proof_mode $< --trace_file $(@D)/$(*F).rs.trace --memory_file $(@D)/$(*F).rs.memory --air_public_input $(@D)/$(*F).rs.air_public_input --air_private_input $(@D)/$(*F).rs.air_private_input
+	cargo llvm-cov run -p cairo-vm-cli --release --no-report -- --layout starknet_with_keccak --proof_mode $< --trace_file $(@D)/$(*F).rs.trace --memory_file $(@D)/$(*F).rs.memory --air_public_input $(@D)/$(*F).rs.air_public_input --air_private_input $(@D)/$(*F).rs.air_private_input --fill-holes false
 
 $(TEST_PROOF_DIR)/%.trace $(TEST_PROOF_DIR)/%.memory $(TEST_PROOF_DIR)/%.air_public_input $(TEST_PROOF_DIR)/%.air_private_input: $(TEST_PROOF_DIR)/%.json
 	cairo-run --layout starknet_with_keccak --proof_mode --program $< --trace_file $(@D)/$(*F).trace  --air_public_input $(@D)/$(*F).air_public_input --memory_file $(@D)/$(*F).memory --air_private_input $(@D)/$(*F).air_private_input
@@ -128,7 +128,7 @@ $(TEST_DIR)/%.json: $(TEST_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
 $(TEST_DIR)/%.rs.trace $(TEST_DIR)/%.rs.memory $(TEST_DIR)/%.rs.pie.zip: $(TEST_DIR)/%.json $(RELBIN)
-	cargo llvm-cov run -p cairo-vm-cli --release --no-report -- --layout all_cairo $< --trace_file $(@D)/$(*F).rs.trace --memory_file $(@D)/$(*F).rs.memory --cairo_pie_output $(@D)/$(*F).rs.pie.zip
+	cargo llvm-cov run -p cairo-vm-cli --release --no-report -- --layout all_cairo $< --trace_file $(@D)/$(*F).rs.trace --memory_file $(@D)/$(*F).rs.memory --cairo_pie_output $(@D)/$(*F).rs.pie.zip --fill-holes false
 
 $(TEST_DIR)/%.trace $(TEST_DIR)/%.memory $(TEST_DIR)/%.pie.zip: $(TEST_DIR)/%.json
 	cairo-run --layout starknet_with_keccak --program $< --trace_file $(@D)/$(*F).trace --memory_file $(@D)/$(*F).memory --cairo_pie_output $(@D)/$(*F).pie.zip

--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -83,6 +83,8 @@ struct Args {
         conflicts_with_all = ["proof_mode", "air_private_input", "air_public_input"]
     )]
     run_from_cairo_pie: bool,
+    #[arg(long)]
+    fill_holes: Option<bool>,
 }
 
 #[derive(Debug, Error)]
@@ -183,6 +185,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
         relocate_trace: trace_enabled,
         layout: args.layout,
         proof_mode: args.proof_mode,
+        fill_holes: args.fill_holes.unwrap_or(args.proof_mode),
         secure_run: args.secure_run,
         allow_missing_builtins: args.allow_missing_builtins,
         dynamic_layout_params: cairo_layout_params,

--- a/examples/hyper_threading/src/main.rs
+++ b/examples/hyper_threading/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
             relocate_mem: false,
             layout: LayoutName::all_cairo,
             proof_mode: true,
+            fill_holes: true,
             secure_run: Some(false),
             ..Default::default()
         };

--- a/vm/src/air_private_input.rs
+++ b/vm/src/air_private_input.rs
@@ -381,6 +381,7 @@ mod tests {
     fn serialize_air_private_input_small_layout_only_builtins() {
         let config = crate::cairo_run::CairoRunConfig {
             proof_mode: true,
+            fill_holes: true,
             relocate_mem: true,
             trace_enabled: true,
             layout: LayoutName::small,

--- a/vm/src/air_public_input.rs
+++ b/vm/src/air_public_input.rs
@@ -194,6 +194,7 @@ mod tests {
 
         let config = crate::cairo_run::CairoRunConfig {
             proof_mode: true,
+            fill_holes: true,
             relocate_mem: true,
             trace_enabled: true,
             layout: LayoutName::all_cairo,

--- a/vm/src/cairo_run.rs
+++ b/vm/src/cairo_run.rs
@@ -36,6 +36,7 @@ pub struct CairoRunConfig<'a> {
     /// It is ignored otherwise.
     pub dynamic_layout_params: Option<CairoLayoutParams>,
     pub proof_mode: bool,
+    pub fill_holes: bool,
     pub secure_run: Option<bool>,
     /// Disable padding of the trace.
     /// By default, the trace is padded to accommodate the expected builtins-n_steps relationships
@@ -58,6 +59,7 @@ impl Default for CairoRunConfig<'_> {
             relocate_trace: true,
             layout: LayoutName::plain,
             proof_mode: false,
+            fill_holes: false,
             secure_run: None,
             disable_trace_padding: false,
             allow_missing_builtins: None,
@@ -109,7 +111,7 @@ pub fn cairo_run_program_with_initial_scope(
         cairo_run_config.disable_trace_padding,
         false,
         hint_processor,
-        cairo_run_config.proof_mode,
+        cairo_run_config.fill_holes,
     )?;
 
     cairo_runner.read_return_values(allow_missing_builtins)?;
@@ -221,7 +223,7 @@ pub fn cairo_run_pie(
         cairo_run_config.disable_trace_padding,
         false,
         hint_processor,
-        cairo_run_config.proof_mode,
+        cairo_run_config.fill_holes,
     )?;
 
     cairo_runner.read_return_values(allow_missing_builtins)?;
@@ -275,7 +277,7 @@ pub fn cairo_run_fuzzed_program(
 
     res.map_err(|err| VmException::from_vm_error(&cairo_runner, err))?;
 
-    cairo_runner.end_run(false, false, hint_processor, cairo_run_config.proof_mode)?;
+    cairo_runner.end_run(false, false, hint_processor, cairo_run_config.fill_holes)?;
 
     cairo_runner.read_return_values(allow_missing_builtins)?;
     if cairo_run_config.proof_mode {

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -1031,6 +1031,7 @@ fn fibonacci_proof_mode_disable_trace_padding() {
     let program_data = include_bytes!("../../../cairo_programs/proof_programs/fibonacci.json");
     let config = CairoRunConfig {
         proof_mode: true,
+        fill_holes: true,
         disable_trace_padding: true,
         ..Default::default()
     };
@@ -1125,6 +1126,7 @@ fn run_program_allow_missing_builtins_proof() {
         include_bytes!("../../../cairo_programs/proof_programs/pedersen_extra_builtins.json");
     let config = CairoRunConfig {
         proof_mode: true,
+        fill_holes: true,
         allow_missing_builtins: Some(true),
         layout: LayoutName::small, // The program logic only uses builtins in the small layout but contains builtins outside of it
         ..Default::default()
@@ -1209,6 +1211,7 @@ fn run_program_with_custom_mod_builtin_params(
     let cairo_run_config = CairoRunConfig {
         layout: LayoutName::all_cairo,
         proof_mode,
+        fill_holes: proof_mode,
         ..Default::default()
     };
     let mut hint_processor = BuiltinHintProcessor::new_empty();
@@ -1241,7 +1244,7 @@ fn run_program_with_custom_mod_builtin_params(
             cairo_run_config.disable_trace_padding,
             false,
             &mut hint_processor,
-            cairo_run_config.proof_mode,
+            cairo_run_config.fill_holes,
         )
         .unwrap();
 

--- a/vm/src/tests/compare_all_pie_outputs.sh
+++ b/vm/src/tests/compare_all_pie_outputs.sh
@@ -24,7 +24,7 @@ for file in $(ls $tests_path | grep .rs.pie.zip$ | sed -E 's/\.rs.pie.zip$//'); 
         break
     fi
     echo "Running $file PIE with cairo-vm"
-     cargo run -p cairo-vm-cli --release $path_file.rs.pie.zip --run_from_cairo_pie  --trace_file $path_file.rs.trace.pie --memory_file $path_file.rs.memory.pie --cairo_pie_output $path_file.rs.pie.zip.pie --layout starknet_with_keccak
+     cargo run -p cairo-vm-cli --release $path_file.rs.pie.zip --run_from_cairo_pie  --trace_file $path_file.rs.trace.pie --memory_file $path_file.rs.memory.pie --cairo_pie_output $path_file.rs.pie.zip.pie --layout starknet_with_keccak --fill-holes false
     # Compare PIE outputs
     echo "Comparing $file.pie outputs"
 

--- a/vm/src/tests/compare_factorial_outputs_all_layouts.sh
+++ b/vm/src/tests/compare_factorial_outputs_all_layouts.sh
@@ -8,7 +8,7 @@ exit_code=0
 for layout in "plain" "small" "dex" "recursive" "starknet" "starknet_with_keccak" "recursive_large_output" "recursive_with_poseidon" "all_solidity" "starknet_with_keccak"; do
     # Run cairo_vm
     echo "Running cairo-vm with layout $layout"
-    cargo run -p cairo-vm-cli --release -- --layout $layout --proof_mode $factorial_compiled --trace_file factorial_rs.trace --memory_file factorial_rs.memory --air_public_input factorial_rs.air_public_input --air_private_input factorial_rs.air_private_input
+    cargo run -p cairo-vm-cli --release -- --layout $layout --proof_mode $factorial_compiled --fill-holes false --trace_file factorial_rs.trace --memory_file factorial_rs.memory --air_public_input factorial_rs.air_public_input --air_private_input factorial_rs.air_private_input
     # Run cairo_lang
     echo "Running cairo_lang with layout $layout"
     cairo-run --layout $layout --proof_mode  --program $factorial_compiled --trace_file factorial_py.trace --memory_file factorial_py.memory --air_public_input factorial_py.air_public_input --air_private_input factorial_py.air_private_input

--- a/vm/src/tests/compare_factorial_outputs_all_layouts.sh
+++ b/vm/src/tests/compare_factorial_outputs_all_layouts.sh
@@ -21,6 +21,15 @@ for layout in "plain" "small" "dex" "recursive" "starknet" "starknet_with_keccak
     else
         passed_tests=$((passed_tests + 1))
     fi
+    # Compare memory
+    echo "Running memory comparison for layout $layout"
+    if ! ./vm/src/tests/memory_comparator.py factorial_rs.memory factorial_py.memory; then
+        echo "Memory differs for layout $layout"
+        exit_code=1
+        failed_tests=$((failed_tests + 1))
+    else
+        passed_tests=$((passed_tests + 1))
+    fi
     # Compare air public input
     echo "Running air public input  comparison for layout $layout"
     if ! ./vm/src/tests/air_public_input_comparator.py factorial_rs.air_public_input factorial_py.air_public_input; then

--- a/vm/src/tests/compare_outputs_dynamic_layouts.sh
+++ b/vm/src/tests/compare_outputs_dynamic_layouts.sh
@@ -254,7 +254,7 @@ for case in "${PIE_CASES[@]}"; do
     echo "Running cairo-vm with case: $case"
     cargo run -p cairo-vm-cli --features mod_builtin --release -- "$full_program" \
         --layout "dynamic" --cairo_layout_params_file "$full_layout" --run_from_cairo_pie  \
-        --trace_file program_rs.trace --memory_file program_rs.memory
+        --trace_file program_rs.trace --memory_file program_rs.memory --fill-holes false
 
     # Run cairo-lang
     echo "Running cairo-lang with case: $case"

--- a/vm/src/tests/compare_outputs_dynamic_layouts.sh
+++ b/vm/src/tests/compare_outputs_dynamic_layouts.sh
@@ -188,7 +188,7 @@ for case in "${CASES[@]}"; do
     # Run cairo-vm
     echo "Running cairo-vm with case: $case"
     cargo run -p cairo-vm-cli --features mod_builtin --release -- "$full_program" \
-        --layout "dynamic" --cairo_layout_params_file "$full_layout" --proof_mode \
+        --layout "dynamic" --cairo_layout_params_file "$full_layout" --proof_mode --fill-holes false \
         --trace_file program_rs.trace --memory_file program_rs.memory --air_public_input program_rs.air_public_input --air_private_input program_rs.air_private_input
 
     # Run cairo-lang

--- a/vm/src/tests/compare_outputs_dynamic_layouts.sh
+++ b/vm/src/tests/compare_outputs_dynamic_layouts.sh
@@ -207,6 +207,15 @@ for case in "${CASES[@]}"; do
         passed_tests=$((passed_tests + 1))
     fi
 
+    # Compare memory
+    echo "Running memory comparison for case: $case"
+    if ! ./vm/src/tests/memory_comparator.py program_rs.memory program_py.memory; then
+        echo "Memory differs for case: $case"
+        exit_code=1
+        failed_tests=$((failed_tests + 1))
+    else
+        passed_tests=$((passed_tests + 1))
+    fi
 
     # Compare air public input
     echo "Running air public input  comparison for case: $case"

--- a/vm/src/tests/compare_vm_state.sh
+++ b/vm/src/tests/compare_vm_state.sh
@@ -65,7 +65,7 @@ for file in $(ls $tests_path | grep .cairo$ | sed -E 's/\.cairo$//'); do
         fi
     fi
 
-    if $memory && -z $proof_tests_path;  then
+    if $memory; then
         if ! ./memory_comparator.py $path_file.memory $path_file.rs.memory; then
             echo "Memory differs for $file"
             exit_code=1

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -75,6 +75,7 @@ fn run_program(
         relocate_mem: true,
         trace_enabled: true,
         proof_mode,
+        fill_holes: proof_mode,
         ..Default::default()
     };
     let res = cairo_run(data, &cairo_run_config, &mut hint_executor);

--- a/vm/src/tests/segment_arena_test.rs
+++ b/vm/src/tests/segment_arena_test.rs
@@ -156,6 +156,7 @@ fn test_segment_arena() {
         relocate_mem: true,
         trace_enabled: true,
         proof_mode: false,
+        fill_holes: false,
         ..Default::default()
     };
     let runner =

--- a/vm/src/vm/runners/builtin_runner/mod.rs
+++ b/vm/src/vm/runners/builtin_runner/mod.rs
@@ -917,6 +917,7 @@ mod tests {
             let config_false = CairoRunConfig {
                 disable_trace_padding: false,
                 proof_mode: true,
+                fill_holes: true,
                 layout: LayoutName::all_cairo,
                 ..Default::default()
             };
@@ -930,6 +931,7 @@ mod tests {
             let config_true = CairoRunConfig {
                 disable_trace_padding: true,
                 proof_mode: true,
+                fill_holes: true,
                 layout: LayoutName::all_cairo,
                 ..Default::default()
             };

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -892,14 +892,14 @@ impl CairoRunner {
         disable_trace_padding: bool,
         disable_finalize_all: bool,
         hint_processor: &mut dyn HintProcessor,
-        proof_mode: bool,
+        fill_holes: bool,
     ) -> Result<(), VirtualMachineError> {
         if self.run_ended {
             return Err(RunnerError::EndRunCalledTwice.into());
         }
 
         self.vm.segments.memory.relocate_memory()?;
-        self.vm.end_run(&self.exec_scopes, proof_mode)?;
+        self.vm.end_run(&self.exec_scopes, fill_holes)?;
 
         if disable_finalize_all {
             return Ok(());

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -3917,6 +3917,7 @@ mod tests {
             relocate_mem: false,
             layout: LayoutName::small,
             proof_mode: false,
+            fill_holes: false,
             secure_run: Some(true),
             ..Default::default()
         };
@@ -3938,6 +3939,7 @@ mod tests {
             relocate_mem: false,
             layout: LayoutName::small,
             proof_mode: true,
+            fill_holes: true,
             secure_run: Some(true),
             ..Default::default()
         };
@@ -3978,6 +3980,7 @@ mod tests {
             relocate_mem: false,
             layout: LayoutName::all_cairo,
             proof_mode: false,
+            fill_holes: false,
             secure_run: Some(false),
             ..Default::default()
         };
@@ -3996,6 +3999,7 @@ mod tests {
             relocate_mem: false,
             layout: LayoutName::all_cairo,
             proof_mode: false,
+            fill_holes: false,
             secure_run: Some(false),
             ..Default::default()
         };
@@ -5497,6 +5501,7 @@ mod tests {
             program_content,
             &CairoRunConfig {
                 proof_mode: true,
+                fill_holes: true,
                 layout: LayoutName::all_cairo,
                 ..Default::default()
             },

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -862,9 +862,9 @@ impl VirtualMachine {
     pub fn end_run(
         &mut self,
         exec_scopes: &ExecutionScopes,
-        proof_mode: bool,
+        fill_holes: bool,
     ) -> Result<(), VirtualMachineError> {
-        if proof_mode {
+        if fill_holes {
             self.complete_builtin_auto_deductions()?;
         } else {
             self.verify_auto_deductions()?;


### PR DESCRIPTION
# Enable memory comparisons again

Closes #2154.

Depends on #2076.

When in proof mode, the builtin segment holes are filled at the end of the run. This generates a discrepancy between this VM and the original Python Cairo VM. For this reason, we disabled the memory comparisons temporarily. See https://github.com/lambdaclass/cairo-vm/pull/2088 and https://github.com/lambdaclass/cairo-vm/pull/2086.

This PR adds a new flag `fill_holes` that can be used independently from `proof_mode`. This enables us to compare proof mode memory with the original Python Cairo VM.

The test coverage workflow is failing because this PR modifies a function that was not being tested.
