### PR TITLE
Fix compute_ids_high_low hint constant path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: Fix compute_ids_high_low hint constant path [#2193](https://github.com/lambdaclass/cairo-vm/pull/2193)
+
 #### [2.4.0] - 2025-27-29
 
 * chore: Bump types-rs to 0.2.0 [#2186](https://github.com/lambdaclass/cairo-vm/pull/2186)

--- a/cairo_programs/cairo-0-secp-hints-feature/assert_165_bit.cairo
+++ b/cairo_programs/cairo-0-secp-hints-feature/assert_165_bit.cairo
@@ -1,0 +1,9 @@
+%builtins range_check
+
+from starkware.cairo.common.secp256r1.field import assert_165_bit
+
+func main{range_check_ptr: felt}() {
+    let value = 10;
+    assert_165_bit(value);
+    return ();
+}

--- a/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
@@ -7,7 +7,7 @@ use crate::stdlib::{
 
 use crate::define_hint_string_map;
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
-    get_constant_from_var_name, get_integer_from_var_name, insert_value_from_var_name,
+    get_integer_from_var_name, insert_value_from_var_name,
 };
 use crate::hint_processor::builtin_hint_processor::uint256_utils::Uint256;
 use crate::hint_processor::hint_processor_definition::HintReference;
@@ -170,15 +170,16 @@ pub fn compute_ids_high_low(
 ) -> Result<(), HintError> {
     exec_scopes.insert_value::<BigInt>("SECP256R1_P", SECP256R1_P.clone());
 
-    const UPPER_BOUND: &str = "starkware.cairo.common.math.assert_250_bit.UPPER_BOUND";
-    const SHIFT: &str = "starkware.cairo.common.math.assert_250_bit.SHIFT";
+    const UPPER_BOUND: &str = "starkware.cairo.common.secp256r1.field.assert_165_bit.UPPER_BOUND";
+    const SHIFT: &str = "starkware.cairo.common.secp256r1.field.assert_165_bit.SHIFT";
 
     let upper_bound = constants
         .get(UPPER_BOUND)
-        .map_or_else(|| get_constant_from_var_name("UPPER_BOUND", constants), Ok)?;
+        .ok_or_else(|| HintError::MissingConstant(Box::new(UPPER_BOUND)))?;
     let shift = constants
         .get(SHIFT)
-        .map_or_else(|| get_constant_from_var_name("SHIFT", constants), Ok)?;
+        .ok_or_else(|| HintError::MissingConstant(Box::new(SHIFT)))?;
+
     let value = Felt252::from(&signed_felt(get_integer_from_var_name(
         "value",
         vm,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/cairo0_hints.rs
@@ -7,7 +7,7 @@ use crate::stdlib::{
 
 use crate::define_hint_string_map;
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, insert_value_from_var_name,
+    get_constant_from_var_name, get_integer_from_var_name, insert_value_from_var_name,
 };
 use crate::hint_processor::builtin_hint_processor::uint256_utils::Uint256;
 use crate::hint_processor::hint_processor_definition::HintReference;
@@ -175,11 +175,10 @@ pub fn compute_ids_high_low(
 
     let upper_bound = constants
         .get(UPPER_BOUND)
-        .ok_or_else(|| HintError::MissingConstant(Box::new(UPPER_BOUND)))?;
+        .map_or_else(|| get_constant_from_var_name("UPPER_BOUND", constants), Ok)?;
     let shift = constants
         .get(SHIFT)
-        .ok_or_else(|| HintError::MissingConstant(Box::new(SHIFT)))?;
-
+        .map_or_else(|| get_constant_from_var_name("SHIFT", constants), Ok)?;
     let value = Felt252::from(&signed_felt(get_integer_from_var_name(
         "value",
         vm,

--- a/vm/src/tests/cairo_run_test.rs
+++ b/vm/src/tests/cairo_run_test.rs
@@ -1355,6 +1355,15 @@ fn cairo_run_secp_cairo0_negative_points() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(feature = "cairo-0-secp-hints")]
+fn cairo_run_secp_cairo0_assert_165_bits() {
+    let program_data =
+        include_bytes!("../../../cairo_programs/cairo-0-secp-hints-feature/assert_165_bit.json");
+    run_program_simple(program_data.as_slice());
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg(feature = "cairo-0-data-availability-hints")]
 fn cairo_run_data_availability_reduced_mul() {
     let program_data =


### PR DESCRIPTION
The `compute_ids_high_low` hint implementation was looking for the required constants at the wrong path (`math.assert_250_bit` instead of `field.assert_165_bit`). As the fallback is to find the constant by ignoring the prefix, this error didn't come up in our tests.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

