### PR TITLE
Prepare for 3.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+#### [3.0.0-rc.2] - 2025-22-08
+
 * feat: Make QM31 functions internal [#2181](https://github.com/lambdaclass/cairo-vm/pull/2181)
 
 * feat: Add `--fill-holes` CLI flag instead of relying on `--proof-mode` [#2165](https://github.com/lambdaclass/cairo-vm/pull/2165)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-tracer"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "axum",
  "cairo-vm",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cairo1-run"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -1607,7 +1607,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cairo-vm",
  "serde",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_threading"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cairo-vm",
  "rayon",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-demo"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cairo-vm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["ensure-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo-vm/"
@@ -24,8 +24,8 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
-cairo-vm = { path = "./vm", version = "3.0.0-rc.1", default-features = false }
-cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "3.0.0-rc.1", default-features = false }
+cairo-vm = { path = "./vm", version = "3.0.0-rc.2", default-features = false }
+cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "3.0.0-rc.2", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
     "serde",


### PR DESCRIPTION
This release pins types-rs to 0.1.8. Unpinning it would remove no_std support (See CI status of #2180). This was fixed in types-rs 0.2.0, but to bump that dependency to that version we have to:

- Bump `starknet-crypto` dependency
- Bump `cairo-lang-*` dependencies once they bump `types-rs` to 0.2.0

Meanwhile we are releasing this version with the `types-rs` dependency pinned and release another version once we are able to bump `types-rs` to 0.2.0.