### PR TITLE
Fix use of rust cache on CI

### DIFF
--- a/.github/workflows/cairo_1_programs.yml
+++ b/.github/workflows/cairo_1_programs.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.87.0
-      - name: Set up Cargo cache
-        uses: Swatinem/rust-cache@v2
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Cargo cache
+        uses: Swatinem/rust-cache@v2
       - name: install corelib
         run:  cd cairo1-run/ && make deps
       - name: Run tests

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@1.87.0
-    - name: Set up Cargo cache
-      uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up Cargo cache
+      uses: Swatinem/rust-cache@v2
     - name: Check Build
       run: cargo build -p hint_accountant
     - name: Clone cairo-lang repo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -162,10 +162,10 @@ jobs:
       uses: dtolnay/rust-toolchain@1.87.0
       with:
           components: rustfmt, clippy
-    - name: Set up cargo cache
-      uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
 
     - uses: actions/download-artifact@master
       with:
@@ -203,6 +203,9 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
 
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -212,9 +215,6 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
-
-    - name: Checkout
-      uses: actions/checkout@v4
 
     - uses: actions/download-artifact@master
       with:
@@ -249,6 +249,9 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
 
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -258,9 +261,6 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
-
-    - name: Checkout
-      uses: actions/checkout@v4
 
     - name: Download proof programs symlinks
       uses: actions/download-artifact@master
@@ -289,13 +289,13 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
 
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
-
-    - name: Checkout
-      uses: actions/checkout@v4
 
     - name: Download proof programs symlinks
       uses: actions/download-artifact@master
@@ -330,10 +330,10 @@ jobs:
       uses: dtolnay/rust-toolchain@1.87.0
       with:
           components: llvm-tools-preview
-    - name: Set up cargo cache
-      uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
 
     - uses: actions/download-artifact@master
       with:
@@ -394,10 +394,10 @@ jobs:
     steps:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.87.0
-    - name: Set up cargo cache
-      uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo b --release -p cairo-vm-cli
     # We don't read from cache because it should always miss


### PR DESCRIPTION
# Fix rust cache on CI

## Description

The rust-cache we are using on the CI was generating [error](https://github.com/lambdaclass/cairo-vm/actions/runs/16788407936/job/47545026778?pr=2150#step:3:50) because we were setting it up before doing the checkout. This generates the error since the cache tries to use the `Cargo.toml` to generate the cache key and is not able to find it.
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

