### PR TITLE
Add support for Hint Data caching

### DIFF
--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::stdlib::prelude::*;
+use crate::stdlib::{ops::Deref, prelude::*};
 use crate::types::relocatable::Relocatable;
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
@@ -46,6 +46,32 @@ pub fn from_relocatable_to_indexes(relocatable: Relocatable) -> (usize, usize) {
         )
     } else {
         (relocatable.segment_index as usize, relocatable.offset)
+    }
+}
+
+/// Like [Cow], but doesn't require the type to implement [ToOwned].
+///
+/// Useful for storing values that may be either a reference, or an owned value,
+/// but are only ever used as a reference.
+///
+/// [Cow]: std::borrow::Cow
+/// [ToOwned]: std::borrow::ToOwned
+pub enum MaybeOwned<'a, T> {
+    Owned(T),
+    Borrowed(&'a T),
+}
+
+impl<'a, T> Deref for MaybeOwned<'a, T>
+where
+    T: Deref,
+{
+    type Target = T::Target;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            MaybeOwned::Owned(v) => v,
+            MaybeOwned::Borrowed(v) => v,
+        }
     }
 }
 


### PR DESCRIPTION
# Add support for Hint Data caching

This PR adds support for caching the compiled hint data between executions of the same contract.

I benchmarked some transactions and found a performance improvement of 20% when running old transactions (Cairo 0).

- The cache used is really simple (thread local). A proper cache for hint data would have more overhead than what I used.
- In my benchmark I ensured that everything is cached beforehand. This won't happen in an actual execution.

Some limitations:

- This PR is not breaking, but to achieve this I had to expose an _unsafe_ API. See safety notes on the `set_hint_data` function.

- This only works without the `extensive_hints` feature, which is a problem due to the way Cargo [unifies features](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2).

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

