### PR TITLE
Revert "Make MemorySegmentManager's memory field private (#2164)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 * feat: Add `--fill-holes` CLI flag instead of relying on `--proof-mode` [#2165](https://github.com/lambdaclass/cairo-vm/pull/2165)
 
-* fix: make `MemorySegmentManager`'s `memory` field private [#2164](https://github.com/lambdaclass/cairo-vm/pull/2164)
-
 * feat: Use BTreeMap in PIE additional data [#2162](https://github.com/lambdaclass/cairo-vm/pull/2162)
 
 * feat: Remove prover input info struct and add getters instead [#2149](https://github.com/lambdaclass/cairo-vm/pull/2149)

--- a/vm/src/vm/vm_memory/memory_segments.rs
+++ b/vm/src/vm/vm_memory/memory_segments.rs
@@ -1,4 +1,3 @@
-use crate::stdlib::borrow::Cow;
 use crate::stdlib::collections::HashSet;
 use core::cmp::max;
 use core::fmt;
@@ -24,7 +23,7 @@ use super::memory::MemoryCell;
 pub struct MemorySegmentManager {
     pub segment_sizes: HashMap<usize, usize>,
     pub segment_used_sizes: Option<Vec<usize>>,
-    pub(crate) memory: Memory,
+    pub memory: Memory,
     // A map from segment index to a list of pairs (offset, page_id) that constitute the
     // public memory. Note that the offset is absolute (not based on the page_id).
     pub public_memory_offsets: HashMap<usize, Vec<(usize, usize)>>,
@@ -328,16 +327,6 @@ impl MemorySegmentManager {
             self.memory.insert((*si as isize, *so).into(), val)?;
         }
         Ok(())
-    }
-
-    pub fn get_integer(&self, key: Relocatable) -> Result<Felt252, MemoryError> {
-        self.memory.get_integer(key).map(Cow::into_owned)
-    }
-    pub fn get_relocatable(&self, key: Relocatable) -> Result<Relocatable, MemoryError> {
-        self.memory.get_relocatable(key)
-    }
-    pub fn get_maybe_relocatable(&self, key: Relocatable) -> Result<MaybeRelocatable, MemoryError> {
-        self.memory.get_maybe_relocatable(key)
     }
 }
 
@@ -1126,49 +1115,6 @@ mod tests {
                 MemoryCell::new(MaybeRelocatable::from(0)),
                 MemoryCell::new(MaybeRelocatable::from(0))
             ])
-        );
-    }
-
-    #[test]
-    fn test_get_integer() {
-        let mut memory_segment_manager = MemorySegmentManager::new();
-        memory_segment_manager.memory = memory![((0, 0), 10)];
-        assert_eq!(
-            memory_segment_manager
-                .get_integer(Relocatable::from((0, 0)))
-                .unwrap()
-                .as_ref(),
-            &Felt252::from(10)
-        );
-    }
-
-    #[test]
-    fn test_get_relocatable() {
-        let mut memory_segment_manager = MemorySegmentManager::new();
-        memory_segment_manager.memory = memory![((0, 0), (0, 1))];
-        assert_eq!(
-            memory_segment_manager
-                .get_relocatable(Relocatable::from((0, 0)))
-                .unwrap(),
-            relocatable!(0, 1)
-        );
-    }
-
-    #[test]
-    fn test_get_maybe_relocatable() {
-        let mut memory_segment_manager = MemorySegmentManager::new();
-        memory_segment_manager.memory = memory![((0, 0), (0, 1)), ((0, 1), 10)];
-        assert_eq!(
-            memory_segment_manager
-                .get_maybe_relocatable(relocatable!(0, 0))
-                .unwrap(),
-            mayberelocatable!(0, 1)
-        );
-        assert_eq!(
-            memory_segment_manager
-                .get_maybe_relocatable(relocatable!(0, 1))
-                .unwrap(),
-            mayberelocatable!(10)
         );
     }
 }


### PR DESCRIPTION
This reverts commit [579c323e4d8b8ee5862f77be8d95e88fb1ce6aa4](https://github.com/lambdaclass/cairo-vm/commit/579c323e4d8b8ee5862f77be8d95e88fb1ce6aa4).