### PR TITLE
test(vm/errors): fix file path in vm_exception test

### DIFF
--- a/vm/src/vm/errors/vm_exception.rs
+++ b/vm/src/vm/errors/vm_exception.rs
@@ -749,7 +749,7 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
             end_line: 5,
             end_col: 2,
             input_file: InputFile {
-                filename: String::from("cairo_programs/bad_prtypoograms/bad_usort.cairo"),
+                filename: String::from("cairo_programs/bad_programs/bad_usort.cairo"),
             },
             parent_location: None,
             start_line: 5,
@@ -759,7 +759,7 @@ cairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)
         assert_eq!(
             location.to_string_with_content(&message),
             String::from(
-                "cairo_programs/bad_prtypoograms/bad_usort.cairo:5:1: Error at pc=0:75:\n"
+                "cairo_programs/bad_programs/bad_usort.cairo:5:1: Error at pc=0:75:\n"
             )
         )
     }


### PR DESCRIPTION
# TITLE
test(vm/errors): fix file path in vm_exception test

## Description
Correct "bad_prtypoograms" to "bad_programs" in vm_exception.rs test case `location_to_string_with_contents_no_file()` to match actual directory structure.

- Directory cairo_programs/bad_programs/ exists and contains bad_usort.cairo  

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

